### PR TITLE
Fix project_id not being set in gitlab_project_level_mr_approvals

### DIFF
--- a/gitlab/resource_gitlab_project_level_mr_approvals.go
+++ b/gitlab/resource_gitlab_project_level_mr_approvals.go
@@ -69,8 +69,12 @@ func resourceGitlabProjectLevelMRApprovalsCreate(d *schema.ResourceData, meta in
 func resourceGitlabProjectLevelMRApprovalsRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gitlab.Client)
 
-	projectId := d.Id()
-	log.Printf("[DEBUG] Reading gitlab approval configuration for project %s", projectId)
+	projectId, err := strconv.Atoi(d.Id())
+	if err != nil {
+		return fmt.Errorf("project ID must be an integer (was %q): %w", d.Id(), err)
+	}
+
+	log.Printf("[DEBUG] Reading gitlab approval configuration for project %q", projectId)
 
 	approvalConfig, _, err := client.Projects.GetApprovalConfiguration(projectId)
 	if err != nil {


### PR DESCRIPTION
EE acceptance tests are still failing in master. This should be the last fix needed. This is to fix a bug in #356 where the `project_id` attribute was not set in `gitlab_project_level_mr_approvals` during read, because it was the wrong type.

As with #401 this does not need an entry in the Changelog since it is for a new resource.