### PR TITLE
Added Quotes in the example for group cluster

### DIFF
--- a/website/docs/r/group_cluster.html.markdown
+++ b/website/docs/r/group_cluster.html.markdown
@@ -21,7 +21,7 @@ resource "gitlab_group" "foo" {
   path = "foo-path"
 }
 
-resource gitlab_group_cluster "bar" {
+resource "gitlab_group_cluster" "bar" {
   group                       = "${gitlab_group.foo.id}"
   name                          = "bar-cluster"
   domain                        = "example.com"


### PR DESCRIPTION
Here is the same PR but from a forked Repo. Is this the correct workflow?

Added required quotes to the example for group_cluster.