### PR TITLE
Updated environment_scope reference

### DIFF
--- a/website/docs/r/project_variable.html.markdown
+++ b/website/docs/r/project_variable.html.markdown
@@ -40,7 +40,7 @@ The following arguments are supported:
 
 * `masked` - (Optional, boolean) If set to `true`, the variable will be masked if it would have been written to the logs. Defaults to `false`.
 
-* `environment_scope` -  (Optional, string) The environment_scope of the variable
+* `environment_scope` -  (Optional, string) The environment_scope of the variable. Use asterisk * for All (default) scope.
 
 ## Import
 


### PR DESCRIPTION
Leaving environment_scope off (optional) results in environment value of 0, it should rather be set to asterisk. If the scope is in GitLab as 0, it will not be accessible to runners in any environment (except 0 of course, which would be a very unusual name for an environment).