### PR TITLE
Do not fail when the group member already exists

### DIFF
--- a/gitlab/resource_gitlab_group_membership.go
+++ b/gitlab/resource_gitlab_group_membership.go
@@ -64,12 +64,27 @@ func resourceGitlabGroupMembershipCreate(d *schema.ResourceData, meta interface{
 	}
 	log.Printf("[DEBUG] create gitlab group groupMember for %d in %s", options.UserID, groupId)
 
-	groupMember, _, err := client.GroupMembers.AddGroupMember(groupId, options)
+	_, resp, err := client.GroupMembers.AddGroupMember(groupId, options)
 	if err != nil {
-		return err
+		if resp != nil && resp.StatusCode == http.StatusConflict {
+			options := gitlab.EditGroupMemberOptions{
+				AccessLevel: &accessLevelId,
+				ExpiresAt:   &expiresAt,
+			}
+			log.Printf("[DEBUG] update gitlab group membership %v for %s", userId, groupId)
+
+			_, _, err := client.GroupMembers.EditGroupMember(groupId, userId, &options)
+			if err != nil {
+				return err
+			}
+		} else {
+			return err
+		}
 	}
-	userIdString := strconv.Itoa(groupMember.ID)
+
+	userIdString := strconv.Itoa(userId)
 	d.SetId(buildTwoPartID(&groupId, &userIdString))
+
 	return resourceGitlabGroupMembershipRead(d, meta)
 }
 

--- a/gitlab/resource_gitlab_group_membership.go
+++ b/gitlab/resource_gitlab_group_membership.go
@@ -66,7 +66,13 @@ func resourceGitlabGroupMembershipCreate(d *schema.ResourceData, meta interface{
 
 	_, resp, err := client.GroupMembers.AddGroupMember(groupId, options)
 	if err != nil {
-		if resp != nil && resp.StatusCode == http.StatusConflict {
+		user, _, err := client.Users.CurrentUser()
+		if err != nil {
+			return err
+		}
+
+		// The user that creates the group is always added automatically as member
+		if resp != nil && resp.StatusCode == http.StatusConflict && user.ID == userId {
 			options := gitlab.EditGroupMemberOptions{
 				AccessLevel: &accessLevelId,
 				ExpiresAt:   &expiresAt,

--- a/gitlab/resource_gitlab_group_membership_test.go
+++ b/gitlab/resource_gitlab_group_membership_test.go
@@ -44,6 +44,14 @@ func TestAccGitlabGroupMembership_basic(t *testing.T) {
 					accessLevel: fmt.Sprintf("developer"),
 				})),
 			},
+
+			// Add the same member again
+			{
+				Config: testAccGitlabGroupMembershipConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(testAccCheckGitlabGroupMembershipExists("gitlab_group_membership.foo", &groupMember), testAccCheckGitlabGroupMembershipAttributes(&groupMember, &testAccGitlabGroupMembershipExpectedAttributes{
+					accessLevel: fmt.Sprintf("developer"),
+				})),
+			},
 		},
 	})
 }


### PR DESCRIPTION
If a member already exists in the group (either because someone manually added it or because that user owns the `GITLAB_TOKEN`), the `gitlab_group_membership` resource creations fails.

Instead, we can handle that failure and update the existing member to match what we do expect.