### PR TITLE
feature: add project mirror resources to provider

### DIFF
--- a/gitlab/provider.go
+++ b/gitlab/provider.go
@@ -88,6 +88,7 @@ func Provider() terraform.ResourceProvider {
 			"gitlab_project_share_group":        resourceGitlabProjectShareGroup(),
 			"gitlab_group_cluster":              resourceGitlabGroupCluster(),
 			"gitlab_group_ldap_link":            resourceGitlabGroupLdapLink(),
+			"gitlab_project_mirror":             resourceGitlabProjectMirror(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/gitlab/resource_gitlab_project_mirror.go
+++ b/gitlab/resource_gitlab_project_mirror.go
@@ -1,0 +1,176 @@
+package gitlab
+
+import (
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/xanzy/go-gitlab"
+)
+
+func resourceGitlabProjectMirror() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGitlabMirrorCreate,
+		Read:   resourceGitlabProjectMirrorRead,
+		Update: resourceGitlabMirrorUpdate,
+		Delete: resourceGitlabMirrorDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"project": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"mirror_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"url": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"enabled": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"only_protected_branches": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+			"keep_divergent_refs": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+			},
+		},
+	}
+}
+
+func resourceGitlabMirrorCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+
+	projectID := d.Get("project").(string)
+	URL := d.Get("url").(string)
+	enabled := d.Get("enabled").(bool)
+	onlyProtectedBranches := d.Get("only_protected_branches").(bool)
+	keepDivergentRefs := d.Get("keep_divergent_refs").(bool)
+
+	options := &gitlab.AddProjectMirrorOptions{
+		URL:                   &URL,
+		Enabled:               &enabled,
+		OnlyProtectedBranches: &onlyProtectedBranches,
+		KeepDivergentRefs:     &keepDivergentRefs,
+	}
+
+	log.Printf("[DEBUG] create gitlab project mirror for project %v", projectID)
+
+	mirror, _, err := client.ProjectMirrors.AddProjectMirror(projectID, options)
+	if err != nil {
+		return err
+	}
+	d.Set("mirror_id", mirror.ID)
+
+	mirrorID := strconv.Itoa(mirror.ID)
+	d.SetId(buildTwoPartID(&projectID, &mirrorID))
+	return resourceGitlabProjectMirrorRead(d, meta)
+}
+
+func resourceGitlabMirrorUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+
+	mirrorID := d.Get("mirror_id").(int)
+	projectID := d.Get("project").(string)
+	enabled := d.Get("enabled").(bool)
+	onlyProtectedBranches := d.Get("only_protected_branches").(bool)
+	keepDivergentRefs := d.Get("keep_divergent_refs").(bool)
+
+	options := gitlab.EditProjectMirrorOptions{
+		Enabled:               &enabled,
+		OnlyProtectedBranches: &onlyProtectedBranches,
+		KeepDivergentRefs:     &keepDivergentRefs,
+	}
+	log.Printf("[DEBUG] update gitlab project mirror %v for %s", mirrorID, projectID)
+
+	_, _, err := client.ProjectMirrors.EditProjectMirror(projectID, mirrorID, &options)
+	if err != nil {
+		return err
+	}
+	return resourceGitlabProjectMirrorRead(d, meta)
+}
+
+// Documented remote mirrors API does not support a delete method, instead mirror is disabled.
+func resourceGitlabMirrorDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+
+	enabled := false
+
+	mirrorID := d.Get("mirror_id").(int)
+	projectID := d.Get("project").(string)
+	onlyProtectedBranches := d.Get("only_protected_branches").(bool)
+	keepDivergentRefs := d.Get("keep_divergent_refs").(bool)
+
+	options := gitlab.EditProjectMirrorOptions{
+		Enabled:               &enabled,
+		OnlyProtectedBranches: &onlyProtectedBranches,
+		KeepDivergentRefs:     &keepDivergentRefs,
+	}
+	log.Printf("[DEBUG] Disable gitlab project mirror %v for %s", mirrorID, projectID)
+
+	_, _, err := client.ProjectMirrors.EditProjectMirror(projectID, mirrorID, &options)
+
+	return err
+}
+
+func resourceGitlabProjectMirrorRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+
+	ids := strings.Split(d.Id(), ":")
+	projectID := ids[0]
+	mirrorID := ids[1]
+	integerMirrorID, err := strconv.Atoi(mirrorID)
+	if err != nil {
+		return err
+	}
+	log.Printf("[DEBUG] read gitlab project mirror %s id %v", projectID, mirrorID)
+
+	mirrors, _, err := client.ProjectMirrors.ListProjectMirror(projectID)
+
+	if err != nil {
+		return err
+	}
+
+	var mirror *gitlab.ProjectMirror
+	found := false
+
+	for _, m := range mirrors {
+		log.Printf("[DEBUG] project mirror found %v", m.ID)
+		if m.ID == integerMirrorID {
+			mirror = m
+			found = true
+		}
+	}
+
+	if !found {
+		d.SetId("")
+		return nil
+	}
+
+	resourceGitlabProjectMirrorSetToState(d, mirror, &projectID)
+	return nil
+}
+
+func resourceGitlabProjectMirrorSetToState(d *schema.ResourceData, projectMirror *gitlab.ProjectMirror, projectID *string) {
+
+	mirrorID := strconv.Itoa(projectMirror.ID)
+	d.Set("enabled", projectMirror.Enabled)
+	d.Set("only_protected_branches", projectMirror.OnlyProtectedBranches)
+	d.Set("keep_divergent_refs", projectMirror.KeepDivergentRefs)
+	d.SetId(buildTwoPartID(projectID, &mirrorID))
+}

--- a/gitlab/resource_gitlab_project_mirror.go
+++ b/gitlab/resource_gitlab_project_mirror.go
@@ -168,6 +168,9 @@ func resourceGitlabProjectMirrorRead(d *schema.ResourceData, meta interface{}) e
 
 func resourceGitlabProjectMirrorSetToState(d *schema.ResourceData, projectMirror *gitlab.ProjectMirror, projectID *string) {
 	d.Set("enabled", projectMirror.Enabled)
-	d.Set("only_protected_branches", projectMirror.OnlyProtectedBranches)
+	d.Set("mirror_id", projectMirror.ID)
 	d.Set("keep_divergent_refs", projectMirror.KeepDivergentRefs)
+	d.Set("only_protected_branches", projectMirror.OnlyProtectedBranches)
+	d.Set("project", projectID)
+	d.Set("url", projectMirror.URL)
 }

--- a/gitlab/resource_gitlab_project_mirror.go
+++ b/gitlab/resource_gitlab_project_mirror.go
@@ -11,10 +11,10 @@ import (
 
 func resourceGitlabProjectMirror() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceGitlabMirrorCreate,
+		Create: resourceGitlabProjectMirrorCreate,
 		Read:   resourceGitlabProjectMirrorRead,
-		Update: resourceGitlabMirrorUpdate,
-		Delete: resourceGitlabMirrorDelete,
+		Update: resourceGitlabProjectMirrorUpdate,
+		Delete: resourceGitlabProjectMirrorDelete,
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
@@ -53,7 +53,7 @@ func resourceGitlabProjectMirror() *schema.Resource {
 	}
 }
 
-func resourceGitlabMirrorCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceGitlabProjectMirrorCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gitlab.Client)
 
 	projectID := d.Get("project").(string)
@@ -82,7 +82,7 @@ func resourceGitlabMirrorCreate(d *schema.ResourceData, meta interface{}) error 
 	return resourceGitlabProjectMirrorRead(d, meta)
 }
 
-func resourceGitlabMirrorUpdate(d *schema.ResourceData, meta interface{}) error {
+func resourceGitlabProjectMirrorUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gitlab.Client)
 
 	mirrorID := d.Get("mirror_id").(int)
@@ -106,7 +106,7 @@ func resourceGitlabMirrorUpdate(d *schema.ResourceData, meta interface{}) error 
 }
 
 // Documented remote mirrors API does not support a delete method, instead mirror is disabled.
-func resourceGitlabMirrorDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceGitlabProjectMirrorDelete(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gitlab.Client)
 
 	enabled := false
@@ -167,10 +167,7 @@ func resourceGitlabProjectMirrorRead(d *schema.ResourceData, meta interface{}) e
 }
 
 func resourceGitlabProjectMirrorSetToState(d *schema.ResourceData, projectMirror *gitlab.ProjectMirror, projectID *string) {
-
-	mirrorID := strconv.Itoa(projectMirror.ID)
 	d.Set("enabled", projectMirror.Enabled)
 	d.Set("only_protected_branches", projectMirror.OnlyProtectedBranches)
 	d.Set("keep_divergent_refs", projectMirror.KeepDivergentRefs)
-	d.SetId(buildTwoPartID(projectID, &mirrorID))
 }

--- a/gitlab/resource_gitlab_project_mirror_test.go
+++ b/gitlab/resource_gitlab_project_mirror_test.go
@@ -1,0 +1,213 @@
+package gitlab
+
+// TODO convert to handle project mirror.
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/xanzy/go-gitlab"
+)
+
+func TestAccGitlabProjectMirror_basic(t *testing.T) {
+	var hook gitlab.ProjectMirror
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGitlabProjectMirrorDestroy,
+		Steps: []resource.TestStep{
+			// Create a project and hook with default options
+			{
+				Config: testAccGitlabProjectMirrorConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabProjectMirrorExists("gitlab_project_mirror.foo", &hook),
+					testAccCheckGitlabProjectMirrorAttributes(&hook, &testAccGitlabProjectMirrorExpectedAttributes{
+						URL:                   fmt.Sprintf("https://example.com/hook-%d", rInt),
+						Enabled:               true,
+						OnlyProtectedBranches: true,
+						KeepDivergentRefs:     true,
+					}),
+				),
+			},
+			// Update the project hook to toggle all the values to their inverse
+			{
+				Config: testAccGitlabProjectMirrorUpdateConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabProjectMirrorExists("gitlab_project_mirror.foo", &hook),
+					testAccCheckGitlabProjectMirrorAttributes(&hook, &testAccGitlabProjectMirrorExpectedAttributes{
+						URL:                   fmt.Sprintf("https://example.com/hook-%d", rInt),
+						Enabled:               false,
+						OnlyProtectedBranches: false,
+						KeepDivergentRefs:     false,
+					}),
+				),
+			},
+			// Update the project hook to toggle the options back
+			{
+				Config: testAccGitlabProjectMirrorConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabProjectMirrorExists("gitlab_project_mirror.foo", &hook),
+					testAccCheckGitlabProjectMirrorAttributes(&hook, &testAccGitlabProjectMirrorExpectedAttributes{
+						URL:                   fmt.Sprintf("https://example.com/hook-%d", rInt),
+						Enabled:               true,
+						OnlyProtectedBranches: true,
+						KeepDivergentRefs:     true,
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGitlabProjectMirror_import(t *testing.T) {
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGitlabProjectMirrorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGitlabProjectMirrorConfig(rInt),
+			},
+			{
+				ResourceName:            "gitlab_project_mirror.foo",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"enabled", "mirror_id", "project", "url"},
+			},
+		},
+	})
+}
+
+func testAccCheckGitlabProjectMirrorExists(n string, mirror *gitlab.ProjectMirror) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not Found: %s", n)
+		}
+
+		splitID := strings.Split(rs.Primary.ID, ":")
+
+		mirrorID, err := strconv.Atoi(splitID[len(splitID)-1])
+		if err != nil {
+			return err
+		}
+		repoName := rs.Primary.Attributes["project"]
+		if repoName == "" {
+			return fmt.Errorf("No project ID is set")
+		}
+		conn := testAccProvider.Meta().(*gitlab.Client)
+
+		mirrors, _, err := conn.ProjectMirrors.ListProjectMirror(repoName, nil)
+		if err != nil {
+			return err
+		}
+
+		for _, m := range mirrors {
+			if m.ID == mirrorID {
+				*mirror = *m
+				break
+			}
+			return errors.New("unable to find mirror.")
+		}
+		return nil
+	}
+}
+
+type testAccGitlabProjectMirrorExpectedAttributes struct {
+	URL                   string
+	Enabled               bool
+	OnlyProtectedBranches bool
+	KeepDivergentRefs     bool
+}
+
+func testAccCheckGitlabProjectMirrorAttributes(mirror *gitlab.ProjectMirror, want *testAccGitlabProjectMirrorExpectedAttributes) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if mirror.URL != want.URL {
+			return fmt.Errorf("got url %q; want %q", mirror.URL, want.URL)
+		}
+
+		if mirror.Enabled != want.Enabled {
+			return fmt.Errorf("got enable_ssl_verification %t; want %t", mirror.Enabled, want.Enabled)
+		}
+		if mirror.OnlyProtectedBranches != want.OnlyProtectedBranches {
+			return fmt.Errorf("got enable_ssl_verification %t; want %t", mirror.OnlyProtectedBranches, want.OnlyProtectedBranches)
+		}
+		if mirror.KeepDivergentRefs != want.KeepDivergentRefs {
+			return fmt.Errorf("got enable_ssl_verification %t; want %t", mirror.KeepDivergentRefs, want.KeepDivergentRefs)
+		}
+		return nil
+	}
+}
+
+func testAccCheckGitlabProjectMirrorDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*gitlab.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "gitlab_project" {
+			continue
+		}
+
+		gotRepo, resp, err := conn.Projects.GetProject(rs.Primary.ID, nil)
+		if err == nil {
+			if gotRepo != nil && fmt.Sprintf("%d", gotRepo.ID) == rs.Primary.ID {
+				if gotRepo.MarkedForDeletionAt == nil {
+					return fmt.Errorf("Repository still exists")
+				}
+			}
+		}
+		if resp.StatusCode != 404 {
+			return err
+		}
+		return nil
+	}
+	return nil
+}
+
+func testAccGitlabProjectMirrorConfig(rInt int) string {
+	return fmt.Sprintf(`
+resource "gitlab_project" "foo" {
+  name = "foo-%d"
+  description = "Terraform acceptance tests"
+
+  # So that acceptance tests can be run in a gitlab organization
+  # with no billing
+  visibility_level = "public"
+}
+
+resource "gitlab_project_mirror" "foo" {
+  project = "${gitlab_project.foo.id}"
+  url = "https://example.com/hook-%d"
+}
+	`, rInt, rInt)
+}
+
+func testAccGitlabProjectMirrorUpdateConfig(rInt int) string {
+	return fmt.Sprintf(`
+resource "gitlab_project" "foo" {
+  name = "foo-%d"
+  description = "Terraform acceptance tests"
+
+  # So that acceptance tests can be run in a gitlab organization
+  # with no billing
+  visibility_level = "public"
+}
+
+resource "gitlab_project_mirror" "foo" {
+  project = "${gitlab_project.foo.id}"
+  url = "https://example.com/hook-%d"
+  enabled = false
+  only_protected_branches = false
+  keep_divergent_refs = false
+}
+	`, rInt, rInt)
+}

--- a/gitlab/resource_gitlab_project_mirror_test.go
+++ b/gitlab/resource_gitlab_project_mirror_test.go
@@ -1,7 +1,5 @@
 package gitlab
 
-// TODO convert to handle project mirror.
-
 import (
 	"errors"
 	"fmt"
@@ -79,10 +77,10 @@ func TestAccGitlabProjectMirror_import(t *testing.T) {
 				Config: testAccGitlabProjectMirrorConfig(rInt),
 			},
 			{
-				ResourceName:            "gitlab_project_mirror.foo",
-				ImportState:             true,
-				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"enabled", "mirror_id", "project", "url"},
+				ResourceName:      "gitlab_project_mirror.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+				//ImportStateVerifyIgnore: []string{"enabled", "mirror_id", "project", "url"},
 			},
 		},
 	})
@@ -137,13 +135,13 @@ func testAccCheckGitlabProjectMirrorAttributes(mirror *gitlab.ProjectMirror, wan
 		}
 
 		if mirror.Enabled != want.Enabled {
-			return fmt.Errorf("got enable_ssl_verification %t; want %t", mirror.Enabled, want.Enabled)
+			return fmt.Errorf("got enabled %t; want %t", mirror.Enabled, want.Enabled)
 		}
 		if mirror.OnlyProtectedBranches != want.OnlyProtectedBranches {
-			return fmt.Errorf("got enable_ssl_verification %t; want %t", mirror.OnlyProtectedBranches, want.OnlyProtectedBranches)
+			return fmt.Errorf("got only protected branches %t; want %t", mirror.OnlyProtectedBranches, want.OnlyProtectedBranches)
 		}
 		if mirror.KeepDivergentRefs != want.KeepDivergentRefs {
-			return fmt.Errorf("got enable_ssl_verification %t; want %t", mirror.KeepDivergentRefs, want.KeepDivergentRefs)
+			return fmt.Errorf("got keep divergent refs %t; want %t", mirror.KeepDivergentRefs, want.KeepDivergentRefs)
 		}
 		return nil
 	}

--- a/gitlab/resource_gitlab_project_mirror_test.go
+++ b/gitlab/resource_gitlab_project_mirror_test.go
@@ -80,7 +80,6 @@ func TestAccGitlabProjectMirror_import(t *testing.T) {
 				ResourceName:      "gitlab_project_mirror.foo",
 				ImportState:       true,
 				ImportStateVerify: true,
-				//ImportStateVerifyIgnore: []string{"enabled", "mirror_id", "project", "url"},
 			},
 		},
 	})

--- a/website/docs/r/project_mirror.html.markdown
+++ b/website/docs/r/project_mirror.html.markdown
@@ -1,0 +1,43 @@
+---
+layout: "gitlab"
+page_title: "GitLab: gitlab_project_mirror"
+sidebar_current: "docs-gitlab-resource-project_mirror"
+description: |-
+  Adds a target to a projects remote mirrors.
+---
+
+# gitlab\_project_mirror
+
+This resource allows you to add a mirror target for the repository, all changes will be synced to the remote target.
+
+## Example Usage
+
+```hcl
+resource "gitlab_project_mirror" "foo" {
+  project = "1"
+  url = "https://username:password@github.com/org/repository.git"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `project` - (Required) The id of the project.
+
+* `url` - (Required) 	The URL of the remote repository to be mirrored.
+
+* `enabled` - 	Determines if the mirror is enabled.
+
+* `only_protected_branches` - Determines if only protected branches are mirrored.
+
+* `keep_divergent_refs` - Determines if divergent refs are skipped.
+
+## Import
+
+GitLab project mirror can be imported using an id made up of `project_id:mirror_id`, e.g.
+
+
+```
+$ terraform import gitlab_project_mirror.foo "12345:1337"
+```

--- a/website/gitlab.erb
+++ b/website/gitlab.erb
@@ -85,6 +85,9 @@
           <li<%= sidebar_current("docs-gitlab-resource-project_membership") %>>
               <a href="/docs/providers/gitlab/r/project_membership.html">gitlab_project_membership</a>
           </li>
+          <li<%= sidebar_current("docs-gitlab-resource-project_mirror") %>>
+              <a href="/docs/providers/gitlab/r/project_mirror.html">gitlab_project_mirror</a>
+          </li>
           <li<%= sidebar_current("docs-gitlab-resource-project_share_group") %>>
               <a href="/docs/providers/gitlab/r/project_share_group.html">gitlab_project_share_group</a>
           <li<%= sidebar_current("docs-gitlab-resource-project_push_rules") %>>


### PR DESCRIPTION
Implemented functionality for project mirrors, as per issue https://github.com/terraform-providers/terraform-provider-gitlab/issues/150

This was recently added to the go-gitlab library by myself and released in v0.33.0

https://github.com/xanzy/go-gitlab/pull/879
