### PR TITLE
Add support for commit_committer_check and reject_unsigned_commits in push rules

### DIFF
--- a/gitlab/resource_gitlab_project_push_rules.go
+++ b/gitlab/resource_gitlab_project_push_rules.go
@@ -57,6 +57,14 @@ func resourceGitlabProjectPushRules() *schema.Resource {
 				Type:     schema.TypeInt,
 				Optional: true,
 			},
+			"commit_committer_check": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
+			"reject_unsigned_commits": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -120,6 +128,8 @@ func resourceGitlabProjectPushRulesRead(d *schema.ResourceData, meta interface{}
 	d.Set("member_check", pushRules.MemberCheck)
 	d.Set("prevent_secrets", pushRules.PreventSecrets)
 	d.Set("max_file_size", pushRules.MaxFileSize)
+	d.Set("commit_committer_check", pushRules.CommitCommitterCheck)
+	d.Set("reject_unsigned_commits", pushRules.RejectUnsignedCommits)
 	return nil
 }
 

--- a/website/docs/r/project_push_rules.html.markdown
+++ b/website/docs/r/project_push_rules.html.markdown
@@ -48,6 +48,8 @@ The following arguments are supported:
 
 * `commit_committer_check` - (Optional, bool) Users can only push commits to this repository that were committed with one of their own verified emails
 
+* `reject_unsigned_commits` - (Optional, bool) Reject commit when it is not signed through GPG.
+
 ## Attributes Reference
 
 The resource exports the following attributes:


### PR DESCRIPTION
Resolves #202, depends on #245 