### PR TITLE
Documentation: Add group_ldap_link to index

### DIFF
--- a/website/gitlab.erb
+++ b/website/gitlab.erb
@@ -58,6 +58,9 @@
           <li<%= sidebar_current("docs-gitlab-resource-label") %>>
             <a href="/docs/providers/gitlab/r/label.html">gitlab_label</a>
           </li>
+          <li<%= sidebar_current("docs-gitlab-resource-group_ldap_link") %>>
+            <a href="/docs/providers/gitlab/r/group_ldap_link.html">group_ldap_link</a>
+          </li>
           <li<%= sidebar_current("docs-gitlab-resource-group-label") %>>
             <a href="/docs/providers/gitlab/r/group_label.html">gitlab_group_label</a>
           </li>


### PR DESCRIPTION
It was missing from the index in the left side, and I almost started implementing it myself before finding it in the source code.