### PR TITLE
Add code_owner_approval_required argument to gitlab_branch_protection resource

### DIFF
--- a/gitlab/resource_gitlab_branch_protection.go
+++ b/gitlab/resource_gitlab_branch_protection.go
@@ -43,6 +43,7 @@ func resourceGitlabBranchProtection() *schema.Resource {
 			"code_owner_approval_required": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				ForceNew: true,
 			},
 		},
 	}

--- a/gitlab/resource_gitlab_branch_protection.go
+++ b/gitlab/resource_gitlab_branch_protection.go
@@ -44,7 +44,7 @@ func resourceGitlabBranchProtection() *schema.Resource {
 			"code_owner_approval_required": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Computed: true,
+				Default:  false,
 			},
 		},
 	}
@@ -132,8 +132,6 @@ func resourceGitlabBranchProtectionUpdate(d *schema.ResourceData, meta interface
 		return err
 	}
 
-	d.SetId(buildTwoPartID(&project, &branch))
-
 	return resourceGitlabBranchProtectionRead(d, meta)
 }
 
@@ -152,7 +150,7 @@ func projectAndBranchFromID(id string) (string, string, error) {
 	project, branch, err := parseTwoPartID(id)
 
 	if err != nil {
-		log.Printf("[WARN] cannot get group member id from input: %v", id)
+		log.Printf("[WARN] cannot get branch protection id from input: %v", id)
 	}
 	return project, branch, err
 }

--- a/gitlab/resource_gitlab_branch_protection.go
+++ b/gitlab/resource_gitlab_branch_protection.go
@@ -1,6 +1,7 @@
 package gitlab
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -129,6 +130,12 @@ func resourceGitlabBranchProtectionUpdate(d *schema.ResourceData, meta interface
 	}
 
 	if _, err := client.ProtectedBranches.RequireCodeOwnerApprovals(project, branch, options); err != nil {
+		// The user might be running a version of GitLab that does not support this feature.
+		// We enhance the generic 404 error with a more informative message.
+		if errResponse, ok := err.(*gitlab.ErrorResponse); ok && errResponse.Response.StatusCode == 404 {
+			return fmt.Errorf("feature unavailable: code owner approvals: %w", err)
+		}
+
 		return err
 	}
 

--- a/gitlab/resource_gitlab_branch_protection.go
+++ b/gitlab/resource_gitlab_branch_protection.go
@@ -56,13 +56,13 @@ func resourceGitlabBranchProtectionCreate(d *schema.ResourceData, meta interface
 	branch := gitlab.String(d.Get("branch").(string))
 	mergeAccessLevel := accessLevelID[d.Get("merge_access_level").(string)]
 	pushAccessLevel := accessLevelID[d.Get("push_access_level").(string)]
-	codeOwnerApprovalRequired := getOptionalBool(d, "code_owner_approval_required")
+	codeOwnerApprovalRequired := d.Get("code_owner_approval_required").(bool)
 
 	options := &gitlab.ProtectRepositoryBranchesOptions{
 		Name:                      branch,
 		MergeAccessLevel:          &mergeAccessLevel,
 		PushAccessLevel:           &pushAccessLevel,
-		CodeOwnerApprovalRequired: codeOwnerApprovalRequired,
+		CodeOwnerApprovalRequired: &codeOwnerApprovalRequired,
 	}
 
 	log.Printf("[DEBUG] create gitlab branch protection on %v for project %s", options.Name, project)
@@ -120,12 +120,12 @@ func resourceGitlabBranchProtectionUpdate(d *schema.ResourceData, meta interface
 	client := meta.(*gitlab.Client)
 	project := d.Get("project").(string)
 	branch := d.Get("branch").(string)
-	codeOwnerApprovalRequired := getOptionalBool(d, "code_owner_approval_required")
+	codeOwnerApprovalRequired := d.Get("code_owner_approval_required").(bool)
 
 	log.Printf("[DEBUG] update gitlab branch protection for project %s, branch %s", project, branch)
 
 	options := &gitlab.RequireCodeOwnerApprovalsOptions{
-		CodeOwnerApprovalRequired: codeOwnerApprovalRequired,
+		CodeOwnerApprovalRequired: &codeOwnerApprovalRequired,
 	}
 
 	if _, err := client.ProtectedBranches.RequireCodeOwnerApprovals(project, branch, options); err != nil {

--- a/gitlab/resource_gitlab_branch_protection.go
+++ b/gitlab/resource_gitlab_branch_protection.go
@@ -40,6 +40,10 @@ func resourceGitlabBranchProtection() *schema.Resource {
 				Required:     true,
 				ForceNew:     true,
 			},
+			"code_owner_approval_required": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 		},
 	}
 }
@@ -50,11 +54,13 @@ func resourceGitlabBranchProtectionCreate(d *schema.ResourceData, meta interface
 	branch := gitlab.String(d.Get("branch").(string))
 	mergeAccessLevel := accessLevelID[d.Get("merge_access_level").(string)]
 	pushAccessLevel := accessLevelID[d.Get("push_access_level").(string)]
+	codeOwnerApprovalRequired := getOptionalBool(d, "code_owner_approval_required")
 
 	options := &gitlab.ProtectRepositoryBranchesOptions{
-		Name:             branch,
-		MergeAccessLevel: &mergeAccessLevel,
-		PushAccessLevel:  &pushAccessLevel,
+		Name:                      branch,
+		MergeAccessLevel:          &mergeAccessLevel,
+		PushAccessLevel:           &pushAccessLevel,
+		CodeOwnerApprovalRequired: codeOwnerApprovalRequired,
 	}
 
 	log.Printf("[DEBUG] create gitlab branch protection on %v for project %s", options.Name, project)
@@ -98,6 +104,7 @@ func resourceGitlabBranchProtectionRead(d *schema.ResourceData, meta interface{}
 	d.Set("branch", pb.Name)
 	d.Set("merge_access_level", accessLevel[pb.MergeAccessLevels[0].AccessLevel])
 	d.Set("push_access_level", accessLevel[pb.PushAccessLevels[0].AccessLevel])
+	d.Set("code_owner_approval_required", pb.CodeOwnerApprovalRequired)
 
 	d.SetId(buildTwoPartID(&project, &pb.Name))
 

--- a/gitlab/resource_gitlab_branch_protection_test.go
+++ b/gitlab/resource_gitlab_branch_protection_test.go
@@ -26,8 +26,8 @@ func TestAccGitlabBranchProtection_basic(t *testing.T) {
 			{
 				Config: testAccGitlabBranchProtectionConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.BranchProtect", &pb),
-					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.BranchProtect", &pb),
+					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.branch_protect", &pb),
+					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
 						Name:             fmt.Sprintf("BranchProtect-%d", rInt),
 						PushAccessLevel:  accessLevel[gitlab.DeveloperPermissions],
@@ -39,8 +39,8 @@ func TestAccGitlabBranchProtection_basic(t *testing.T) {
 			{
 				Config: testAccGitlabBranchProtectionUpdateConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.BranchProtect", &pb),
-					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.BranchProtect", &pb),
+					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.branch_protect", &pb),
+					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
 						Name:             fmt.Sprintf("BranchProtect-%d", rInt),
 						PushAccessLevel:  accessLevel[gitlab.MasterPermissions],
@@ -52,8 +52,8 @@ func TestAccGitlabBranchProtection_basic(t *testing.T) {
 			{
 				Config: testAccGitlabBranchProtectionConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.BranchProtect", &pb),
-					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.BranchProtect", &pb),
+					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.branch_protect", &pb),
+					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
 						Name:             fmt.Sprintf("BranchProtect-%d", rInt),
 						PushAccessLevel:  accessLevel[gitlab.DeveloperPermissions],
@@ -66,8 +66,8 @@ func TestAccGitlabBranchProtection_basic(t *testing.T) {
 				SkipFunc: isRunningInCE,
 				Config:   testAccGitlabBranchProtectionUpdateConfigCodeOwnerTrue(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.BranchProtect", &pb),
-					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.BranchProtect", &pb),
+					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.branch_protect", &pb),
+					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
 						Name:                      fmt.Sprintf("BranchProtect-%d", rInt),
 						PushAccessLevel:           accessLevel[gitlab.DeveloperPermissions],
@@ -82,8 +82,8 @@ func TestAccGitlabBranchProtection_basic(t *testing.T) {
 				Config:      testAccGitlabBranchProtectionUpdateConfigCodeOwnerTrue(rInt),
 				ExpectError: regexp.MustCompile("feature unavailable: code owner approvals"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.BranchProtect", &pb),
-					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.BranchProtect", &pb),
+					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.branch_protect", &pb),
+					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
 						Name:             fmt.Sprintf("BranchProtect-%d", rInt),
 						PushAccessLevel:  accessLevel[gitlab.DeveloperPermissions],
@@ -95,8 +95,8 @@ func TestAccGitlabBranchProtection_basic(t *testing.T) {
 			{
 				Config: testAccGitlabBranchProtectionConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.BranchProtect", &pb),
-					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.BranchProtect", &pb),
+					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.branch_protect", &pb),
+					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
 						Name:             fmt.Sprintf("BranchProtect-%d", rInt),
 						PushAccessLevel:  accessLevel[gitlab.DeveloperPermissions],
@@ -122,8 +122,8 @@ func TestAccGitlabBranchProtection_createWithCodeOwnerApproval(t *testing.T) {
 				SkipFunc: isRunningInCE,
 				Config:   testAccGitlabBranchProtectionUpdateConfigCodeOwnerTrue(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.BranchProtect", &pb),
-					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.BranchProtect", &pb),
+					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.branch_protect", &pb),
+					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
 						Name:                      fmt.Sprintf("BranchProtect-%d", rInt),
 						PushAccessLevel:           accessLevel[gitlab.DeveloperPermissions],
@@ -138,8 +138,8 @@ func TestAccGitlabBranchProtection_createWithCodeOwnerApproval(t *testing.T) {
 				Config:      testAccGitlabBranchProtectionUpdateConfigCodeOwnerTrue(rInt),
 				ExpectError: regexp.MustCompile("feature unavailable: code owner approvals"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.BranchProtect", &pb),
-					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.BranchProtect", &pb),
+					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.branch_protect", &pb),
+					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
 						Name:             fmt.Sprintf("BranchProtect-%d", rInt),
 						PushAccessLevel:  accessLevel[gitlab.DeveloperPermissions],
@@ -151,8 +151,8 @@ func TestAccGitlabBranchProtection_createWithCodeOwnerApproval(t *testing.T) {
 			{
 				Config: testAccGitlabBranchProtectionConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.BranchProtect", &pb),
-					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.BranchProtect", &pb),
+					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.branch_protect", &pb),
+					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
 						Name:             fmt.Sprintf("BranchProtect-%d", rInt),
 						PushAccessLevel:  accessLevel[gitlab.DeveloperPermissions],
@@ -278,8 +278,8 @@ resource "gitlab_project" "foo" {
   visibility_level = "public"
 }
 
-resource "gitlab_branch_protection" "BranchProtect" {
-  project = "${gitlab_project.foo.id}"
+resource "gitlab_branch_protection" "branch_protect" {
+  project = gitlab_project.foo.id
   branch = "BranchProtect-%d"
   push_access_level = "developer"
   merge_access_level = "developer"
@@ -298,8 +298,8 @@ resource "gitlab_project" "foo" {
   visibility_level = "public"
 }
 
-resource "gitlab_branch_protection" "BranchProtect" {
-	project = "${gitlab_project.foo.id}"
+resource "gitlab_branch_protection" "branch_protect" {
+	project = gitlab_project.foo.id
 	branch = "BranchProtect-%d"
 	push_access_level = "maintainer"
 	merge_access_level = "maintainer"
@@ -318,7 +318,7 @@ resource "gitlab_project" "foo" {
   visibility_level = "public"
 }
 
-resource "gitlab_branch_protection" "BranchProtect" {
+resource "gitlab_branch_protection" "branch_protect" {
   project = gitlab_project.foo.id
   branch = "BranchProtect-%d"
   push_access_level = "developer"

--- a/gitlab/resource_gitlab_branch_protection_test.go
+++ b/gitlab/resource_gitlab_branch_protection_test.go
@@ -2,6 +2,7 @@ package gitlab
 
 import (
 	"fmt"
+	"regexp"
 	"strconv"
 	"testing"
 
@@ -75,41 +76,15 @@ func TestAccGitlabBranchProtection_basic(t *testing.T) {
 					}),
 				),
 			},
-			// Update the Branch Protection to get back to initial settings.
-			// Since code_owner_approval_required is an optional setting, it does not revert to its original setting.
-			// This test ensures that the addition of this optional value is backward compatible and does not overwrite existing settings in GitLab when it is unset.
+			// Attempting to update code owner approval setting on CE should fail safely
 			{
-				SkipFunc: isRunningInCE,
-				Config:   testAccGitlabBranchProtectionConfig(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.BranchProtect", &pb),
-					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.BranchProtect", &pb),
-					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
-						Name:                      fmt.Sprintf("BranchProtect-%d", rInt),
-						PushAccessLevel:           accessLevel[gitlab.DeveloperPermissions],
-						MergeAccessLevel:          accessLevel[gitlab.DeveloperPermissions],
-						CodeOwnerApprovalRequired: true,
-					}),
-				),
+				SkipFunc:    isRunningInEE,
+				Config:      testAccGitlabBranchProtectionUpdateConfigCodeOwnerTrue(rInt),
+				ExpectError: regexp.MustCompile("404 Not Found"),
 			},
-			// Update the the Branch Protection to explicitly disable code owner approval, to truly reset state back to initial settings.
+			// Update the Branch Protection to get back to initial settings
 			{
-				SkipFunc: isRunningInCE,
-				Config:   testAccGitlabBranchProtectionUpdateConfigCodeOwnerFalse(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.BranchProtect", &pb),
-					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.BranchProtect", &pb),
-					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
-						Name:             fmt.Sprintf("BranchProtect-%d", rInt),
-						PushAccessLevel:  accessLevel[gitlab.DeveloperPermissions],
-						MergeAccessLevel: accessLevel[gitlab.DeveloperPermissions],
-					}),
-				),
-			},
-			// Update the Branch Protection to get back to initial settings.
-			{
-				SkipFunc: isRunningInCE,
-				Config:   testAccGitlabBranchProtectionConfig(rInt),
+				Config: testAccGitlabBranchProtectionConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.BranchProtect", &pb),
 					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.BranchProtect", &pb),
@@ -284,27 +259,6 @@ resource "gitlab_branch_protection" "BranchProtect" {
   push_access_level = "developer"
   merge_access_level = "developer"
   code_owner_approval_required = true
-}
-	`, rInt, rInt)
-}
-
-func testAccGitlabBranchProtectionUpdateConfigCodeOwnerFalse(rInt int) string {
-	return fmt.Sprintf(`
-resource "gitlab_project" "foo" {
-  name = "foo-%d"
-  description = "Terraform acceptance tests"
-
-  # So that acceptance tests can be run in a gitlab organization
-  # with no billing
-  visibility_level = "public"
-}
-
-resource "gitlab_branch_protection" "BranchProtect" {
-  project = "${gitlab_project.foo.id}"
-  branch = "BranchProtect-%d"
-  push_access_level = "developer"
-  merge_access_level = "developer"
-  code_owner_approval_required = false
 }
 	`, rInt, rInt)
 }

--- a/gitlab/resource_gitlab_branch_protection_test.go
+++ b/gitlab/resource_gitlab_branch_protection_test.go
@@ -319,7 +319,7 @@ resource "gitlab_project" "foo" {
 }
 
 resource "gitlab_branch_protection" "BranchProtect" {
-  project = "${gitlab_project.foo.id}"
+  project = gitlab_project.foo.id
   branch = "BranchProtect-%d"
   push_access_level = "developer"
   merge_access_level = "developer"

--- a/gitlab/resource_gitlab_branch_protection_test.go
+++ b/gitlab/resource_gitlab_branch_protection_test.go
@@ -76,11 +76,11 @@ func TestAccGitlabBranchProtection_basic(t *testing.T) {
 					}),
 				),
 			},
-			// Attempting to update code owner approval setting on CE should fail safely
+			// Attempting to update code owner approval setting on CE should fail safely and with an informative error message
 			{
 				SkipFunc:    isRunningInEE,
 				Config:      testAccGitlabBranchProtectionUpdateConfigCodeOwnerTrue(rInt),
-				ExpectError: regexp.MustCompile("404 Not Found"),
+				ExpectError: regexp.MustCompile("feature unavailable: code owner approvals"),
 			},
 			// Update the Branch Protection to get back to initial settings
 			{

--- a/gitlab/util.go
+++ b/gitlab/util.go
@@ -190,3 +190,12 @@ func stringSetToStringSlice(stringSet *schema.Set) *[]string {
 	}
 	return &ret
 }
+
+func getOptionalBool(d *schema.ResourceData, key string) *bool {
+	var result *bool
+	if value, isSet := d.GetOk(key); isSet {
+		valueBool := value.(bool)
+		result = &valueBool
+	}
+	return result
+}

--- a/gitlab/util.go
+++ b/gitlab/util.go
@@ -190,12 +190,3 @@ func stringSetToStringSlice(stringSet *schema.Set) *[]string {
 	}
 	return &ret
 }
-
-func getOptionalBool(d *schema.ResourceData, key string) *bool {
-	var result *bool
-	if value, isSet := d.GetOk(key); isSet {
-		valueBool := value.(bool)
-		result = &valueBool
-	}
-	return result
-}

--- a/website/docs/r/branch_protection.html.markdown
+++ b/website/docs/r/branch_protection.html.markdown
@@ -25,12 +25,12 @@ resource "gitlab_branch_protection" "BranchProtect" {
 
 The following arguments are supported:
 
-* `project` - (Required, string) The id of the project.
+* `project` - (Required) The id of the project.
 
-* `branch` - (Required, string) Name of the branch.
+* `branch` - (Required) Name of the branch.
 
-* `push_access_level` - (Required, string) One of five levels of access to the project.
+* `push_access_level` - (Required) One of five levels of access to the project.
 
-* `merge_access_level` - (Required, string) One of five levels of access to the project.
+* `merge_access_level` - (Required) One of five levels of access to the project.
 
-* `code_owner_approval_required` (Optional, bool) Can be set to true to enable code owner approval requirement. Requires GitLab Silver/Premium.
+* `code_owner_approval_required` (Optional) Bool, defaults to false. Can be set to true to require code owner approval before merging.

--- a/website/docs/r/branch_protection.html.markdown
+++ b/website/docs/r/branch_protection.html.markdown
@@ -25,10 +25,12 @@ resource "gitlab_branch_protection" "BranchProtect" {
 
 The following arguments are supported:
 
-* `project` - (Required) The id of the project.
+* `project` - (Required, string) The id of the project.
 
-* `branch` - (Required) Name of the branch.
+* `branch` - (Required, string) Name of the branch.
 
-* `push_access_level` - (Required) One of five levels of access to the project.
+* `push_access_level` - (Required, string) One of five levels of access to the project.
 
-* `merge_access_level` - (Required) One of five levels of access to the project.
+* `merge_access_level` - (Required, string) One of five levels of access to the project.
+
+* `code_owner_approval_required` (Optional, bool) Can be set to true to enable code owner approval requirement. Requires GitLab Silver/Premium.


### PR DESCRIPTION
Closes #310 

I added an optional`code_owner_approval_required` argument to the existing `gitlab_branch_protection` resource.

GitLab doc for the feature here: https://docs.gitlab.com/ee/user/project/protected_branches.html#protected-branches-approval-by-code-owners-premium

Users who manage this setting out of band will see a diff in their plan after upgrading the plugin.