### PR TITLE
Fix isRunningInEE helper

### DIFF
--- a/gitlab/helper_test.go
+++ b/gitlab/helper_test.go
@@ -1,12 +1,10 @@
 package gitlab
 
 import (
-	"errors"
 	"fmt"
-	"strings"
+	"os"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
-	"github.com/xanzy/go-gitlab"
 )
 
 // testAccCompareGitLabAttribute compares an attribute in two ResourceData's for

--- a/gitlab/helper_test.go
+++ b/gitlab/helper_test.go
@@ -43,16 +43,8 @@ func testAccIsSkippedAttribute(needle string, haystack []string) bool {
 // Returns true if the acceptance test is running Gitlab EE.
 // Meant to be used as SkipFunc to skip tests that work only on Gitlab CE.
 func isRunningInEE() (bool, error) {
-	if conn, ok := testAccProvider.Meta().(*gitlab.Client); ok {
-		version, _, err := conn.Version.GetVersion()
-		if err != nil {
-			return false, err
-		}
-		if strings.Contains(version.String(), "-ee") {
-			return true, nil
-		}
-	} else {
-		return false, errors.New("Provider not initialized, unable to get GitLab connection")
+	if v := os.Getenv("GITLAB_LICENSE_FILE"); len(v) > 0 {
+		return true, nil
 	}
 	return false, nil
 }

--- a/gitlab/provider_test.go
+++ b/gitlab/provider_test.go
@@ -11,10 +11,8 @@ import (
 var testAccProviders map[string]terraform.ResourceProvider
 var testAccProvider *schema.Provider
 
-const TestEnvVar = "TF_ACC"
-
 func init() {
-	if os.Getenv(TestEnvVar) != "" {
+	if os.Getenv("TF_ACC") != "" {
 		testAccProvider = Provider().(*schema.Provider)
 		if err := testAccProvider.Configure(&terraform.ResourceConfig{}); err != nil {
 			panic(err)

--- a/gitlab/provider_test.go
+++ b/gitlab/provider_test.go
@@ -12,12 +12,14 @@ var testAccProviders map[string]terraform.ResourceProvider
 var testAccProvider *schema.Provider
 
 func init() {
-	testAccProvider = Provider().(*schema.Provider)
-	if err := testAccProvider.Configure(&terraform.ResourceConfig{}); err != nil {
-		panic(err)
-	}
-	testAccProviders = map[string]terraform.ResourceProvider{
-		"gitlab": testAccProvider,
+	if os.Getenv(resource.TestEnvVar) != "" {
+		testAccProvider = Provider().(*schema.Provider)
+		if err := testAccProvider.Configure(&terraform.ResourceConfig{}); err != nil {
+			panic(err)
+		}
+		testAccProviders = map[string]terraform.ResourceProvider{
+			"gitlab": testAccProvider,
+		}
 	}
 }
 

--- a/gitlab/provider_test.go
+++ b/gitlab/provider_test.go
@@ -10,6 +10,7 @@ import (
 
 var testAccProviders map[string]terraform.ResourceProvider
 var testAccProvider *schema.Provider
+
 const TestEnvVar = "TF_ACC"
 
 func init() {

--- a/gitlab/provider_test.go
+++ b/gitlab/provider_test.go
@@ -13,6 +13,9 @@ var testAccProvider *schema.Provider
 
 func init() {
 	testAccProvider = Provider().(*schema.Provider)
+	if err := testAccProvider.Configure(&terraform.ResourceConfig{}); err != nil {
+		panic(err)
+	}
 	testAccProviders = map[string]terraform.ResourceProvider{
 		"gitlab": testAccProvider,
 	}

--- a/gitlab/provider_test.go
+++ b/gitlab/provider_test.go
@@ -12,7 +12,7 @@ var testAccProviders map[string]terraform.ResourceProvider
 var testAccProvider *schema.Provider
 
 func init() {
-	if os.Getenv(resource.TestEnvVar) != "" {
+	if os.Getenv(TestEnvVar) != "" {
 		testAccProvider = Provider().(*schema.Provider)
 		if err := testAccProvider.Configure(&terraform.ResourceConfig{}); err != nil {
 			panic(err)

--- a/gitlab/provider_test.go
+++ b/gitlab/provider_test.go
@@ -10,6 +10,7 @@ import (
 
 var testAccProviders map[string]terraform.ResourceProvider
 var testAccProvider *schema.Provider
+const TestEnvVar = "TF_ACC"
 
 func init() {
 	if os.Getenv(TestEnvVar) != "" {

--- a/gitlab/provider_test.go
+++ b/gitlab/provider_test.go
@@ -1,18 +1,18 @@
 package gitlab
 
 import (
-	"os"
-	"testing"
-
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"os"
+	"testing"
 )
 
 var testAccProviders map[string]terraform.ResourceProvider
 var testAccProvider *schema.Provider
 
 func init() {
-	if os.Getenv("TF_ACC") != "" {
+	if os.Getenv(resource.TestEnvVar) != "" {
 		testAccProvider = Provider().(*schema.Provider)
 		if err := testAccProvider.Configure(&terraform.ResourceConfig{}); err != nil {
 			panic(err)


### PR DESCRIPTION
Several tests are only meant to run in Gitlab CE, so we were using a helper function `isRunningInEE` to detect the provider version and skip functions that only run in core and not in EE. We found that when running tests that use the `isRunningInEE` function, like `gitlab/resource_gitlab_service_github_test.go` and `gitlab/resource_gitlab_project_push_rules_test.go` , the test would fail because "Provider not initialized, unable to get GitLab connection". This is because when running single one-off tests, the provider is indeed not initialized, so `isRunningInEE` would not be able to find the provider nor the version in its metadata. Running single tests that relied on this function would fail, but running all the tests with `make testacc` would pass because the provider is initialized when running a whole test suite and not single tests. 

So we change the `isRunningInEE` function to look for the Gitlab license file instead, which is generated by the acceptance-ee test in `.github/workflows/acceptance-tests.yml` and is not generated for CE tests. This should pass local tests that use the function, no matter what order the tests are run in. 