### PR TITLE
Do not fail when the group member does not exist

### DIFF
--- a/gitlab/resource_gitlab_group_membership.go
+++ b/gitlab/resource_gitlab_group_membership.go
@@ -2,6 +2,7 @@ package gitlab
 
 import (
 	"log"
+	"net/http"
 	"strconv"
 	"strings"
 
@@ -82,8 +83,13 @@ func resourceGitlabGroupMembershipRead(d *schema.ResourceData, meta interface{})
 		return e
 	}
 
-	groupMember, _, err := client.GroupMembers.GetGroupMember(groupId, userId)
+	groupMember, resp, err := client.GroupMembers.GetGroupMember(groupId, userId)
 	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			log.Printf("[DEBUG] gitlab group membership for %s not found so removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
Same as discussed in #240: if the group member doesn't exist, then remove it from the state also.

Fixes #254