### PR TITLE
Delete and overwrite existing project push rules on new resource creation

### DIFF
--- a/gitlab/resource_gitlab_project_push_rules.go
+++ b/gitlab/resource_gitlab_project_push_rules.go
@@ -98,7 +98,17 @@ func resourceGitlabProjectPushRulesCreate(d *schema.ResourceData, meta interface
 
 	pushRules, _, err := client.Projects.AddProjectPushRule(project, options)
 	if err != nil {
-		return err
+		// Delete existing push rules
+		_, err := client.Projects.DeleteProjectPushRule(project)
+		if err != nil {
+			return err
+		}
+
+		// Add push rules
+		pushRules, _, err = client.Projects.AddProjectPushRule(project, options)
+		if err != nil {
+			return err
+		}
 	}
 	d.SetId(fmt.Sprintf("%d", pushRules.ID))
 	return resourceGitlabProjectPushRulesRead(d, meta)


### PR DESCRIPTION
Currently, this resource fails on every apply, regardless of whether or not push rules actually exist for a given project.  With this change, existing push rules are overwritten with the parameters configured in Terraform if a new resource is being created.