### PR TITLE
Make password and reset_password exclusive

### DIFF
--- a/gitlab/resource_gitlab_user.go
+++ b/gitlab/resource_gitlab_user.go
@@ -109,6 +109,10 @@ func resourceGitlabUserCreate(d *schema.ResourceData, meta interface{}) error {
 		ResetPassword:    gitlab.Bool(d.Get("reset_password").(bool)),
 	}
 
+	if *options.Password == "" && !*options.ResetPassword {
+		return fmt.Errorf("At least one of either password or reset_password must be defined")
+	}
+
 	log.Printf("[DEBUG] create gitlab user %q", *options.Username)
 
 	user, _, err := client.Users.CreateUser(options)

--- a/gitlab/resource_gitlab_user_test.go
+++ b/gitlab/resource_gitlab_user_test.go
@@ -100,7 +100,7 @@ func TestAccGitlabUser_password_reset(t *testing.T) {
 			// Test that either password or reset_password is needed
 			{
 				Config:      testAccGitlabUserConfigWrong(rInt),
-				ExpectError: regexp.MustCompile(`\sAt least one of either password or reset_password must be defined`),
+				ExpectError: regexp.MustCompile("At least one of either password or reset_password must be defined"),
 			},
 			// Create a user without a password
 			{

--- a/gitlab/resource_gitlab_user_test.go
+++ b/gitlab/resource_gitlab_user_test.go
@@ -2,6 +2,7 @@ package gitlab
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"testing"
 
@@ -96,7 +97,12 @@ func TestAccGitlabUser_password_reset(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGitlabGroupDestroy,
 		Steps: []resource.TestStep{
-			// Create a user
+			// Test that either password or reset_password is needed
+			{
+				Config:      testAccGitlabUserConfigWrong(rInt),
+				ExpectError: regexp.MustCompile(`\sAt least one of either password or reset_password must be defined`),
+			},
+			// Create a user without a password
 			{
 				Config: testAccGitlabUserConfigPasswordReset(rInt),
 				Check:  testAccCheckGitlabUserExists("gitlab_user.foo", &user),
@@ -214,13 +220,18 @@ func testAccGitlabUserConfigPasswordReset(rInt int) string {
 resource "gitlab_user" "foo" {
   name             = "foo %d"
   username         = "listest%d"
-  password         = "test%dtt"
   email            = "listest%d@ssss.com"
-  is_admin         = false
-  projects_limit   = 0
-  can_create_group = false
-  is_external      = false
   reset_password   = true
 }
-  `, rInt, rInt, rInt, rInt)
+  `, rInt, rInt, rInt)
+}
+
+func testAccGitlabUserConfigWrong(rInt int) string {
+	return fmt.Sprintf(`
+resource "gitlab_user" "foo" {
+  name             = "foo %d"
+  username         = "listest%d"
+  email            = "listest%d@ssss.com"
+}
+  `, rInt, rInt, rInt)
 }

--- a/website/docs/r/user.html.markdown
+++ b/website/docs/r/user.html.markdown
@@ -11,6 +11,8 @@ description: |-
 This resource allows you to create and manage GitLab users.
 Note your provider will need to be configured with admin-level access for this resource to work.
 
+-> **Note:** You must specify either `password` or `reset_password`.
+
 ## Example Usage
 
 ```hcl
@@ -35,9 +37,9 @@ The following arguments are supported:
 
 * `username` - (Required) The username of the user.
 
-* `password` - (Required) The password of the user.
-
 * `email` - (Required) The e-mail address of the user.
+
+* `password` - (Optional) The password of the user.
 
 * `is_admin` - (Optional) Boolean, defaults to false.  Whether to enable administrative priviledges
 for the user.


### PR DESCRIPTION
The documentation works when either `password` or `reset_password` is set.