### PR TITLE
feat: Add support to create projects from templates

### DIFF
--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -193,6 +193,18 @@ var resourceGitLabProjectSchema = map[string]*schema.Schema{
 		Type:     schema.TypeBool,
 		Optional: true,
 	},
+	"template_name": {
+		Type:     schema.TypeString,
+		Optional: true,
+	},
+	"use_custom_template": {
+		Type:     schema.TypeBool,
+		Optional: true,
+	},
+	"group_with_project_templates_id": {
+		Type:     schema.TypeInt,
+		Optional: true,
+	},
 }
 
 func resourceGitlabProject() *schema.Resource {
@@ -259,6 +271,9 @@ func resourceGitlabProjectCreate(d *schema.ResourceData, meta interface{}) error
 		OnlyAllowMergeIfAllDiscussionsAreResolved: gitlab.Bool(d.Get("only_allow_merge_if_all_discussions_are_resolved").(bool)),
 		SharedRunnersEnabled:                      gitlab.Bool(d.Get("shared_runners_enabled").(bool)),
 		RemoveSourceBranchAfterMerge:              gitlab.Bool(d.Get("remove_source_branch_after_merge").(bool)),
+		TemplateName:                              gitlab.String(d.Get("template_name").(string)),
+		UseCustomTemplate:                         gitlab.Bool(d.Get("use_custom_template").(bool)),
+		GroupWithProjectTemplatesID:               gitlab.Int(d.Get("group_with_project_templates_id").(int)),
 	}
 
 	// need to manage partial state since project creation may require
@@ -282,6 +297,9 @@ func resourceGitlabProjectCreate(d *schema.ResourceData, meta interface{}) error
 		"only_allow_merge_if_all_discussions_are_resolved",
 		"shared_runners_enabled",
 		"remove_source_branch_after_merge",
+		"template_name",
+		"use_custom_template",
+		"group_with_project_templates_id",
 	}
 
 	if v, ok := d.GetOk("path"); ok {

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -23,6 +23,37 @@ resource "gitlab_project" "example" {
 }
 ```
 
+### Template Examples
+
+Project templates can pre-populate a new project with the necessary files to get you started quickly.
+
+### Built-In Template Project
+
+Gitlab has [built-in templates](https://docs.gitlab.com/ee/gitlab-basics/create-project.html#built-in-templates), sourced from the following groups:
+* [project-templates](https://gitlab.com/gitlab-org/project-templates)
+* [pages](https://gitlab.com/pages)
+
+
+```hcl
+resource "gitlab_project" "template" {
+  name          = "template"
+  template_name = "gatsby"
+}
+```
+
+###  Custom Template Project
+
+GitLab administrators and users can configure their own [Custom project templates](https://docs.gitlab.com/ee/gitlab-basics/create-project.html#custom-project-templates-premium) 
+
+```hcl
+resource "gitlab_project" "custom_template" {
+  name = "my-new-project"
+  template_name = "my-custom-template"
+  use_custom_template= true
+  group_with_project_templates_id = 1
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
@@ -81,6 +112,11 @@ The following arguments are supported:
 
 * `initialize_with_readme` - (Optional) Create master branch with first commit containing a README.md file.
 
+* `template_name` - (Optional)  Create project from existing template. When used without `use_custom_template`, name of a built-in project template. When used with `use_custom_template`, name of a custom project template
+
+* `use_custom_template` - (Optional) Use either custom instance or group (with `group_with_project_templates_id`) project template
+
+* `group_with_project_templates_id` - (Optional) For group-level custom templates, specifies ID of group from which all the custom project templates are sourced. Leave empty for instance-level templates. Requires use_custom_template to be true
 ## Attributes Reference
 
 The following additional attributes are exported:


### PR DESCRIPTION
Resolves #333 

This PR adds the following attributes to the create project resource:

* `template_name` - (Optional)  Create project from existing template. When used without `use_custom_template`, name of a built-in project template. When used with `use_custom_template`, name of a custom project template

* `use_custom_template` - (Optional) Use either custom instance or group (with `group_with_project_templates_id`) project template

* `group_with_project_templates_id` - (Optional) For group-level custom templates, specifies ID of group from which all the custom project templates are sourced. Leave empty for instance-level templates. Requires use_custom_template to be true


I have also updated the documentation for the provider. 

I have successfully tested this against my own org

Please let me know if there is anything else I can do. 
