### PR TITLE
Allow to change user email without recreating the resource

### DIFF
--- a/gitlab/resource_gitlab_user.go
+++ b/gitlab/resource_gitlab_user.go
@@ -48,7 +48,6 @@ func resourceGitlabUser() *schema.Resource {
 			"email": {
 				Type:     schema.TypeString,
 				Required: true,
-				ForceNew: true,
 			},
 			"name": {
 				Type:     schema.TypeString,
@@ -151,6 +150,11 @@ func resourceGitlabUserUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if d.HasChange("username") {
 		options.Username = gitlab.String(d.Get("username").(string))
+	}
+
+	if d.HasChange("email") {
+		options.Email = gitlab.String(d.Get("email").(string))
+		options.SkipReconfirmation = gitlab.Bool(true)
 	}
 
 	if d.HasChange("is_admin") {

--- a/gitlab/resource_gitlab_user.go
+++ b/gitlab/resource_gitlab_user.go
@@ -92,6 +92,10 @@ func resourceGitlabUserSetToState(d *schema.ResourceData, user *gitlab.User) {
 	d.Set("name", user.Name)
 	d.Set("can_create_group", user.CanCreateGroup)
 	d.Set("projects_limit", user.ProjectsLimit)
+	d.Set("email", user.Email)
+	d.Set("is_admin", user.IsAdmin)
+	d.Set("is_external", user.External)
+	d.Set("skip_confirmation", !user.ConfirmedAt.IsZero())
 }
 
 func resourceGitlabUserCreate(d *schema.ResourceData, meta interface{}) error {
@@ -117,8 +121,6 @@ func resourceGitlabUserCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	d.SetId(fmt.Sprintf("%d", user.ID))
-	d.Set("is_admin", user.IsAdmin)
-	d.Set("is_external", user.External)
 
 	return resourceGitlabUserRead(d, meta)
 }

--- a/gitlab/resource_gitlab_user.go
+++ b/gitlab/resource_gitlab_user.go
@@ -170,7 +170,7 @@ func resourceGitlabUserUpdate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if d.HasChange("is_external") {
-		options.Admin = gitlab.Bool(d.Get("is_external").(bool))
+		options.External = gitlab.Bool(d.Get("is_external").(bool))
 	}
 
 	log.Printf("[DEBUG] update gitlab user %s", d.Id())

--- a/gitlab/resource_gitlab_user_test.go
+++ b/gitlab/resource_gitlab_user_test.go
@@ -52,7 +52,7 @@ func TestAccGitlabUser_basic(t *testing.T) {
 						Admin:            true,
 						CanCreateGroup:   true,
 						SkipConfirmation: false,
-						External:         true,
+						External:         false,
 					}),
 				),
 			},
@@ -224,7 +224,7 @@ resource "gitlab_user" "foo" {
   is_admin         = true
   projects_limit   = 10
   can_create_group = true
-  is_external      = true
+  is_external      = false
 }
   `, rInt, rInt, rInt, rInt)
 }

--- a/gitlab/resource_gitlab_user_test.go
+++ b/gitlab/resource_gitlab_user_test.go
@@ -44,7 +44,7 @@ func TestAccGitlabUser_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabUserExists("gitlab_user.foo", &user),
 					testAccCheckGitlabUserAttributes(&user, &testAccGitlabUserExpectedAttributes{
-						Email:            fmt.Sprintf("listest%d@ssss.com", rInt),
+						Email:            fmt.Sprintf("listest%d@tttt.com", rInt),
 						Password:         fmt.Sprintf("test%dtt", rInt),
 						Username:         fmt.Sprintf("listest%d", rInt),
 						Name:             fmt.Sprintf("bar %d", rInt),
@@ -220,7 +220,7 @@ resource "gitlab_user" "foo" {
   name             = "bar %d"
   username         = "listest%d"
   password         = "test%dtt"
-  email            = "listest%d@ssss.com"
+  email            = "listest%d@tttt.com"
   is_admin         = true
   projects_limit   = 10
   can_create_group = true

--- a/gitlab/resource_gitlab_user_test.go
+++ b/gitlab/resource_gitlab_user_test.go
@@ -26,7 +26,7 @@ func TestAccGitlabUser_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabUserExists("gitlab_user.foo", &user),
 					testAccCheckGitlabUserAttributes(&user, &testAccGitlabUserExpectedAttributes{
-						Email:            "listest%d@ssss.com",
+						Email:            fmt.Sprintf("listest%d@ssss.com", rInt),
 						Password:         fmt.Sprintf("test%dtt", rInt),
 						Username:         fmt.Sprintf("listest%d", rInt),
 						Name:             fmt.Sprintf("foo %d", rInt),
@@ -38,13 +38,13 @@ func TestAccGitlabUser_basic(t *testing.T) {
 					}),
 				),
 			},
-			// Update the user to change the name
+			// Update the user to change the name, email, projects_limit and more
 			{
 				Config: testAccGitlabUserUpdateConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabUserExists("gitlab_user.foo", &user),
 					testAccCheckGitlabUserAttributes(&user, &testAccGitlabUserExpectedAttributes{
-						Email:            "listest%d@ssss.com",
+						Email:            fmt.Sprintf("listest%d@ssss.com", rInt),
 						Password:         fmt.Sprintf("test%dtt", rInt),
 						Username:         fmt.Sprintf("listest%d", rInt),
 						Name:             fmt.Sprintf("bar %d", rInt),
@@ -62,7 +62,7 @@ func TestAccGitlabUser_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabUserExists("gitlab_user.foo", &user),
 					testAccCheckGitlabUserAttributes(&user, &testAccGitlabUserExpectedAttributes{
-						Email:            "listest%d@ssss.com",
+						Email:            fmt.Sprintf("listest%d@ssss.com", rInt),
 						Password:         fmt.Sprintf("test%dtt", rInt),
 						Username:         fmt.Sprintf("listest%d", rInt),
 						Name:             fmt.Sprintf("foo %d", rInt),
@@ -149,6 +149,26 @@ func testAccCheckGitlabUserAttributes(user *gitlab.User, want *testAccGitlabUser
 
 		if user.Username != want.Username {
 			return fmt.Errorf("got username %q; want %q", user.Username, want.Username)
+		}
+
+		if user.Email != want.Email {
+			return fmt.Errorf("got email %q; want %q", user.Email, want.Email)
+		}
+
+		if user.CanCreateGroup != want.CanCreateGroup {
+			return fmt.Errorf("got can_create_group %t; want %t", user.CanCreateGroup, want.CanCreateGroup)
+		}
+
+		if user.External != want.External {
+			return fmt.Errorf("got is_external %t; want %t", user.External, want.External)
+		}
+
+		if user.IsAdmin != want.Admin {
+			return fmt.Errorf("got is_admin %t; want %t", user.IsAdmin, want.Admin)
+		}
+
+		if user.ProjectsLimit != want.ProjectsLimit {
+			return fmt.Errorf("got projects_limit %d; want %d", user.ProjectsLimit, want.ProjectsLimit)
 		}
 
 		return nil


### PR DESCRIPTION
I imported an user into the terraform state and after I set the mandatory arguments the provider wanted to delete and recreate such user even if I didn't change anything.

This PRs maps the missing user attributes into the state.