### PR TITLE
feature: add environment and repository file

### DIFF
--- a/gitlab/provider.go
+++ b/gitlab/provider.go
@@ -88,6 +88,8 @@ func Provider() terraform.ResourceProvider {
 			"gitlab_project_share_group":        resourceGitlabProjectShareGroup(),
 			"gitlab_group_cluster":              resourceGitlabGroupCluster(),
 			"gitlab_group_ldap_link":            resourceGitlabGroupLdapLink(),
+			"gitlab_repository_file":            resourceGitlabRepositoryFile(),
+			"gitlab_environment":                resourceGitlabEnvironment(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/gitlab/resource_gitlab_environment.go
+++ b/gitlab/resource_gitlab_environment.go
@@ -118,6 +118,12 @@ func resourceGitlabEnvironmentDelete(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 
+	// Environment must be stopped prior to deletion or a 403 will be received
+	stopResp, err := client.Environments.StopEnvironment(project, environmentID)
+	if err != nil {
+		return fmt.Errorf("%s failed to stop environment prior to delete: %s", d.Id(), stopResp.Status)
+	}
+
 	resp, err := client.Environments.DeleteEnvironment(project, environmentID)
 	if err != nil {
 		return fmt.Errorf("%s failed to delete environment: %s", d.Id(), resp.Status)

--- a/gitlab/resource_gitlab_environment.go
+++ b/gitlab/resource_gitlab_environment.go
@@ -1,0 +1,126 @@
+package gitlab
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/xanzy/go-gitlab"
+)
+
+func resourceGitlabEnvironment() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGitlabEnvironmentCreate,
+		Read:   resourceGitlabEnvironmentRead,
+		Update: resourceGitlabEnvironmentUpdate,
+		Delete: resourceGitlabEnvironmentDelete,
+
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"external_url": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"slug": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceGitlabEnvironmentCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	project := d.Get("project").(string)
+	options := &gitlab.CreateEnvironmentOptions{
+		Name:        gitlab.String(d.Get("name").(string)),
+		ExternalURL: gitlab.String(d.Get("external_url").(string)),
+	}
+
+	environment, _, err := client.Environments.CreateEnvironment(project, options)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(strconv.Itoa(environment.ID))
+
+	return resourceGitlabEnvironmentRead(d, meta)
+}
+
+func resourceGitlabEnvironmentRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	project := d.Get("project").(string)
+	environmentID, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return err
+	}
+
+	environment, _, err := client.Environments.GetEnvironment(project, environmentID)
+	if err != nil {
+		return err
+	}
+
+	d.Set("project", project)
+	d.Set("name", environment.Name)
+	d.Set("external_url", environment.ExternalURL)
+	d.Set("slug", environment.Slug)
+	d.Set("state", environment.State)
+
+	return nil
+}
+
+func resourceGitlabEnvironmentUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	project := d.Get("project").(string)
+	options := &gitlab.EditEnvironmentOptions{
+		Name:        gitlab.String(d.Get("name").(string)),
+		ExternalURL: gitlab.String(d.Get("external_url").(string)),
+	}
+	environmentID, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return err
+	}
+
+	if d.HasChange("name") {
+		options.Name = gitlab.String(d.Get("name").(string))
+	}
+
+	if d.HasChange("external_url") {
+		options.ExternalURL = gitlab.String(d.Get("external_url").(string))
+	}
+
+	_, _, err = client.Environments.EditEnvironment(project, environmentID, options)
+	if err != nil {
+		return err
+	}
+
+	return resourceGitlabEnvironmentRead(d, meta)
+}
+
+func resourceGitlabEnvironmentDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	project := d.Get("project").(string)
+	environmentID, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Environments.DeleteEnvironment(project, environmentID)
+	if err != nil {
+		return fmt.Errorf("%s failed to delete environment: %s", d.Id(), resp.Status)
+	}
+	return err
+}

--- a/gitlab/resource_gitlab_environment.go
+++ b/gitlab/resource_gitlab_environment.go
@@ -59,7 +59,7 @@ func resourceGitlabEnvironmentCreate(d *schema.ResourceData, meta interface{}) e
 	}
 
 	d.Set("environment_id", environment.ID)
-	d.SetId(fmt.Sprintf("%s/%d", project, environment.ID))
+	d.SetId(fmt.Sprintf("%s:%d", project, environment.ID))
 
 	return resourceGitlabEnvironmentRead(d, meta)
 }
@@ -116,12 +116,12 @@ func resourceGitlabEnvironmentDelete(d *schema.ResourceData, meta interface{}) e
 	// Environment must be stopped prior to deletion or a 403 will be received
 	stopResp, err := client.Environments.StopEnvironment(project, environmentID)
 	if err != nil {
-		return fmt.Errorf("%s failed to stop environment prior to delete: %s", d.Id(), stopResp.Status)
+		return fmt.Errorf("%s failed to stop environment prior to delete: (%s) %v", d.Id(), stopResp.Status, err)
 	}
 
 	resp, err := client.Environments.DeleteEnvironment(project, environmentID)
 	if err != nil {
-		return fmt.Errorf("%s failed to delete environment: %s", d.Id(), resp.Status)
+		return fmt.Errorf("%s failed to delete environment: (%s) %v", d.Id(), resp.Status, err)
 	}
 	return err
 }

--- a/gitlab/resource_gitlab_environment_test.go
+++ b/gitlab/resource_gitlab_environment_test.go
@@ -2,7 +2,6 @@ package gitlab
 
 import (
 	"fmt"
-	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -51,20 +50,21 @@ func testAccCheckGitlabEnvironmentExists(n string, environment *gitlab.Environme
 		}
 
 		environmentID := rs.Primary.ID
-		repoName := rs.Primary.Attributes["project"]
-		if repoName == "" {
+		project := rs.Primary.Attributes["project"]
+		if project == "" {
 			return fmt.Errorf("No project ID is set")
 		}
 
 		conn := testAccProvider.Meta().(*gitlab.Client)
 
-		environments, _, err := conn.Environments.ListEnvironments(repoName, nil)
+		environments, _, err := conn.Environments.ListEnvironments(project, nil)
 		if err != nil {
 			return err
 		}
 
 		for _, gotEnvironment := range environments {
-			if strconv.Itoa(gotEnvironment.ID) == environmentID {
+			resourceID := fmt.Sprintf("%s/%d", project, gotEnvironment.ID)
+			if resourceID == environmentID {
 				*environment = *gotEnvironment
 				return nil
 			}

--- a/gitlab/resource_gitlab_environment_test.go
+++ b/gitlab/resource_gitlab_environment_test.go
@@ -1,0 +1,154 @@
+package gitlab
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	gitlab "github.com/xanzy/go-gitlab"
+)
+
+func TestAccGitlabEnvironment_basic(t *testing.T) {
+	var environment gitlab.Environment
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGitlabEnvironmentDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGitlabEnvironmentConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabEnvironmentExists("gitlab_environment.environment", &environment),
+					testAccCheckGitlabEnvironmentAttributes(&environment, &testAccGitlabEnvironmentAttributes{
+						Name:        "meow",
+						ExternalURL: "https://google.com",
+					}),
+				),
+			},
+			{
+				Config: testAccGitlabEnvironmentConfigNameOnly(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabEnvironmentExists("gitlab_environment.environment", &environment),
+					testAccCheckGitlabEnvironmentAttributes(&environment, &testAccGitlabEnvironmentAttributes{
+						Name: "meow",
+					}),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckGitlabEnvironmentExists(n string, environment *gitlab.Environment) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not Found: %s", n)
+		}
+
+		environmentID := rs.Primary.ID
+		repoName := rs.Primary.Attributes["project"]
+		if repoName == "" {
+			return fmt.Errorf("No project ID is set")
+		}
+
+		conn := testAccProvider.Meta().(*gitlab.Client)
+
+		environments, _, err := conn.Environments.ListEnvironments(repoName, nil)
+		if err != nil {
+			return err
+		}
+
+		for _, gotEnvironment := range environments {
+			if strconv.Itoa(gotEnvironment.ID) == environmentID {
+				*environment = *gotEnvironment
+				return nil
+			}
+		}
+		return fmt.Errorf("Environment does not exist")
+	}
+}
+
+type testAccGitlabEnvironmentAttributes struct {
+	Name        string
+	ExternalURL string
+}
+
+func testAccCheckGitlabEnvironmentAttributes(environment *gitlab.Environment, want *testAccGitlabEnvironmentAttributes) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if environment.Name != want.Name {
+			return fmt.Errorf("got name %q; want %q", environment.Name, want.Name)
+		}
+
+		if environment.ExternalURL != want.ExternalURL {
+			return fmt.Errorf("got external url %q; want %q", environment.ExternalURL, want.ExternalURL)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckGitlabEnvironmentDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*gitlab.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "gitlab_project" {
+			continue
+		}
+
+		gotRepo, resp, err := conn.Projects.GetProject(rs.Primary.ID, nil)
+		if err == nil {
+			if gotRepo != nil && fmt.Sprintf("%d", gotRepo.ID) == rs.Primary.ID {
+				if gotRepo.MarkedForDeletionAt == nil {
+					return fmt.Errorf("Repository still exists")
+				}
+			}
+		}
+		if resp.StatusCode != 404 {
+			return err
+		}
+		return nil
+	}
+	return nil
+}
+
+func testAccGitlabEnvironmentConfig(rInt int) string {
+	return fmt.Sprintf(`
+	resource "gitlab_project" "foo" {
+		name = "foo-%d"
+		description = "Terraform acceptance tests"
+	  
+		# So that acceptance tests can be run in a gitlab organization
+		# with no billing
+		visibility_level = "public"
+	  }
+	  
+	  resource "gitlab_environment" "environment" {
+		  project = "${gitlab_project.foo.id}"
+		  name = "meow"
+		  external_url = "https://google.com"
+	  }
+		  `, rInt)
+}
+
+func testAccGitlabEnvironmentConfigNameOnly(rInt int) string {
+	return fmt.Sprintf(`
+	resource "gitlab_project" "foo" {
+		name = "foo-%d"
+		description = "Terraform acceptance tests"
+	  
+		# So that acceptance tests can be run in a gitlab organization
+		# with no billing
+		visibility_level = "public"
+	  }
+	  
+	  resource "gitlab_environment" "environment" {
+		  project = "${gitlab_project.foo.id}"
+		  name = "meow"
+	  }
+		  `, rInt)
+}

--- a/gitlab/resource_gitlab_repository_file.go
+++ b/gitlab/resource_gitlab_repository_file.go
@@ -2,8 +2,8 @@ package gitlab
 
 import (
 	"fmt"
-	"time"
 	"math/rand"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/xanzy/go-gitlab"
@@ -46,7 +46,7 @@ func resourceGitlabRepositoryFile() *schema.Resource {
 				Required: true,
 			},
 			"ignore_content_changes": {
-				Type: schema.TypeBool,
+				Type:     schema.TypeBool,
 				Optional: true,
 			},
 		},
@@ -71,7 +71,7 @@ func resourceGitlabRepositoryFileCreate(d *schema.ResourceData, meta interface{}
 	rand.Seed(time.Now().UnixNano())
 	n := rand.Intn(30)
 	nPlus := n + 2
-	time.Sleep(time.Duration(nPlus)*time.Second)	
+	time.Sleep(time.Duration(nPlus) * time.Second)
 
 	repositoryFile, _, err := client.RepositoryFiles.CreateFile(project, file, options)
 	if err != nil {
@@ -115,7 +115,7 @@ func resourceGitlabRepositoryFileUpdate(d *schema.ResourceData, meta interface{}
 		AuthorName:    gitlab.String(d.Get("author_name").(string)),
 		Content:       gitlab.String(d.Get("content").(string)),
 		CommitMessage: gitlab.String(d.Get("commit_message").(string)),
-		Encoding: gitlab.String("base64"),
+		Encoding:      gitlab.String("base64"),
 		//TODO: add LastCommitID
 	}
 
@@ -158,12 +158,11 @@ func resourceGitlabRepositoryFileDelete(d *schema.ResourceData, meta interface{}
 		//TODO: add LastCommitID
 	}
 
-
 	// Sleep so the API doesn't derp out
 	rand.Seed(time.Now().UnixNano())
 	n := rand.Intn(30)
 	nPlus := n + 2
-	time.Sleep(time.Duration(nPlus)*time.Second)	
+	time.Sleep(time.Duration(nPlus) * time.Second)
 
 	resp, err := client.RepositoryFiles.DeleteFile(project, file, options)
 	if err != nil {

--- a/gitlab/resource_gitlab_repository_file.go
+++ b/gitlab/resource_gitlab_repository_file.go
@@ -20,7 +20,7 @@ func resourceGitlabRepositoryFile() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 			},
-			"file": {
+			"file_path": {
 				Type:     schema.TypeString,
 				Required: true,
 				ForceNew: true,
@@ -53,7 +53,7 @@ func resourceGitlabRepositoryFile() *schema.Resource {
 func resourceGitlabRepositoryFileCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gitlab.Client)
 	project := d.Get("project").(string)
-	file := d.Get("file").(string)
+	filePath := d.Get("file_path").(string)
 
 	options := &gitlab.CreateFileOptions{
 		Branch:        gitlab.String(d.Get("branch").(string)),
@@ -64,7 +64,7 @@ func resourceGitlabRepositoryFileCreate(d *schema.ResourceData, meta interface{}
 		Encoding:      gitlab.String("base64"),
 	}
 
-	repositoryFile, _, err := client.RepositoryFiles.CreateFile(project, file, options)
+	repositoryFile, _, err := client.RepositoryFiles.CreateFile(project, filePath, options)
 	if err != nil {
 		return err
 	}
@@ -88,7 +88,7 @@ func resourceGitlabRepositoryFileRead(d *schema.ResourceData, meta interface{}) 
 	}
 
 	d.Set("project", project)
-	d.Set("file", repositoryFile.FileName)
+	d.Set("file_path", repositoryFile.FileName)
 	d.Set("content", repositoryFile.Content)
 	d.Set("branch", repositoryFile.Ref)
 
@@ -98,7 +98,7 @@ func resourceGitlabRepositoryFileRead(d *schema.ResourceData, meta interface{}) 
 func resourceGitlabRepositoryFileUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gitlab.Client)
 	project := d.Get("project").(string)
-	file := d.Get("file").(string)
+	filePath := d.Get("file_path").(string)
 	options := &gitlab.UpdateFileOptions{
 		Branch:        gitlab.String(d.Get("branch").(string)),
 		AuthorEmail:   gitlab.String(d.Get("author_email").(string)),
@@ -128,7 +128,7 @@ func resourceGitlabRepositoryFileUpdate(d *schema.ResourceData, meta interface{}
 	if d.HasChange("commit_message") {
 		options.CommitMessage = gitlab.String(d.Get("commit_message").(string))
 	}
-	_, _, err := client.RepositoryFiles.UpdateFile(project, file, options)
+	_, _, err := client.RepositoryFiles.UpdateFile(project, filePath, options)
 	if err != nil {
 		return err
 	}
@@ -139,7 +139,7 @@ func resourceGitlabRepositoryFileUpdate(d *schema.ResourceData, meta interface{}
 func resourceGitlabRepositoryFileDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gitlab.Client)
 	project := d.Get("project").(string)
-	file := d.Get("file").(string)
+	filePath := d.Get("file_path").(string)
 	options := &gitlab.DeleteFileOptions{
 		Branch:        gitlab.String(d.Get("branch").(string)),
 		AuthorEmail:   gitlab.String(d.Get("author_email").(string)),
@@ -148,7 +148,7 @@ func resourceGitlabRepositoryFileDelete(d *schema.ResourceData, meta interface{}
 		//TODO: add LastCommitID
 	}
 
-	resp, err := client.RepositoryFiles.DeleteFile(project, file, options)
+	resp, err := client.RepositoryFiles.DeleteFile(project, filePath, options)
 	if err != nil {
 		return fmt.Errorf("%s failed to delete repository file: (%s) %v", d.Id(), resp.Status, err)
 	}

--- a/gitlab/resource_gitlab_repository_file.go
+++ b/gitlab/resource_gitlab_repository_file.go
@@ -2,7 +2,6 @@ package gitlab
 
 import (
 	"fmt"
-	"math/rand"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -62,12 +61,6 @@ func resourceGitlabRepositoryFileCreate(d *schema.ResourceData, meta interface{}
 		CommitMessage: gitlab.String(d.Get("commit_message").(string)),
 		Encoding:      gitlab.String("base64"),
 	}
-
-	// Sleep so the API doesn't derp out
-	rand.Seed(time.Now().UnixNano())
-	n := rand.Intn(30)
-	nPlus := n + 2
-	time.Sleep(time.Duration(nPlus) * time.Second)
 
 	repositoryFile, _, err := client.RepositoryFiles.CreateFile(project, file, options)
 	if err != nil {
@@ -152,12 +145,6 @@ func resourceGitlabRepositoryFileDelete(d *schema.ResourceData, meta interface{}
 		CommitMessage: gitlab.String(d.Get("commit_message").(string)),
 		//TODO: add LastCommitID
 	}
-
-	// Sleep so the API doesn't derp out
-	rand.Seed(time.Now().UnixNano())
-	n := rand.Intn(30)
-	nPlus := n + 2
-	time.Sleep(time.Duration(nPlus) * time.Second)
 
 	resp, err := client.RepositoryFiles.DeleteFile(project, file, options)
 	if err != nil {

--- a/gitlab/resource_gitlab_repository_file.go
+++ b/gitlab/resource_gitlab_repository_file.go
@@ -18,10 +18,12 @@ func resourceGitlabRepositoryFile() *schema.Resource {
 			"project": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"file": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"content": {
 				Type:     schema.TypeString,
@@ -30,6 +32,7 @@ func resourceGitlabRepositoryFile() *schema.Resource {
 			"branch": {
 				Type:     schema.TypeString,
 				Required: true,
+				ForceNew: true,
 			},
 			"author_name": {
 				Type:     schema.TypeString,

--- a/gitlab/resource_gitlab_repository_file.go
+++ b/gitlab/resource_gitlab_repository_file.go
@@ -147,7 +147,7 @@ func resourceGitlabRepositoryFileDelete(d *schema.ResourceData, meta interface{}
 
 	resp, err := client.RepositoryFiles.DeleteFile(project, file, options)
 	if err != nil {
-		return fmt.Errorf("%s failed to delete repository file: %s", d.Id(), resp.Status)
+		return fmt.Errorf("%s failed to delete repository file: (%s) %v", d.Id(), resp.Status, err)
 	}
 	return err
 }

--- a/gitlab/resource_gitlab_repository_file.go
+++ b/gitlab/resource_gitlab_repository_file.go
@@ -45,10 +45,6 @@ func resourceGitlabRepositoryFile() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"ignore_content_changes": {
-				Type:     schema.TypeBool,
-				Optional: true,
-			},
 		},
 	}
 }
@@ -108,7 +104,6 @@ func resourceGitlabRepositoryFileUpdate(d *schema.ResourceData, meta interface{}
 	client := meta.(*gitlab.Client)
 	project := d.Get("project").(string)
 	file := d.Get("file").(string)
-	// ignoreContentChanges := d.Get("ignore_content_changes").(bool)
 	options := &gitlab.UpdateFileOptions{
 		Branch:        gitlab.String(d.Get("branch").(string)),
 		AuthorEmail:   gitlab.String(d.Get("author_email").(string)),

--- a/gitlab/resource_gitlab_repository_file.go
+++ b/gitlab/resource_gitlab_repository_file.go
@@ -1,0 +1,152 @@
+package gitlab
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/xanzy/go-gitlab"
+)
+
+func resourceGitlabRepositoryFile() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGitlabRepositoryFileCreate,
+		Read:   resourceGitlabRepositoryFileRead,
+		Update: resourceGitlabRepositoryFileUpdate,
+		Delete: resourceGitlabRepositoryFileDelete,
+
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"file": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"content": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"branch": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"author_name": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"author_email": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"commit_message": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+		},
+	}
+}
+
+func resourceGitlabRepositoryFileCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	project := d.Get("project").(string)
+	file := d.Get("file").(string)
+
+	options := &gitlab.CreateFileOptions{
+		Branch:        gitlab.String(d.Get("branch").(string)),
+		AuthorEmail:   gitlab.String(d.Get("author_email").(string)),
+		AuthorName:    gitlab.String(d.Get("author_name").(string)),
+		Content:       gitlab.String(d.Get("content").(string)),
+		CommitMessage: gitlab.String(d.Get("commit_message").(string)),
+		Encoding:      gitlab.String("base64"),
+	}
+
+	repositoryFile, _, err := client.RepositoryFiles.CreateFile(project, file, options)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(repositoryFile.FilePath)
+
+	return resourceGitlabRepositoryFileRead(d, meta)
+}
+
+func resourceGitlabRepositoryFileRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	project := d.Get("project").(string)
+	fileID := d.Id()
+	options := &gitlab.GetFileOptions{
+		Ref: gitlab.String(d.Get("branch").(string)),
+	}
+
+	repositoryFile, _, err := client.RepositoryFiles.GetFile(project, fileID, options)
+	if err != nil {
+		return err
+	}
+
+	d.Set("project", project)
+	d.Set("file", repositoryFile.FileName)
+	d.Set("content", repositoryFile.Content)
+	d.Set("branch", repositoryFile.Ref)
+
+	return nil
+}
+
+func resourceGitlabRepositoryFileUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	project := d.Get("project").(string)
+	file := d.Get("file").(string)
+	options := &gitlab.UpdateFileOptions{
+		Branch:        gitlab.String(d.Get("branch").(string)),
+		AuthorEmail:   gitlab.String(d.Get("author_email").(string)),
+		AuthorName:    gitlab.String(d.Get("author_name").(string)),
+		Content:       gitlab.String(d.Get("content").(string)),
+		CommitMessage: gitlab.String(d.Get("commit_message").(string)),
+		//TODO: add LastCommitID
+	}
+
+	if d.HasChange("branch") {
+		options.Branch = gitlab.String(d.Get("branch").(string))
+	}
+
+	if d.HasChange("author_email") {
+		options.AuthorEmail = gitlab.String(d.Get("author_email").(string))
+	}
+
+	if d.HasChange("author_name") {
+		options.AuthorName = gitlab.String(d.Get("author_name").(string))
+	}
+
+	if d.HasChange("content") {
+		options.Content = gitlab.String(d.Get("content").(string))
+	}
+
+	if d.HasChange("commit_message") {
+		options.CommitMessage = gitlab.String(d.Get("commit_message").(string))
+	}
+	_, _, err := client.RepositoryFiles.UpdateFile(project, file, options)
+	if err != nil {
+		return err
+	}
+
+	return resourceGitlabRepositoryFileRead(d, meta)
+}
+
+func resourceGitlabRepositoryFileDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	project := d.Get("project").(string)
+	file := d.Get("file").(string)
+	options := &gitlab.DeleteFileOptions{
+		Branch:        gitlab.String(d.Get("branch").(string)),
+		AuthorEmail:   gitlab.String(d.Get("author_email").(string)),
+		AuthorName:    gitlab.String(d.Get("author_name").(string)),
+		CommitMessage: gitlab.String(d.Get("commit_message").(string)),
+		//TODO: add LastCommitID
+	}
+
+	resp, err := client.RepositoryFiles.DeleteFile(project, file, options)
+	if err != nil {
+		return fmt.Errorf("%s failed to delete repository file: %s", d.Id(), resp.Status)
+	}
+	return err
+}

--- a/gitlab/resource_gitlab_repository_file.go
+++ b/gitlab/resource_gitlab_repository_file.go
@@ -2,6 +2,8 @@ package gitlab
 
 import (
 	"fmt"
+	"time"
+	"math/rand"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/xanzy/go-gitlab"
@@ -43,6 +45,10 @@ func resourceGitlabRepositoryFile() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"ignore_content_changes": {
+				Type: schema.TypeBool,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -60,6 +66,12 @@ func resourceGitlabRepositoryFileCreate(d *schema.ResourceData, meta interface{}
 		CommitMessage: gitlab.String(d.Get("commit_message").(string)),
 		Encoding:      gitlab.String("base64"),
 	}
+
+	// Sleep so the API doesn't derp out
+	rand.Seed(time.Now().UnixNano())
+	n := rand.Intn(30)
+	nPlus := n + 2
+	time.Sleep(time.Duration(nPlus)*time.Second)	
 
 	repositoryFile, _, err := client.RepositoryFiles.CreateFile(project, file, options)
 	if err != nil {
@@ -96,12 +108,14 @@ func resourceGitlabRepositoryFileUpdate(d *schema.ResourceData, meta interface{}
 	client := meta.(*gitlab.Client)
 	project := d.Get("project").(string)
 	file := d.Get("file").(string)
+	// ignoreContentChanges := d.Get("ignore_content_changes").(bool)
 	options := &gitlab.UpdateFileOptions{
 		Branch:        gitlab.String(d.Get("branch").(string)),
 		AuthorEmail:   gitlab.String(d.Get("author_email").(string)),
 		AuthorName:    gitlab.String(d.Get("author_name").(string)),
 		Content:       gitlab.String(d.Get("content").(string)),
 		CommitMessage: gitlab.String(d.Get("commit_message").(string)),
+		Encoding: gitlab.String("base64"),
 		//TODO: add LastCommitID
 	}
 
@@ -143,6 +157,13 @@ func resourceGitlabRepositoryFileDelete(d *schema.ResourceData, meta interface{}
 		CommitMessage: gitlab.String(d.Get("commit_message").(string)),
 		//TODO: add LastCommitID
 	}
+
+
+	// Sleep so the API doesn't derp out
+	rand.Seed(time.Now().UnixNano())
+	n := rand.Intn(30)
+	nPlus := n + 2
+	time.Sleep(time.Duration(nPlus)*time.Second)	
 
 	resp, err := client.RepositoryFiles.DeleteFile(project, file, options)
 	if err != nil {

--- a/gitlab/resource_gitlab_repository_file.go
+++ b/gitlab/resource_gitlab_repository_file.go
@@ -2,7 +2,6 @@ package gitlab
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/xanzy/go-gitlab"

--- a/gitlab/resource_gitlab_repository_file_test.go
+++ b/gitlab/resource_gitlab_repository_file_test.go
@@ -1,0 +1,135 @@
+package gitlab
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	gitlab "github.com/xanzy/go-gitlab"
+)
+
+func TestAccGitlabRepositoryFile_basic(t *testing.T) {
+	var file gitlab.File
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGitlabRepositoryFileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGitlabRepositoryFileConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabRepositoryFileExists("gitlab_repository_file.this", &file),
+					testAccCheckGitlabRepositoryFileAttributes(&file, &testAccGitlabRepositoryFileAttributes{
+						FileName: "meow.txt",
+						Content:  "bWVvdyBtZW93IG1lb3c=",
+					}),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckGitlabRepositoryFileExists(n string, file *gitlab.File) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+
+		fileID := rs.Primary.ID
+		branch := rs.Primary.Attributes["branch"]
+		if branch == "" {
+			return fmt.Errorf("No branch set")
+		}
+		options := &gitlab.GetFileOptions{
+			Ref: gitlab.String(branch),
+		}
+		repoName := rs.Primary.Attributes["project"]
+		if repoName == "" {
+			return fmt.Errorf("No project ID set")
+		}
+
+		conn := testAccProvider.Meta().(*gitlab.Client)
+
+		gotFile, _, err := conn.RepositoryFiles.GetFile(repoName, fileID, options)
+		if err != nil {
+			return fmt.Errorf("Cannot get file: %v", err)
+		}
+
+		if gotFile.FilePath == fileID {
+			*file = *gotFile
+			return nil
+		}
+		return fmt.Errorf("File does not exist")
+	}
+}
+
+type testAccGitlabRepositoryFileAttributes struct {
+	FileName string
+	Content  string
+}
+
+func testAccCheckGitlabRepositoryFileAttributes(got *gitlab.File, want *testAccGitlabRepositoryFileAttributes) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if got.FileName != want.FileName {
+			return fmt.Errorf("got name %q; want %q", got.FileName, want.FileName)
+		}
+
+		if got.Content != want.Content {
+			return fmt.Errorf("got content %q; want %q", got.Content, want.Content)
+		}
+		return nil
+	}
+}
+
+func testAccCheckGitlabRepositoryFileDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*gitlab.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "gitlab_project" {
+			continue
+		}
+
+		gotRepo, resp, err := conn.Projects.GetProject(rs.Primary.ID, nil)
+		if err == nil {
+			if gotRepo != nil && fmt.Sprintf("%d", gotRepo.ID) == rs.Primary.ID {
+				if gotRepo.MarkedForDeletionAt == nil {
+					return fmt.Errorf("Repository still exists")
+				}
+			}
+		}
+		if resp.StatusCode != 404 {
+			return err
+		}
+		return nil
+	}
+	return nil
+}
+
+func testAccGitlabRepositoryFileConfig(rInt int) string {
+	return fmt.Sprintf(`
+	resource "gitlab_project" "foo" {
+	  name = "foo-%d"
+	  description = "Terraform acceptance tests"
+	
+	  # So that acceptance tests can be run in a gitlab organization
+	  # with no billing
+	  visibility_level = "public"
+	  initialize_with_readme = true
+	}
+	
+	resource "gitlab_repository_file" "this" {
+	  project = "${gitlab_project.foo.id}"
+	  file = "meow.txt"
+	  content = "bWVvdyBtZW93IG1lb3c="
+	  branch = "master"
+	  author_name = "Meow Meowington"
+	  author_email = "meow@catnip.com"
+	  commit_message = "feature: add launch codes"
+	}
+		`, rInt)
+}

--- a/website/docs/r/environment.html.markdown
+++ b/website/docs/r/environment.html.markdown
@@ -1,0 +1,50 @@
+---
+layout: "gitlab"
+page_title: "Gitlab: gitlab_environment_file"
+sidebar_current: "docs-gitlab-environment-file"
+---
+
+# gitlab\_environment
+
+This resource allows you to create and manage Gitlab environments.
+
+## Example Usage
+
+```hcl
+resource "gitlab_group" "this" {
+    name = "example"
+    path = "example"
+    description = "An example project"
+}
+
+resource "gitlab_project" "this" {
+    name = "exmaple"
+    namespace_id = gitlab_group.this.id
+    pipelines_enabled = true
+}
+
+resource "gitlab_environment" "this" {
+    project = gitlab_project.this.id
+    name = "dev"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project` - (Required) The ID of the project the environment belongs to.
+
+* `name` - (Required) The name of the environment.
+
+* `external_url` - (Optional) An external URL to refer to.
+
+## Attribute Reference
+
+The resource exports the following attributes:
+
+* `id` - The unique ID assigned to the environment.
+
+* `slug` - The slug of the environment name.
+
+* `state` - The state of the environment.

--- a/website/docs/r/repository_file.html.markdown
+++ b/website/docs/r/repository_file.html.markdown
@@ -1,0 +1,59 @@
+---
+layout: "gitlab"
+page_title: "Gitlab: gitlab_repository_file"
+sidebar_current: "docs-gitlab-repository-file"
+---
+
+# gitlab\_repository\_file
+
+This resource allows you to create and manage GitLab repository files.
+
+## Example Usage
+
+```hcl
+resource "gitlab_group" "this" {
+    name        = "example"
+    path        = "example"
+    description = "An example group"
+}
+
+resource "gitlab_project" "this" {
+    name                   = "example"
+    namespace_id           = gitlab_group.this.id
+    initialize_with_readme = true
+}
+
+resource "gitlab_repository_file" "this" {
+    project        = gitlab_project.this.id
+    file           = "meow.txt"
+    content        = base64encode("Meow goes the cat")
+    branch         = "master"
+    author_name    = "Terraform"
+    author_email   = "terraform@example.com"
+    commit_message = "feature: add meow file"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project` - (Required) The ID of the project.
+
+* `file` - (Required) The full path of the file.
+
+* `content` - (Required) Base64 encoded string.
+
+* `branch` - (Required) Name of the branch to which to commit to.
+
+* `author_name` - (Optional) Name of the commit author.
+
+* `author_email` - (Optional) Email of the commit author.
+
+* `commit_message` - (Required) Commit message.
+
+## Attribute Reference
+
+The resource exports the following attributes:
+
+* `id` - The unique ID assigned to the file.


### PR DESCRIPTION
This PR contains the code to implement `gitlab_resource_file` and `gitlab_environment`, as per the below checklist a few items are still required before this is good to be merged.

One thing that I would like some assistance with however is the fact that sometimes when using the `gitlab_resource_file` resource type the GitLab API returns a `400 Bad Request` when deleting files as well as creating. This is why I have added a sleep into both create and delete functions. It seems to only occur when a few files are being added or deleted. Any advice here would be greatly appreciated.


# ToDo
- [x] Add tests for `gitlab_resource_file`
- [x] Add tests for `gitlab_environment`
- [x] Update website data for the two new resources