### PR TITLE
Add import_url to project

### DIFF
--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -298,12 +298,19 @@ func resourceGitlabProjectCreate(d *schema.ResourceData, meta interface{}) error
 }
 
 func resourceGitlabProjectRead(d *schema.ResourceData, meta interface{}) error {
+	var project *gitlab.Project
 	client := meta.(*gitlab.Client)
 	log.Printf("[DEBUG] read gitlab project %s", d.Id())
 
 	project, _, err := client.Projects.GetProject(d.Id(), nil)
 	if err != nil {
 		return err
+	}
+	for project.ImportStatus == "started" {
+		project, _, err = client.Projects.GetProject(d.Id(), nil)
+		if err != nil {
+			return err
+		}
 	}
 
 	resourceGitlabProjectSetToState(d, project)

--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -76,6 +76,10 @@ var resourceGitLabProjectSchema = map[string]*schema.Schema{
 		ValidateFunc: validation.StringInSlice([]string{"private", "internal", "public"}, true),
 		Default:      "private",
 	},
+	"import_url": {
+		Type:     schema.TypeString,
+		Optional: true,
+	},
 	"merge_method": {
 		Type:         schema.TypeString,
 		Optional:     true,
@@ -245,6 +249,10 @@ func resourceGitlabProjectCreate(d *schema.ResourceData, meta interface{}) error
 	if v, ok := d.GetOk("tags"); ok {
 		options.TagList = stringSetToStringSlice(v.(*schema.Set))
 		setProperties = append(setProperties, "tags")
+	}
+
+	if v, ok := d.GetOk("import_url"); ok {
+		options.ImportURL = gitlab.String(v.(string))
 	}
 
 	log.Printf("[DEBUG] create gitlab project %q", *options.Name)

--- a/gitlab/resource_gitlab_project_test.go
+++ b/gitlab/resource_gitlab_project_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform/helper/acctest"
 	"github.com/hashicorp/terraform/helper/resource"
@@ -506,7 +505,7 @@ func testImportURLOptions() string {
 resource "gitlab_project" "import_url" {
   name = "import"
   path = "import"
-  description = " Terraform Import URL Acceptance test"
+  description = "Terraform Import URL Acceptance test"
 
   # So that acceptance tests can be run in a gitlab organization
   # with no billing
@@ -524,14 +523,13 @@ resource "gitlab_project" "import_url" {
   shared_runners_enabled = false
   archived = false
   import_url = "https://github.com/terraform-providers/terraform-provider-gitlab.git"
-	default_branch = "master"
+  default_branch = "master"
 }
 	`)
 }
 
 func testAccCheckImportURL(fp string, project *gitlab.Project) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		time.Sleep(10 * time.Second)
 		conn := testAccProvider.Meta().(*gitlab.Client)
 		ref := &gitlab.GetFileOptions{
 			Ref: gitlab.String("master"),


### PR DESCRIPTION
This adds `import_url` to the options to create a project, and implements the suggested acceptance test from #142.

Supersedes #142
Resolves #42 