### PR TITLE
feat(gitlab-application): Add resource for gitlab application, data source for current user

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -7,6 +7,12 @@ default: build
 
 build: fmtcheck
 	go install
+	go build -o terraform-provider-gitlab
+
+build-example: build
+	mkdir -p example/.terraform/plugins/darwin_amd64
+	cp terraform-provider-gitlab example/.terraform/plugins/darwin_amd64/
+	cd example && terraform init
 
 test: fmtcheck
 	go test -i $(TEST) || exit 1

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -7,12 +7,6 @@ default: build
 
 build: fmtcheck
 	go install
-	go build -o terraform-provider-gitlab
-
-build-example: build
-	mkdir -p example/.terraform/plugins/darwin_amd64
-	cp terraform-provider-gitlab example/.terraform/plugins/darwin_amd64/
-	cd example && terraform init
 
 test: fmtcheck
 	go test -i $(TEST) || exit 1

--- a/example/gitlab_application.tf
+++ b/example/gitlab_application.tf
@@ -1,0 +1,28 @@
+data "gitlab_current_user" "me" {
+}
+
+// https://github.com/terraform-providers/terraform-provider-gitlab/issues/321
+resource "gitlab_application" "grafana" {
+  // create the application if user has admin role, 
+  // otherwise Gitlab API rejects requests with 403 http status code
+  count = data.gitlab_current_user.me.is_admin ? 1 : 0
+
+  name = "grafana"
+  redirect_uri = [
+    "http://localhost:8080/auth/gitlab/callback",
+    "http://localhost:8080/auth/gitlab/callback2"
+  ]
+  scopes = ["openid", "email", "profile"]
+}
+
+output "me" {
+  value = data.gitlab_current_user.me
+}
+
+output "grafana_app_secret" {
+  value = {
+    app_id     = gitlab_application.grafana[0].application_id
+    app_secret = gitlab_application.grafana[0].secret
+  }
+  sensitive = true
+}

--- a/example/provider.tf
+++ b/example/provider.tf
@@ -1,0 +1,3 @@
+provider "gitlab" {
+  base_url = "http://localhost:8080"
+}

--- a/gitlab/data_source_gitlab_application.go
+++ b/gitlab/data_source_gitlab_application.go
@@ -1,0 +1,85 @@
+package gitlab
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/mitchellh/hashstructure"
+	"github.com/xanzy/go-gitlab"
+)
+
+func dataSourceGitlabApplications() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGitlabApplicationsRead,
+		Schema: map[string]*schema.Schema{
+			"applications": {
+				Type:     schema.TypeList,
+				Computed: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"application_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"application_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"id": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func flattenApplications(apps []*gitlab.Application) (values []map[string]interface{}) {
+	if apps != nil {
+		for _, app := range apps {
+			v := map[string]interface{}{
+				"id":               app.ID,
+				"application_id":   app.ApplicationID,
+				"application_name": app.ApplicationName,
+			}
+			values = append(values, v)
+		}
+	}
+	values = append(values, map[string]interface{}{
+		"id":               1,
+		"application_id":   "foo",
+		"application_name": "bar",
+	})
+	return values
+}
+
+func dataSourceGitlabApplicationsRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+
+	options := &gitlab.ListApplicationsOptions{
+		PerPage: 10,
+	}
+
+	log.Printf("[INFO] Reading Gitlab applications")
+
+	var apps []*gitlab.Application
+	_apps, _, err := client.Applications.ListApplications(options)
+	apps = append(apps, _apps...)
+
+	if err != nil {
+		return err
+	}
+
+	d.Set("applications", flattenApplications(apps))
+
+	h, err := hashstructure.Hash(*options, nil)
+	if err != nil {
+		return err
+	}
+	d.SetId(fmt.Sprintf("%d", h))
+
+	return nil
+}

--- a/gitlab/data_source_gitlab_curr_user.go
+++ b/gitlab/data_source_gitlab_curr_user.go
@@ -1,0 +1,184 @@
+package gitlab
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	gitlab "github.com/xanzy/go-gitlab"
+)
+
+// FIXME: there is exist a way to avoid resource definition duplication?
+// see dataSourceGitlabUser() function
+func dataSourceGitlabCurrentUser() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceGitlabUserCurrRead,
+		Schema: map[string]*schema.Schema{
+			"user_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+				Optional: true,
+				ConflictsWith: []string{
+					"username",
+					"email",
+				},
+			},
+			"username": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+				ConflictsWith: []string{
+					"user_id",
+					"email",
+				},
+			},
+			"email": {
+				Type:     schema.TypeString,
+				Computed: true,
+				Optional: true,
+				ConflictsWith: []string{
+					"user_id",
+					"username",
+				},
+			},
+			"name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"is_admin": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"can_create_group": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"can_create_project": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"projects_limit": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"created_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"state": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"external": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"extern_uid": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"organization": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"two_factor_enabled": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"user_provider": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"avatar_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"bio": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"location": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"skype": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"linkedin": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"twitter": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"website_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"theme_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"color_scheme_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
+			"last_sign_in_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"current_sign_in_at": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceGitlabUserCurrRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+
+	var user *gitlab.User
+	var err error
+
+	log.Printf("[INFO] Reading Gitlab user")
+
+	user, _, err = client.Users.CurrentUser()
+	if err != nil {
+		return nil
+	}
+	if user == nil {
+		return nil
+	}
+
+	d.Set("user_id", user.ID)
+	d.Set("username", user.Username)
+	d.Set("email", user.Email)
+	d.Set("name", user.Name)
+	d.Set("is_admin", user.IsAdmin)
+	d.Set("can_create_group", user.CanCreateGroup)
+	d.Set("can_create_project", user.CanCreateProject)
+	d.Set("projects_limit", user.ProjectsLimit)
+	d.Set("state", user.State)
+	d.Set("external", user.External)
+	d.Set("extern_uid", user.ExternUID)
+	d.Set("created_at", user.CreatedAt)
+	d.Set("organization", user.Organization)
+	d.Set("two_factor_enabled", user.TwoFactorEnabled)
+	d.Set("provider", user.Provider)
+	d.Set("avatar_url", user.AvatarURL)
+	d.Set("bio", user.Bio)
+	d.Set("location", user.Location)
+	d.Set("skype", user.Skype)
+	d.Set("linkedin", user.Linkedin)
+	d.Set("twitter", user.Twitter)
+	d.Set("website_url", user.WebsiteURL)
+	d.Set("theme_id", user.ThemeID)
+	d.Set("color_scheme_id", user.ColorSchemeID)
+
+	d.SetId(fmt.Sprintf("%d", user.ID))
+
+	return nil
+}

--- a/gitlab/provider.go
+++ b/gitlab/provider.go
@@ -54,14 +54,17 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"gitlab_group":    dataSourceGitlabGroup(),
-			"gitlab_project":  dataSourceGitlabProject(),
-			"gitlab_projects": dataSourceGitlabProjects(),
-			"gitlab_user":     dataSourceGitlabUser(),
-			"gitlab_users":    dataSourceGitlabUsers(),
+			"gitlab_group":        dataSourceGitlabGroup(),
+			"gitlab_project":      dataSourceGitlabProject(),
+			"gitlab_projects":     dataSourceGitlabProjects(),
+			"gitlab_user":         dataSourceGitlabUser(),
+			"gitlab_users":        dataSourceGitlabUsers(),
+			"gitlab_applications": dataSourceGitlabApplications(),
+			"gitlab_current_user": dataSourceGitlabCurrentUser(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
+			"gitlab_application":                resourceGitlabApplication(),
 			"gitlab_branch_protection":          resourceGitlabBranchProtection(),
 			"gitlab_tag_protection":             resourceGitlabTagProtection(),
 			"gitlab_group":                      resourceGitlabGroup(),

--- a/gitlab/resource_gitlab_application.go
+++ b/gitlab/resource_gitlab_application.go
@@ -1,0 +1,147 @@
+package gitlab
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	gitlab "github.com/xanzy/go-gitlab"
+)
+
+// https://docs.gitlab.com/ce/api/applications.html
+func resourceGitlabApplication() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGitlabApplicationCreate,
+		Read:   resourceGitlabApplicationRead,
+		Update: resourceGitlabApplicationUpdate,
+		Delete: resourceGitlabApplicationDelete,
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"scopes": {
+				Type:     schema.TypeSet,
+				ForceNew: true,
+				Required: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"redirect_uri": {
+				Type:     schema.TypeSet,
+				Required: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"confidential": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+				ForceNew: true,
+			},
+			"application_name": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"secret": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+			"application_id": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"callback_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func resourceGitlabApplicationCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	uris := strings.Join(*stringSetToStringSlice(d.Get("redirect_uri").(*schema.Set)), " ")
+	scopes := strings.Join(*stringSetToStringSlice(d.Get("scopes").(*schema.Set)), " ")
+
+	options := &gitlab.CreateApplicationOptions{
+		Name:        gitlab.String(d.Get("name").(string)),
+		RedirectURI: gitlab.String(uris),
+		Scopes:      gitlab.String(scopes),
+	}
+
+	log.Printf("[DEBUG] create application %s", *options.Name)
+
+	app, _, err := client.Applications.CreateApplication(options)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(strconv.Itoa(app.ID))
+	d.Set("application_id", app.ApplicationID)
+	d.Set("secret", app.Secret)
+
+	return resourceGitlabApplicationRead(d, meta)
+}
+
+func resourceGitlabApplicationRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+
+	appID := d.Get("application_id").(string)
+
+	log.Printf("[DEBUG] read gitlab application by id %s", appID)
+
+	page := 1
+	appsLen := 0
+	for page == 1 || appsLen != 0 {
+		apps, _, err := client.Applications.ListApplications(&gitlab.ListApplicationsOptions{Page: page})
+		if err != nil {
+			return err
+		}
+		for _, app := range apps {
+			if app.ApplicationID == appID {
+				d.Set("callback_url", app.CallbackURL)
+				d.Set("application_id", app.ApplicationID)
+				d.Set("application_name", app.ApplicationName)
+				d.Set("confidential", app.Confidential)
+				d.SetId(strconv.Itoa(app.ID))
+				return nil
+			}
+		}
+		appsLen = len(apps)
+		page = page + 1
+	}
+
+	log.Printf("[DEBUG] failed to read gitlab application %s", appID)
+	d.SetId("")
+	return nil
+}
+
+func resourceGitlabApplicationUpdate(d *schema.ResourceData, meta interface{}) error {
+	log.Printf("[DEBUG] update gitlab application %s", d.Id())
+
+	return resourceGitlabApplicationRead(d, meta)
+}
+
+func resourceGitlabApplicationDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+
+	log.Printf("[DEBUG] Delete gitlab application %s", d.Id())
+
+	var err error
+
+	appID, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return fmt.Errorf("failed to get clusterId: %v", err)
+	}
+
+	_, err = client.Applications.DeleteApplication(appID)
+	return err
+}


### PR DESCRIPTION
Fixes #321 

This PR adds the ability to create [an application](https://docs.gitlab.com/ee/api/applications.html), data source for [gitlab current user](https://docs.gitlab.com/ce/api/users.html#list-current-user-for-normal-users) to don't fail in case if gitlab isn't self-hosted, see below the terraform configuration for this case.

```hcl
data "gitlab_current_user" "me" {
}

// https://github.com/terraform-providers/terraform-provider-gitlab/issues/321
resource "gitlab_application" "grafana" {
  // create the application if user has admin role, 
  // otherwise Gitlab API rejects requests with 403 http status code
  count = data.gitlab_current_user.me.is_admin ? 1 : 0

  name = "grafana"
  redirect_uri = [
    "http://localhost:8080/auth/gitlab/callback",
    "http://localhost:8080/auth/gitlab/callback2"
  ]
  scopes = ["openid", "email", "profile"]
}

output "me" {
  value = data.gitlab_current_user.me
}

output "grafana_app_secret" {
  value = {
    app_id     = gitlab_application.grafana[0].application_id
    app_secret = gitlab_application.grafana[0].secret
  }
  sensitive = true
}

```

Gitlab API has limitations that don't allow to update the existing application, thus any property changes will force deleting and creating new one.
