### PR TITLE
Add support for impersonation tokens

### DIFF
--- a/gitlab/provider.go
+++ b/gitlab/provider.go
@@ -77,6 +77,7 @@ func Provider() terraform.ResourceProvider {
 			"gitlab_deploy_key_enable":          resourceGitlabDeployEnableKey(),
 			"gitlab_deploy_token":               resourceGitlabDeployToken(),
 			"gitlab_user":                       resourceGitlabUser(),
+			"gitlab_user_impersonation_token":   resourceGitlabUserImpersonationToken(),
 			"gitlab_project_membership":         resourceGitlabProjectMembership(),
 			"gitlab_group_membership":           resourceGitlabGroupMembership(),
 			"gitlab_project_variable":           resourceGitlabProjectVariable(),

--- a/gitlab/resource_gitlab_user_impersonation_token.go
+++ b/gitlab/resource_gitlab_user_impersonation_token.go
@@ -1,0 +1,137 @@
+package gitlab
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+	gitlab "github.com/xanzy/go-gitlab"
+)
+
+func resourceGitlabUserImpersonationToken() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGitlabUserImpersonationTokenCreate,
+		Read:   resourceGitlabUserImpersonationTokenRead,
+		Delete: resourceGitlabUserImpersonationTokenDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"user_id": {
+				Type:     schema.TypeInt,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"active": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"revoked": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"token": {
+				Type:      schema.TypeString,
+				Sensitive: true,
+				Computed:  true,
+			},
+			"scopes": {
+				Type:     schema.TypeSet,
+				Required: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringInSlice([]string{"api", "read_user"}, true),
+				},
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"expires_at": {
+				Type:         schema.TypeString,
+				ValidateFunc: validateDateFunc,
+				Optional:     true,
+				ForceNew:     true,
+			},
+		},
+	}
+}
+
+func resourceGitlabUserImpersonationTokenCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	user_id := d.Get("user_id").(int)
+	options := &gitlab.CreateImpersonationTokenOptions{
+		Name: gitlab.String(d.Get("name").(string)),
+	}
+
+	if v, ok := d.GetOk("scopes"); ok {
+		options.Scopes = stringSetToStringSlice(v.(*schema.Set))
+	}
+
+	if v, ok := d.GetOk("expires_at"); ok {
+		layout := "2006-01-02"
+		t, _ := time.Parse(layout, v.(string))
+		options.ExpiresAt = &t
+	}
+
+	log.Printf("[DEBUG] create gitlab user impersonation %s for user %d", *options.Name, user_id)
+	impersonationToken, _, err := client.Users.CreateImpersonationToken(user_id, options)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(fmt.Sprintf("%d:%d", user_id, impersonationToken.ID))
+	// We need to set token here instead of read, as it is only returned once
+	d.Set("token", impersonationToken.Token)
+
+	return resourceGitlabUserImpersonationTokenRead(d, meta)
+}
+
+func resourceGitlabUserImpersonationTokenRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	usertoken := strings.Split(d.Id(), ":")
+	userId, _ := strconv.Atoi(usertoken[0])
+	tokenId, _ := strconv.Atoi(usertoken[1])
+
+	log.Printf("[DEBUG] read gitlab user impersonation token %d:%d", userId, tokenId)
+
+	impersonationToken, _, err := client.Users.GetImpersonationToken(userId, tokenId)
+	if err != nil {
+		return err
+	}
+
+	d.Set("user_id", userId)
+	d.Set("name", impersonationToken.Name)
+	d.Set("active", impersonationToken.Active)
+	d.Set("revoked", impersonationToken.Revoked)
+	d.Set("scopes", impersonationToken.Scopes)
+	d.Set("created_at", impersonationToken.CreatedAt)
+	d.Set("expires_at", impersonationToken.ExpiresAt)
+	return nil
+}
+
+// In case we delete an impersonation token, Gitlab will update it with `revoked: true`
+// so the object still exists on Gitlab side, but we remove it from TF state
+func resourceGitlabUserImpersonationTokenDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	usertoken := strings.Split(d.Id(), ":")
+	userId, _ := strconv.Atoi(usertoken[0])
+	tokenId, _ := strconv.Atoi(usertoken[1])
+
+	log.Printf("[DEBUG] delete (revoke) gitlab user impersonation token %d:%d", userId, tokenId)
+
+	_, err := client.Users.RevokeImpersonationToken(userId, tokenId)
+	return err
+}

--- a/gitlab/resource_gitlab_user_impersonation_token_test.go
+++ b/gitlab/resource_gitlab_user_impersonation_token_test.go
@@ -1,0 +1,239 @@
+package gitlab
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/xanzy/go-gitlab"
+)
+
+func TestAccGitlabUserImpersonationToken_basic(t *testing.T) {
+	var token gitlab.ImpersonationToken
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccGitlabUserImpersonationTokenDestroy,
+		Steps: []resource.TestStep{
+			// Create a user and impersonation token
+			// gitlab_user is already tested as part of `resource_gitlab_user`
+			{
+				Config: testAccGitlabUserImpersonationTokenConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabUserImpersonationTokenExists("gitlab_user_impersonation_token.bar", &token),
+					testAccCheckGitlabUserImpersonationTokenAttributes("gitlab_user_impersonation_token.bar", &token, &testAccCheckGitlabUserImpersonationTokenExpectedAttributes{
+						Name:    fmt.Sprintf("Token bar %d", rInt),
+						Active:  true,
+						Scopes:  []string{"api"},
+						Revoked: false,
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGitlabUserImpersonationToken_withexpiration(t *testing.T) {
+	var token gitlab.ImpersonationToken
+	rInt := acctest.RandInt()
+	layout := "2006-01-02"
+	d, _ := time.Parse(layout, "2222-12-31")
+	iso_d := gitlab.ISOTime(d)
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccGitlabUserImpersonationTokenDestroy,
+		Steps: []resource.TestStep{
+			// Create a user and impersonation token with expiration
+			// gitlab_user is already tested as part of `resource_gitlab_user`
+			{
+				Config: testAccGitlabUserImpersonationTokenWithExpirationConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabUserImpersonationTokenExists("gitlab_user_impersonation_token.will_expire", &token),
+					testAccCheckGitlabUserImpersonationTokenAttributes("gitlab_user_impersonation_token.will_expire", &token, &testAccCheckGitlabUserImpersonationTokenExpectedAttributes{
+						Name:      fmt.Sprintf("Token will_expire %d", rInt),
+						Active:    true,
+						Scopes:    []string{"api", "read_user"},
+						Revoked:   false,
+						ExpiresAt: &iso_d,
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGitlabUserImpersonationToken_import(t *testing.T) {
+	var token gitlab.ImpersonationToken
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccGitlabUserImpersonationTokenDestroy,
+		Steps: []resource.TestStep{
+			// Create a user and impersonation token
+			// gitlab_user is already tested as part of `resource_gitlab_user`
+			{
+				Config: testAccGitlabUserImpersonationTokenConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabUserImpersonationTokenExists("gitlab_user_impersonation_token.bar", &token),
+					testAccCheckGitlabUserImpersonationTokenAttributes("gitlab_user_impersonation_token.bar", &token, &testAccCheckGitlabUserImpersonationTokenExpectedAttributes{
+						Name:    fmt.Sprintf("Token bar %d", rInt),
+						Active:  true,
+						Scopes:  []string{"api"},
+						Revoked: false,
+					}),
+				),
+			},
+			{
+				ResourceName:      "gitlab_user_impersonation_token.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				// the API can't serve these fields, so ignore them
+				ImportStateVerifyIgnore: []string{"token"},
+			},
+		},
+	})
+}
+
+func testAccCheckGitlabUserImpersonationTokenExists(n string, token *gitlab.ImpersonationToken) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		tokenID := rs.Primary.ID
+		if tokenID == "" {
+			return fmt.Errorf("No token ID is set")
+		}
+
+		userID := rs.Primary.Attributes["user_id"]
+		if userID == "" {
+			return fmt.Errorf("No user ID is set")
+		}
+		conn := testAccProvider.Meta().(*gitlab.Client)
+
+		usertoken := strings.Split(rs.Primary.ID, ":")
+		userId, _ := strconv.Atoi(usertoken[0])
+		tokenId, _ := strconv.Atoi(usertoken[1])
+		gotToken, _, err := conn.Users.GetImpersonationToken(userId, tokenId, nil)
+		if err != nil {
+			return err
+		}
+		*token = *gotToken
+		return nil
+	}
+}
+
+func testAccGitlabUserImpersonationTokenDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*gitlab.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "gitlab_user_impersonation_token" {
+			continue
+		}
+
+		usertoken := strings.Split(rs.Primary.ID, ":")
+		userId, _ := strconv.Atoi(usertoken[0])
+		tokenId, _ := strconv.Atoi(usertoken[1])
+
+		token, resp, err := conn.Users.GetImpersonationToken(userId, tokenId, nil)
+		if err == nil {
+			if token != nil && fmt.Sprintf("%d", token.ID) == rs.Primary.ID && !token.Revoked {
+				return fmt.Errorf("Impersonation token still exists ")
+			}
+		}
+		if resp.StatusCode != 404 {
+			return err
+		}
+		return nil
+	}
+	return nil
+}
+
+type testAccCheckGitlabUserImpersonationTokenExpectedAttributes struct {
+	Name      string
+	Active    bool
+	Scopes    []string
+	Revoked   bool
+	ExpiresAt *gitlab.ISOTime
+}
+
+func testAccCheckGitlabUserImpersonationTokenAttributes(n string, token *gitlab.ImpersonationToken, want *testAccCheckGitlabUserImpersonationTokenExpectedAttributes) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		if token.Name != want.Name {
+			return fmt.Errorf("got name %q; want %q", token.Name, want.Name)
+		}
+
+		if token.Revoked != want.Revoked {
+			return fmt.Errorf("got revoked %t; want %t", token.Revoked, want.Revoked)
+		}
+
+		if want.ExpiresAt != nil {
+			if token.ExpiresAt.String() != want.ExpiresAt.String() {
+				return fmt.Errorf("got expires %q; want %q", token.ExpiresAt, want.ExpiresAt)
+			}
+		}
+
+		if !token.Revoked && rs.Primary.Attributes["token"] == "" {
+			return fmt.Errorf("token should be defined but is empty.")
+		}
+		return nil
+	}
+}
+
+func testAccGitlabUserImpersonationTokenConfig(rInt int) string {
+	return fmt.Sprintf(`
+resource "gitlab_user" "foo" {
+  name             = "foo %d"
+  username         = "listest%d"
+  password         = "test%dtt"
+  email            = "listest%d@ssss.com"
+  is_admin         = false
+  projects_limit   = 0
+  can_create_group = false
+  is_external      = false
+}
+
+resource "gitlab_user_impersonation_token" "bar" {
+    user_id = gitlab_user.foo.id
+    name    = "Token bar %d"
+    scopes  = ["api"]
+}
+  `, rInt, rInt, rInt, rInt, rInt)
+}
+
+func testAccGitlabUserImpersonationTokenWithExpirationConfig(rInt int) string {
+	return fmt.Sprintf(`
+resource "gitlab_user" "foo" {
+  name             = "foo %d"
+  username         = "listest%d"
+  password         = "test%dtt"
+  email            = "listest%d@ssss.com"
+  is_admin         = false
+  projects_limit   = 0
+  can_create_group = false
+  is_external      = false
+}
+
+resource "gitlab_user_impersonation_token" "will_expire" {
+    user_id    = gitlab_user.foo.id
+    name       = "Token will_expire %d"
+    scopes     = ["api", "read_user"]
+    expires_at = "2222-12-31"
+}
+  `, rInt, rInt, rInt, rInt, rInt)
+}

--- a/website/docs/r/user_impersonation_token.html.markdown
+++ b/website/docs/r/user_impersonation_token.html.markdown
@@ -1,0 +1,56 @@
+---
+layout: "gitlab"
+page_title: "GitLab: gitlab_user_impersonation_token"
+sidebar_current: "docs-gitlab-resource-user_impersonation_token"
+description: |-
+  Manage impersonation tokens for a user.
+---
+
+# gitlab\_user_impersonation_token
+
+This resource allows you to manage impersonation tokens of an existing user.
+
+## Example Usage
+
+```hcl
+resource "gitlab_user" "example" {
+  name     = "Example Foo"
+  username = "example"
+  password = "superPassword"
+  email    = "gitlab@user.create"
+}
+
+resource "gitlab_user_impersonation_token" "my-new-token" {
+  user   = gitlab_user.example.id
+  name   = "Token bar %d"
+  scopes = ["api"]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `user` - (Required) The id of user
+* `name` - (Required) The name of the token
+* `scopes` - (Optional) Array, scopes of the token, can be any `api`, `user_read` or both.
+* `expires_at` - (Optional) Expiration date, format is `YYYY-MM-DD`
+
+## Attributes Reference
+
+The resource exports the following attributes:
+
+* `id` The unique id given by the Gitlab server.
+* `active` (Boolean) Is the token active or expired
+* `revoked` (Boolean) Has the token been revoked
+* `created_at` Time of token creation
+* `token` The impersonation token, will only be exported if resource has been created through terraform, but not in case of import.
+
+## Importing user impersonation token
+
+You can import an impersonation token to terraform state using `terraform import <resource> <id>`.
+The `id` must be formated like `<user_id>:<token_id>`, for example:
+
+    terraform import gitlab_user_impersonation_token.example 21/25
+
+Note: When importing impersonation token, Gitlab do not send the token itself, so terraform won't be able to access it.


### PR DESCRIPTION
Impersonation token are only returned once, as response to the create request.

That's why we use `Set` inside the  `create` method instead of read.

Tested on latest gitlab-ce 