### PR TITLE
Fix failing test TestAccGitlabProjectPushRules_import

### DIFF
--- a/gitlab/resource_gitlab_project_push_rules.go
+++ b/gitlab/resource_gitlab_project_push_rules.go
@@ -3,6 +3,7 @@ package gitlab
 import (
 	"fmt"
 	"log"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	gitlab "github.com/xanzy/go-gitlab"
@@ -152,7 +153,7 @@ func resourceGitlabProjectPushRulesImporter(d *schema.ResourceData, meta interfa
 	d.SetId(fmt.Sprintf("%d", pushRules.ID))
 
 	// Since project is used as a primary key in the Read function, we set that too.
-	d.Set("project", project)
+	d.Set("project", strconv.Itoa(pushRules.ProjectID))
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/gitlab/resource_gitlab_project_push_rules_test.go
+++ b/gitlab/resource_gitlab_project_push_rules_test.go
@@ -93,7 +93,7 @@ func TestAccGitlabProjectPushRules_import(t *testing.T) {
 			{
 				SkipFunc:          isRunningInCE,
 				ResourceName:      "gitlab_project_push_rules.foo",
-				ImportStateId:     fmt.Sprintf("foo-%d", rInt),
+				ImportStateId:     fmt.Sprintf("root/foo-%d", rInt),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},


### PR DESCRIPTION
Closes #399 

Making this PR from a branch so that the EE acceptance tests run. This fixes the broken EE acceptance tests. I think the breakage got introduced originally while the EE license was expired and could not be tested.