### PR TITLE
Allow disable/enable packages repository

### DIFF
--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -70,3 +70,5 @@ The following attributes are exported:
 * `archived` - Whether the project is in read-only mode (archived).
 
 * `remove_source_branch_after_merge` - Enable `Delete source branch` option by default for all new merge requests
+
+* `packages_enabled` - Enable packages repository for the project.

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -78,6 +78,8 @@ The following arguments are supported:
 
 * `initialize_with_readme` - (Optional) Create master branch with first commit containing a README.md file.
 
+* `packages_enabled` - (Optional) Enable packages repository for the project.
+
 ## Attributes Reference
 
 The following additional attributes are exported:

--- a/gitlab/data_source_gitlab_projects.go
+++ b/gitlab/data_source_gitlab_projects.go
@@ -156,6 +156,7 @@ func flattenProjects(projects []*gitlab.Project) (values []map[string]interface{
 				"_links":                              flattenProjectLinks(project.Links),
 				"ci_config_path":                      project.CIConfigPath,
 				"custom_attributes":                   project.CustomAttributes,
+				"packages_enabled":                    project.PackagesEnabled,
 			}
 			values = append(values, v)
 		}
@@ -647,6 +648,10 @@ func dataSourceGitlabProjects() *schema.Resource {
 							Elem: &schema.Schema{
 								Type: schema.TypeMap,
 							},
+						},
+						"packages_enabled": {
+							Type:     schema.TypeBool,
+							Computed: true,
 						},
 					},
 				},

--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -186,6 +186,11 @@ var resourceGitLabProjectSchema = map[string]*schema.Schema{
 		Type:     schema.TypeBool,
 		Optional: true,
 	},
+	"packages_enabled": {
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  true,
+	},
 }
 
 func resourceGitlabProject() *schema.Resource {
@@ -230,6 +235,7 @@ func resourceGitlabProjectSetToState(d *schema.ResourceData, project *gitlab.Pro
 	d.Set("tags", project.TagList)
 	d.Set("archived", project.Archived)
 	d.Set("remove_source_branch_after_merge", project.RemoveSourceBranchAfterMerge)
+	d.Set("packages_enabled", project.PackagesEnabled)
 }
 
 func resourceGitlabProjectCreate(d *schema.ResourceData, meta interface{}) error {
@@ -252,6 +258,7 @@ func resourceGitlabProjectCreate(d *schema.ResourceData, meta interface{}) error
 		OnlyAllowMergeIfAllDiscussionsAreResolved: gitlab.Bool(d.Get("only_allow_merge_if_all_discussions_are_resolved").(bool)),
 		SharedRunnersEnabled:                      gitlab.Bool(d.Get("shared_runners_enabled").(bool)),
 		RemoveSourceBranchAfterMerge:              gitlab.Bool(d.Get("remove_source_branch_after_merge").(bool)),
+		PackagesEnabled:                           gitlab.Bool(d.Get("packages_enabled").(bool)),
 	}
 
 	if v, ok := d.GetOk("path"); ok {
@@ -427,6 +434,10 @@ func resourceGitlabProjectUpdate(d *schema.ResourceData, meta interface{}) error
 
 	if d.HasChange("remove_source_branch_after_merge") {
 		options.RemoveSourceBranchAfterMerge = gitlab.Bool(d.Get("remove_source_branch_after_merge").(bool))
+	}
+
+	if d.HasChange("packages_enabled") {
+		options.PackagesEnabled = gitlab.Bool(d.Get("packages_enabled").(bool))
 	}
 
 	if *options != (gitlab.EditProjectOptions{}) {

--- a/gitlab/resource_gitlab_project_test.go
+++ b/gitlab/resource_gitlab_project_test.go
@@ -40,7 +40,8 @@ func TestAccGitlabProject_basic(t *testing.T) {
 		MergeMethod:                      gitlab.FastForwardMerge,
 		OnlyAllowMergeIfPipelineSucceeds: true,
 		OnlyAllowMergeIfAllDiscussionsAreResolved: true,
-		Archived: false, // needless, but let's make this explicit
+		Archived:        false, // needless, but let's make this explicit
+		PackagesEnabled: true,
 	}
 
 	defaultsMasterBranch = defaults
@@ -80,7 +81,8 @@ func TestAccGitlabProject_basic(t *testing.T) {
 						MergeMethod:                      gitlab.FastForwardMerge,
 						OnlyAllowMergeIfPipelineSucceeds: true,
 						OnlyAllowMergeIfAllDiscussionsAreResolved: true,
-						Archived: true,
+						Archived:        true,
+						PackagesEnabled: false,
 					}, &received),
 				),
 			},
@@ -151,6 +153,7 @@ func TestAccGitlabProject_willError(t *testing.T) {
 		MergeMethod:                      gitlab.FastForwardMerge,
 		OnlyAllowMergeIfPipelineSucceeds: true,
 		OnlyAllowMergeIfAllDiscussionsAreResolved: true,
+		PackagesEnabled: true,
 	}
 	willError := defaults
 	willError.TagList = []string{"notatag"}
@@ -249,6 +252,7 @@ func TestAccGitlabProject_transfer(t *testing.T) {
 		MergeMethod:                      gitlab.NoFastForwardMerge,
 		OnlyAllowMergeIfPipelineSucceeds: false,
 		OnlyAllowMergeIfAllDiscussionsAreResolved: false,
+		PackagesEnabled: true,
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -534,8 +538,9 @@ resource "gitlab_project" "foo" {
   snippets_enabled = false
   container_registry_enabled = false
   lfs_enabled = false
-	shared_runners_enabled = false
-	archived = true
+  shared_runners_enabled = false
+  archived = true
+  packages_enabled = false
 }
 	`, rInt, rInt)
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gitlabhq/terraform-provider-gitlab
 require (
 	github.com/hashicorp/terraform-plugin-sdk v1.13.1
 	github.com/mitchellh/hashstructure v1.0.0
-	github.com/xanzy/go-gitlab v0.34.1
+	github.com/xanzy/go-gitlab v0.38.1
 )
 
 go 1.14

--- a/go.sum
+++ b/go.sum
@@ -192,8 +192,8 @@ github.com/ulikunitz/xz v0.5.5/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4A
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.1+incompatible h1:RMF1enSPeKTlXrXdOcqjFUElywVZjjC6pqse21bKbEU=
 github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
-github.com/xanzy/go-gitlab v0.34.1 h1:Dtqla2gWIQIevfZVS6FY4qjgrKf+5LYLzW6XBNstGSw=
-github.com/xanzy/go-gitlab v0.34.1/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
+github.com/xanzy/go-gitlab v0.38.1 h1:st5/Ag4h8CqVfp3LpOWW0Jd4jYHTGETwu0KksYDPnYE=
+github.com/xanzy/go-gitlab v0.38.1/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
 github.com/zclconf/go-cty v1.0.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.2.1 h1:vGMsygfmeCl4Xb6OA5U5XVAaQZ69FvoG7X2jUtQujb8=

--- a/vendor/github.com/xanzy/go-gitlab/client_options.go
+++ b/vendor/github.com/xanzy/go-gitlab/client_options.go
@@ -24,6 +24,16 @@ func WithCustomBackoff(backoff retryablehttp.Backoff) ClientOptionFunc {
 	}
 }
 
+// WithCustomLimiter injects a custom rate limiter to the client.
+func WithCustomLimiter(limiter RateLimiter) ClientOptionFunc {
+	return func(c *Client) error {
+		c.configureLimiterOnce.Do(func() {
+			c.limiter = limiter
+		})
+		return nil
+	}
+}
+
 // WithCustomRetry can be used to configure a custom retry policy.
 func WithCustomRetry(checkRetry retryablehttp.CheckRetry) ClientOptionFunc {
 	return func(c *Client) error {

--- a/vendor/github.com/xanzy/go-gitlab/commits.go
+++ b/vendor/github.com/xanzy/go-gitlab/commits.go
@@ -446,6 +446,8 @@ type SetCommitStatusOptions struct {
 	Context     *string         `url:"context,omitempty" json:"context,omitempty"`
 	TargetURL   *string         `url:"target_url,omitempty" json:"target_url,omitempty"`
 	Description *string         `url:"description,omitempty" json:"description,omitempty"`
+	Coverage    *float64        `url:"coverage,omitempty" json:"coverage,omitempty"`
+	PipelineID  *int            `url:"pipeline_id,omitempty" json:"pipeline_id,omitempty"`
 }
 
 // SetCommitStatus sets the status of a commit in a project.

--- a/vendor/github.com/xanzy/go-gitlab/epics.go
+++ b/vendor/github.com/xanzy/go-gitlab/epics.go
@@ -30,16 +30,12 @@ type Epic struct {
 	ID                      int         `json:"id"`
 	IID                     int         `json:"iid"`
 	GroupID                 int         `json:"group_id"`
-	Author                  *EpicAuthor `json:"author"`
+	ParentID                int         `json:"parent_id"`
+	Title                   string      `json:"title"`
 	Description             string      `json:"description"`
 	State                   string      `json:"state"`
-	Upvotes                 int         `json:"upvotes"`
-	Downvotes               int         `json:"downvotes"`
-	Labels                  []string    `json:"labels"`
-	Title                   string      `json:"title"`
-	UpdatedAt               *time.Time  `json:"updated_at"`
-	CreatedAt               *time.Time  `json:"created_at"`
-	UserNotesCount          int         `json:"user_notes_count"`
+	WebURL                  string      `json:"web_url"`
+	Author                  *EpicAuthor `json:"author"`
 	StartDate               *ISOTime    `json:"start_date"`
 	StartDateIsFixed        bool        `json:"start_date_is_fixed"`
 	StartDateFixed          *ISOTime    `json:"start_date_fixed"`
@@ -48,6 +44,13 @@ type Epic struct {
 	DueDateIsFixed          bool        `json:"due_date_is_fixed"`
 	DueDateFixed            *ISOTime    `json:"due_date_fixed"`
 	DueDateFromMilestones   *ISOTime    `json:"due_date_from_milestones"`
+	CreatedAt               *time.Time  `json:"created_at"`
+	UpdatedAt               *time.Time  `json:"updated_at"`
+	Labels                  []string    `json:"labels"`
+	Upvotes                 int         `json:"upvotes"`
+	Downvotes               int         `json:"downvotes"`
+	UserNotesCount          int         `json:"user_notes_count"`
+	URL                     string      `json:"url"`
 }
 
 func (e Epic) String() string {
@@ -59,12 +62,20 @@ func (e Epic) String() string {
 // GitLab API docs: https://docs.gitlab.com/ee/api/epics.html#list-epics-for-a-group
 type ListGroupEpicsOptions struct {
 	ListOptions
-	State    *string `url:"state,omitempty" json:"state,omitempty"`
-	Labels   Labels  `url:"labels,comma,omitempty" json:"labels,omitempty"`
-	AuthorID *int    `url:"author_id,omitempty" json:"author_id,omitempty"`
-	OrderBy  *string `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort     *string `url:"sort,omitempty" json:"sort,omitempty"`
-	Search   *string `url:"search,omitempty" json:"search,omitempty"`
+	AuthorID                *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
+	Labels                  Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	WithLabelDetails        *bool      `url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
+	OrderBy                 *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort                    *string    `url:"sort,omitempty" json:"sort,omitempty"`
+	Search                  *string    `url:"search,omitempty" json:"search,omitempty"`
+	State                   *string    `url:"state,omitempty" json:"state,omitempty"`
+	CreatedAfter            *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
+	CreatedBefore           *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
+	UpdatedAfter            *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
+	UpdatedBefore           *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
+	IncludeAncestorGroups   *bool      `url:"include_ancestor_groups,omitempty" json:"include_ancestor_groups,omitempty"`
+	IncludeDescendantGroups *bool      `url:"include_descendant_groups,omitempty" json:"include_descendant_groups,omitempty"`
+	MyReactionEmoji         *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
 }
 
 // ListGroupEpics gets a list of group epics. This function accepts pagination
@@ -109,6 +120,30 @@ func (s *EpicsService) GetEpic(gid interface{}, epic int, options ...RequestOpti
 
 	e := new(Epic)
 	resp, err := s.client.Do(req, e)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return e, resp, err
+}
+
+// GetEpicLinks gets all child epics of an epic.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/epic_links.html
+func (s *EpicsService) GetEpicLinks(gid interface{}, epic int, options ...RequestOptionFunc) ([]*Epic, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/epics/%d/epics", pathEscape(group), epic)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var e []*Epic
+	resp, err := s.client.Do(req, &e)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/vendor/github.com/xanzy/go-gitlab/gitlab.go
+++ b/vendor/github.com/xanzy/go-gitlab/gitlab.go
@@ -80,7 +80,7 @@ type Client struct {
 	configureLimiterOnce sync.Once
 
 	// Limiter is used to limit API calls and prevent 429 responses.
-	limiter *rate.Limiter
+	limiter RateLimiter
 
 	// Token type used to make authenticated API calls.
 	authType authType
@@ -127,6 +127,7 @@ type Client struct {
 	GroupVariables        *GroupVariablesService
 	Groups                *GroupsService
 	InstanceCluster       *InstanceClustersService
+	InstanceVariables     *InstanceVariablesService
 	IssueLinks            *IssueLinksService
 	Issues                *IssuesService
 	IssuesStatistics      *IssuesStatisticsService
@@ -183,6 +184,11 @@ type ListOptions struct {
 
 	// For paginated result sets, the number of results to include per page.
 	PerPage int `url:"per_page,omitempty" json:"per_page,omitempty"`
+}
+
+// RateLimiter describes the interface that all (custom) rate limiters must implement.
+type RateLimiter interface {
+	Wait(context.Context) error
 }
 
 // NewClient returns a new GitLab API client. To use API methods which require
@@ -626,15 +632,16 @@ func (c *Client) Do(req *retryablehttp.Request, v interface{}) (*Response, error
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusUnauthorized && c.authType == basicAuth {
+		resp.Body.Close()
 		// The token most likely expired, so we need to request a new one and try again.
 		if _, err := c.requestOAuthToken(req.Context(), basicAuthToken); err != nil {
 			return nil, err
 		}
 		return c.Do(req, v)
 	}
+	defer resp.Body.Close()
 
 	response := newResponse(resp)
 
@@ -667,8 +674,8 @@ func (c *Client) requestOAuthToken(ctx context.Context, token string) (string, e
 
 	config := &oauth2.Config{
 		Endpoint: oauth2.Endpoint{
-			AuthURL:  fmt.Sprintf("%s://%s/oauth/authorize", c.BaseURL().Scheme, c.BaseURL().Host),
-			TokenURL: fmt.Sprintf("%s://%s/oauth/token", c.BaseURL().Scheme, c.BaseURL().Host),
+			AuthURL:  strings.TrimSuffix(c.baseURL.String(), apiVersionPath) + "oauth/authorize",
+			TokenURL: strings.TrimSuffix(c.baseURL.String(), apiVersionPath) + "oauth/token",
 		},
 	}
 

--- a/vendor/github.com/xanzy/go-gitlab/group_boards.go
+++ b/vendor/github.com/xanzy/go-gitlab/group_boards.go
@@ -144,7 +144,7 @@ type UpdateGroupIssueBoardOptions struct {
 	Name        *string `url:"name,omitempty" json:"name,omitempty"`
 	AssigneeID  *int    `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
 	MilestoneID *int    `url:"milestone_id,omitempty" json:"milestone_id,omitempty"`
-	Labels      *Labels `url:"labels,omitempty" json:"labels,omitempty"`
+	Labels      Labels  `url:"labels,omitempty" json:"labels,omitempty"`
 	Weight      *int    `url:"weight,omitempty" json:"weight,omitempty"`
 }
 

--- a/vendor/github.com/xanzy/go-gitlab/group_milestones.go
+++ b/vendor/github.com/xanzy/go-gitlab/group_milestones.go
@@ -43,6 +43,7 @@ type GroupMilestone struct {
 	State       string     `json:"state"`
 	UpdatedAt   *time.Time `json:"updated_at"`
 	CreatedAt   *time.Time `json:"created_at"`
+	Expired     *bool      `json:"expired"`
 }
 
 func (m GroupMilestone) String() string {
@@ -56,9 +57,11 @@ func (m GroupMilestone) String() string {
 // https://docs.gitlab.com/ce/api/group_milestones.html#list-group-milestones
 type ListGroupMilestonesOptions struct {
 	ListOptions
-	IIDs   []int  `url:"iids,omitempty" json:"iids,omitempty"`
-	State  string `url:"state,omitempty" json:"state,omitempty"`
-	Search string `url:"search,omitempty" json:"search,omitempty"`
+	IIDs                    []int   `url:"iids,omitempty" json:"iids,omitempty"`
+	State                   *string `url:"state,omitempty" json:"state,omitempty"`
+	Title                   *string `url:"title,omitempty" json:"title,omitempty"`
+	Search                  *string `url:"search,omitempty" json:"search,omitempty"`
+	IncludeParentMilestones *bool   `url:"include_parent_milestones,omitempty" json:"include_parent_milestones,omitempty"`
 }
 
 // ListGroupMilestones returns a list of group milestones.

--- a/vendor/github.com/xanzy/go-gitlab/groups.go
+++ b/vendor/github.com/xanzy/go-gitlab/groups.go
@@ -398,7 +398,7 @@ func (s *GroupsService) ListGroupLDAPLinks(gid interface{}, options ...RequestOp
 type AddGroupLDAPLinkOptions struct {
 	CN          *string `url:"cn,omitempty" json:"cn,omitempty"`
 	GroupAccess *int    `url:"group_access,omitempty" json:"group_access,omitempty"`
-	Provider    *string `url:"provider,omitempty" json:"provider,ommitempty"`
+	Provider    *string `url:"provider,omitempty" json:"provider,omitempty"`
 }
 
 // AddGroupLDAPLink creates a new group LDAP link. Available only for users who
@@ -463,6 +463,158 @@ func (s *GroupsService) DeleteGroupLDAPLinkForProvider(gid interface{}, provider
 		pathEscape(provider),
 		pathEscape(cn),
 	)
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
+// GroupPushRules represents a group push rule.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/groups.html#get-group-push-rules
+type GroupPushRules struct {
+	ID                         int        `json:"id"`
+	CreatedAt                  *time.Time `json:"created_at"`
+	CommitMessageRegex         string     `json:"commit_message_regex"`
+	CommitMessageNegativeRegex string     `json:"commit_message_negative_regex"`
+	BranchNameRegex            string     `json:"branch_name_regex"`
+	DenyDeleteTag              bool       `json:"deny_delete_tag"`
+	MemberCheck                bool       `json:"member_check"`
+	PreventSecrets             bool       `json:"prevent_secrets"`
+	AuthorEmailRegex           string     `json:"author_email_regex"`
+	FileNameRegex              string     `json:"file_name_regex"`
+	MaxFileSize                int        `json:"max_file_size"`
+	CommitCommitterCheck       bool       `json:"commit_committer_check"`
+	RejectUnsignedCommits      bool       `json:"reject_unsigned_commits"`
+}
+
+// GetGroupPushRules gets the push rules of a group.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/groups.html#get-group-push-rules
+func (s *GroupsService) GetGroupPushRules(gid interface{}, options ...RequestOptionFunc) (*GroupPushRules, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/push_rule", pathEscape(group))
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	gpr := new(GroupPushRules)
+	resp, err := s.client.Do(req, gpr)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return gpr, resp, err
+}
+
+// AddGroupPushRuleOptions represents the available AddGroupPushRule()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/groups.html#add-group-push-rule
+type AddGroupPushRuleOptions struct {
+	DenyDeleteTag              *bool   `url:"deny_delete_tag,omitempty" json:"deny_delete_tag,omitempty"`
+	MemberCheck                *bool   `url:"member_check,omitempty" json:"member_check,omitempty"`
+	PreventSecrets             *bool   `url:"prevent_secrets,omitempty" json:"prevent_secrets,omitempty"`
+	CommitMessageRegex         *string `url:"commit_message_regex,omitempty" json:"commit_message_regex,omitempty"`
+	CommitMessageNegativeRegex *string `url:"commit_message_negative_regex,omitempty" json:"commit_message_negative_regex,omitempty"`
+	BranchNameRegex            *string `url:"branch_name_regex,omitempty" json:"branch_name_regex,omitempty"`
+	AuthorEmailRegex           *string `url:"author_email_regex,omitempty" json:"author_email_regex,omitempty"`
+	FileNameRegex              *string `url:"file_name_regex,omitempty" json:"file_name_regex,omitempty"`
+	MaxFileSize                *int    `url:"max_file_size,omitempty" json:"max_file_size,omitempty"`
+	CommitCommitterCheck       *bool   `url:"commit_committer_check,omitempty" json:"commit_committer_check,omitempty"`
+	RejectUnsignedCommits      *bool   `url:"reject_unsigned_commits,omitempty" json:"reject_unsigned_commits,omitempty"`
+}
+
+// AddGroupPushRule adds push rules to the specified group.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/groups.html#add-group-push-rule
+func (s *GroupsService) AddGroupPushRule(gid interface{}, opt *AddGroupPushRuleOptions, options ...RequestOptionFunc) (*GroupPushRules, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/push_rule", pathEscape(group))
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	gpr := new(GroupPushRules)
+	resp, err := s.client.Do(req, gpr)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return gpr, resp, err
+}
+
+// EditGroupPushRuleOptions represents the available EditGroupPushRule()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/groups.html#edit-group-push-rule
+type EditGroupPushRuleOptions struct {
+	DenyDeleteTag              *bool   `url:"deny_delete_tag,omitempty" json:"deny_delete_tag,omitempty"`
+	MemberCheck                *bool   `url:"member_check,omitempty" json:"member_check,omitempty"`
+	PreventSecrets             *bool   `url:"prevent_secrets,omitempty" json:"prevent_secrets,omitempty"`
+	CommitMessageRegex         *string `url:"commit_message_regex,omitempty" json:"commit_message_regex,omitempty"`
+	CommitMessageNegativeRegex *string `url:"commit_message_negative_regex,omitempty" json:"commit_message_negative_regex,omitempty"`
+	BranchNameRegex            *string `url:"branch_name_regex,omitempty" json:"branch_name_regex,omitempty"`
+	AuthorEmailRegex           *string `url:"author_email_regex,omitempty" json:"author_email_regex,omitempty"`
+	FileNameRegex              *string `url:"file_name_regex,omitempty" json:"file_name_regex,omitempty"`
+	MaxFileSize                *int    `url:"max_file_size,omitempty" json:"max_file_size,omitempty"`
+	CommitCommitterCheck       *bool   `url:"commit_committer_check,omitempty" json:"commit_committer_check,omitempty"`
+	RejectUnsignedCommits      *bool   `url:"reject_unsigned_commits,omitempty" json:"reject_unsigned_commits,omitempty"`
+}
+
+// EditGroupPushRule edits a push rule for a specified group.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/groups.html#edit-group-push-rule
+func (s *GroupsService) EditGroupPushRule(gid interface{}, opt *EditGroupPushRuleOptions, options ...RequestOptionFunc) (*GroupPushRules, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/push_rule", pathEscape(group))
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	gpr := new(GroupPushRules)
+	resp, err := s.client.Do(req, gpr)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return gpr, resp, err
+}
+
+// DeleteGroupPushRule deletes the push rules of a group.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/groups.html#delete-group-push-rule
+func (s *GroupsService) DeleteGroupPushRule(gid interface{}, options ...RequestOptionFunc) (*Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("groups/%s/push_rule", pathEscape(group))
 
 	req, err := s.client.NewRequest("DELETE", u, nil, options)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/instance_clusters.go
+++ b/vendor/github.com/xanzy/go-gitlab/instance_clusters.go
@@ -37,6 +37,7 @@ type InstanceCluster struct {
 	ID                 int                 `json:"id"`
 	Name               string              `json:"name"`
 	Domain             string              `json:"domain"`
+	Managed            bool                `json:"managed"`
 	CreatedAt          *time.Time          `json:"created_at"`
 	ProviderType       string              `json:"provider_type"`
 	PlatformType       string              `json:"platform_type"`
@@ -56,7 +57,7 @@ func (v InstanceCluster) String() string {
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/instance_clusters.html#list-instance-clusters
 func (s *InstanceClustersService) ListClusters(options ...RequestOptionFunc) ([]*InstanceCluster, *Response, error) {
-	u := fmt.Sprintf("admin/clusters")
+	u := "admin/clusters"
 
 	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
@@ -98,7 +99,7 @@ func (s *InstanceClustersService) GetCluster(cluster int, options ...RequestOpti
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/instance_clusters.html#add-existing-instance-cluster
 func (s *InstanceClustersService) AddCluster(opt *AddClusterOptions, options ...RequestOptionFunc) (*InstanceCluster, *Response, error) {
-	u := fmt.Sprintf("admin/clusters/add")
+	u := "admin/clusters/add"
 
 	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/instance_variables.go
+++ b/vendor/github.com/xanzy/go-gitlab/instance_variables.go
@@ -1,0 +1,179 @@
+//
+// Copyright 2018, Patrick Webster
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// InstanceVariablesService handles communication with the
+// instance level CI variables related methods of the GitLab API.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/instance_level_ci_variables.html
+type InstanceVariablesService struct {
+	client *Client
+}
+
+// InstanceVariable represents a GitLab instance level CI Variable.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/instance_level_ci_variables.html
+type InstanceVariable struct {
+	Key          string            `json:"key"`
+	Value        string            `json:"value"`
+	VariableType VariableTypeValue `json:"variable_type"`
+	Protected    bool              `json:"protected"`
+	Masked       bool              `json:"masked"`
+}
+
+func (v InstanceVariable) String() string {
+	return Stringify(v)
+}
+
+// ListInstanceVariablesOptions represents the available options for listing variables
+// for an instance.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/instance_level_ci_variables.html#list-all-instance-variables
+type ListInstanceVariablesOptions ListOptions
+
+// ListVariables gets a list of all variables for an instance.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/instance_level_ci_variables.html#list-all-instance-variables
+func (s *InstanceVariablesService) ListVariables(opt *ListInstanceVariablesOptions, options ...RequestOptionFunc) ([]*InstanceVariable, *Response, error) {
+	u := "admin/ci/variables"
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var vs []*InstanceVariable
+	resp, err := s.client.Do(req, &vs)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return vs, resp, err
+}
+
+// GetVariable gets a variable.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/instance_level_ci_variables.html#show-instance-variable-details
+func (s *InstanceVariablesService) GetVariable(key string, options ...RequestOptionFunc) (*InstanceVariable, *Response, error) {
+	u := fmt.Sprintf("admin/ci/variables/%s", url.PathEscape(key))
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	v := new(InstanceVariable)
+	resp, err := s.client.Do(req, v)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return v, resp, err
+}
+
+// CreateInstanceVariableOptions represents the available CreateVariable()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/instance_level_ci_variables.html#create-instance-variable
+type CreateInstanceVariableOptions struct {
+	Key          *string            `url:"key,omitempty" json:"key,omitempty"`
+	Value        *string            `url:"value,omitempty" json:"value,omitempty"`
+	VariableType *VariableTypeValue `url:"variable_type,omitempty" json:"variable_type,omitempty"`
+	Protected    *bool              `url:"protected,omitempty" json:"protected,omitempty"`
+	Masked       *bool              `url:"masked,omitempty" json:"masked,omitempty"`
+}
+
+// CreateVariable creates a new instance level CI variable.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/instance_level_ci_variables.html#create-instance-variable
+func (s *InstanceVariablesService) CreateVariable(opt *CreateInstanceVariableOptions, options ...RequestOptionFunc) (*InstanceVariable, *Response, error) {
+	u := "admin/ci/variables"
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	v := new(InstanceVariable)
+	resp, err := s.client.Do(req, v)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return v, resp, err
+}
+
+// UpdateInstanceVariableOptions represents the available UpdateVariable()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/instance_level_ci_variables.html#update-instance-variable
+type UpdateInstanceVariableOptions struct {
+	Value        *string            `url:"value,omitempty" json:"value,omitempty"`
+	VariableType *VariableTypeValue `url:"variable_type,omitempty" json:"variable_type,omitempty"`
+	Protected    *bool              `url:"protected,omitempty" json:"protected,omitempty"`
+	Masked       *bool              `url:"masked,omitempty" json:"masked,omitempty"`
+}
+
+// UpdateVariable updates the position of an existing
+// instance level CI variable.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/instance_level_ci_variables.html#update-instance-variable
+func (s *InstanceVariablesService) UpdateVariable(key string, opt *UpdateInstanceVariableOptions, options ...RequestOptionFunc) (*InstanceVariable, *Response, error) {
+	u := fmt.Sprintf("admin/ci/variables/%s", url.PathEscape(key))
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	v := new(InstanceVariable)
+	resp, err := s.client.Do(req, v)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return v, resp, err
+}
+
+// RemoveVariable removes an instance level CI variable.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/instance_level_ci_variables.html#remove-instance-variable
+func (s *InstanceVariablesService) RemoveVariable(key string, options ...RequestOptionFunc) (*Response, error) {
+	u := fmt.Sprintf("admin/ci/variables/%s", url.PathEscape(key))
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/vendor/github.com/xanzy/go-gitlab/issues.go
+++ b/vendor/github.com/xanzy/go-gitlab/issues.go
@@ -17,6 +17,7 @@
 package gitlab
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -113,6 +114,7 @@ type Issue struct {
 	IssueLinkID          int              `json:"issue_link_id"`
 	MergeRequestCount    int              `json:"merge_requests_count"`
 	EpicIssueID          int              `json:"epic_issue_id"`
+	Epic                 *Epic            `json:"epic"`
 	TaskCompletionStatus struct {
 		Count          int `json:"count"`
 		CompletedCount int `json:"completed_count"`
@@ -162,7 +164,19 @@ type Labels []string
 
 // MarshalJSON implements the json.Marshaler interface.
 func (l *Labels) MarshalJSON() ([]byte, error) {
+	if *l == nil {
+		return []byte(`null`), nil
+	}
 	return json.Marshal(strings.Join(*l, ","))
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (l *Labels) UnmarshalJSON(data []byte) error {
+	type alias Labels
+	if !bytes.HasPrefix(data, []byte("[")) {
+		data = []byte(fmt.Sprintf("[%s]", string(data)))
+	}
+	return json.Unmarshal(data, (*alias)(l))
 }
 
 // EncodeValues implements the query.EncodeValues interface
@@ -186,23 +200,29 @@ type LabelDetails struct {
 // GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#list-issues
 type ListIssuesOptions struct {
 	ListOptions
-	State            *string    `url:"state,omitempty" json:"state,omitempty"`
-	Labels           Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
-	WithLabelDetails *bool      `url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
-	Milestone        *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
-	Scope            *string    `url:"scope,omitempty" json:"scope,omitempty"`
-	AuthorID         *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
-	AssigneeID       *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
-	MyReactionEmoji  *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
-	IIDs             []int      `url:"iids[],omitempty" json:"iids,omitempty"`
-	OrderBy          *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort             *string    `url:"sort,omitempty" json:"sort,omitempty"`
-	Search           *string    `url:"search,omitempty" json:"search,omitempty"`
-	CreatedAfter     *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
-	CreatedBefore    *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
-	UpdatedAfter     *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
-	UpdatedBefore    *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
-	Confidential     *bool      `url:"confidential,omitempty" json:"confidential,omitempty"`
+	State              *string    `url:"state,omitempty" json:"state,omitempty"`
+	Labels             Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	NotLabels          Labels     `url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
+	WithLabelDetails   *bool      `url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
+	Milestone          *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
+	NotMilestone       *string    `url:"not[milestone],omitempty" json:"not[milestone],omitempty"`
+	Scope              *string    `url:"scope,omitempty" json:"scope,omitempty"`
+	AuthorID           *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
+	NotAuthorID        []int      `url:"not[author_id],omitempty" json:"not[author_id],omitempty"`
+	AssigneeID         *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
+	NotAssigneeID      []int      `url:"not[assignee_id],omitempty" json:"not[assignee_id],omitempty"`
+	AssigneeUsername   *string    `url:"assignee_username,omitempty" json:"assignee_username,omitempty"`
+	MyReactionEmoji    *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
+	NotMyReactionEmoji []string   `url:"not[my_reaction_emoji],omitempty" json:"not[my_reaction_emoji],omitempty"`
+	IIDs               []int      `url:"iids[],omitempty" json:"iids,omitempty"`
+	OrderBy            *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort               *string    `url:"sort,omitempty" json:"sort,omitempty"`
+	Search             *string    `url:"search,omitempty" json:"search,omitempty"`
+	CreatedAfter       *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
+	CreatedBefore      *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
+	UpdatedAfter       *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
+	UpdatedBefore      *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
+	Confidential       *bool      `url:"confidential,omitempty" json:"confidential,omitempty"`
 }
 
 // ListIssues gets all issues created by authenticated user. This function
@@ -229,25 +249,30 @@ func (s *IssuesService) ListIssues(opt *ListIssuesOptions, options ...RequestOpt
 // GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#list-group-issues
 type ListGroupIssuesOptions struct {
 	ListOptions
-	State            *string    `url:"state,omitempty" json:"state,omitempty"`
-	Labels           Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
-	WithLabelDetails *bool      `url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
-	IIDs             []int      `url:"iids[],omitempty" json:"iids,omitempty"`
-	Milestone        *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
-	Scope            *string    `url:"scope,omitempty" json:"scope,omitempty"`
-	AuthorID         *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
-	AuthorUsername   *string    `url:"author_username,omitempty" json:"author_username,omitempty"`
-	AssigneeID       *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
-	AssigneeUsername *string    `url:"assignee_username,omitempty" json:"assignee_username,omitempty"`
-	MyReactionEmoji  *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
-	OrderBy          *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort             *string    `url:"sort,omitempty" json:"sort,omitempty"`
-	Search           *string    `url:"search,omitempty" json:"search,omitempty"`
-	In               *string    `url:"in,omitempty" json:"in,omitempty"`
-	CreatedAfter     *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
-	CreatedBefore    *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
-	UpdatedAfter     *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
-	UpdatedBefore    *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
+	State              *string    `url:"state,omitempty" json:"state,omitempty"`
+	Labels             Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	NotLabels          Labels     `url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
+	WithLabelDetails   *bool      `url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
+	IIDs               []int      `url:"iids[],omitempty" json:"iids,omitempty"`
+	Milestone          *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
+	NotMilestone       *string    `url:"not[milestone],omitempty" json:"not[milestone],omitempty"`
+	Scope              *string    `url:"scope,omitempty" json:"scope,omitempty"`
+	AuthorID           *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
+	NotAuthorID        []int      `url:"not[author_id],omitempty" json:"not[author_id],omitempty"`
+	AuthorUsername     *string    `url:"author_username,omitempty" json:"author_username,omitempty"`
+	AssigneeID         *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
+	NotAssigneeID      []int      `url:"not[assignee_id],omitempty" json:"not[assignee_id],omitempty"`
+	AssigneeUsername   *string    `url:"assignee_username,omitempty" json:"assignee_username,omitempty"`
+	MyReactionEmoji    *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
+	NotMyReactionEmoji []string   `url:"not[my_reaction_emoji],omitempty" json:"not[my_reaction_emoji],omitempty"`
+	OrderBy            *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort               *string    `url:"sort,omitempty" json:"sort,omitempty"`
+	Search             *string    `url:"search,omitempty" json:"search,omitempty"`
+	In                 *string    `url:"in,omitempty" json:"in,omitempty"`
+	CreatedAfter       *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
+	CreatedBefore      *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
+	UpdatedAfter       *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
+	UpdatedBefore      *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
 }
 
 // ListGroupIssues gets a list of group issues. This function accepts
@@ -280,24 +305,30 @@ func (s *IssuesService) ListGroupIssues(pid interface{}, opt *ListGroupIssuesOpt
 // GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#list-project-issues
 type ListProjectIssuesOptions struct {
 	ListOptions
-	IIDs             []int      `url:"iids[],omitempty" json:"iids,omitempty"`
-	State            *string    `url:"state,omitempty" json:"state,omitempty"`
-	Labels           Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
-	WithLabelDetails *bool      `url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
-	Milestone        *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
-	Scope            *string    `url:"scope,omitempty" json:"scope,omitempty"`
-	AuthorID         *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
-	AssigneeID       *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
-	MyReactionEmoji  *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
-	OrderBy          *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort             *string    `url:"sort,omitempty" json:"sort,omitempty"`
-	Search           *string    `url:"search,omitempty" json:"search,omitempty"`
-	In               *string    `url:"in,omitempty" json:"in,omitempty"`
-	CreatedAfter     *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
-	CreatedBefore    *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
-	UpdatedAfter     *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
-	UpdatedBefore    *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
-	Confidential     *bool      `url:"confidential,omitempty" json:"confidential,omitempty"`
+	IIDs               []int      `url:"iids[],omitempty" json:"iids,omitempty"`
+	State              *string    `url:"state,omitempty" json:"state,omitempty"`
+	Labels             Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	NotLabels          Labels     `url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
+	WithLabelDetails   *bool      `url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
+	Milestone          *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
+	NotMilestone       []string   `url:"not[milestone],omitempty" json:"not[milestone],omitempty"`
+	Scope              *string    `url:"scope,omitempty" json:"scope,omitempty"`
+	AuthorID           *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
+	NotAuthorID        []int      `url:"not[author_id],omitempty" json:"not[author_id],omitempty"`
+	AssigneeID         *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
+	NotAssigneeID      []int      `url:"not[assignee_id],omitempty" json:"not[assignee_id],omitempty"`
+	AssigneeUsername   *string    `url:"assignee_username,omitempty" json:"assignee_username,omitempty"`
+	MyReactionEmoji    *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
+	NotMyReactionEmoji []string   `url:"not[my_reaction_emoji],omitempty" json:"not[my_reaction_emoji],omitempty"`
+	OrderBy            *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort               *string    `url:"sort,omitempty" json:"sort,omitempty"`
+	Search             *string    `url:"search,omitempty" json:"search,omitempty"`
+	In                 *string    `url:"in,omitempty" json:"in,omitempty"`
+	CreatedAfter       *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
+	CreatedBefore      *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
+	UpdatedAfter       *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
+	UpdatedBefore      *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
+	Confidential       *bool      `url:"confidential,omitempty" json:"confidential,omitempty"`
 }
 
 // ListProjectIssues gets a list of project issues. This function accepts
@@ -359,7 +390,7 @@ type CreateIssueOptions struct {
 	Confidential                       *bool      `url:"confidential,omitempty" json:"confidential,omitempty"`
 	AssigneeIDs                        []int      `url:"assignee_ids,omitempty" json:"assignee_ids,omitempty"`
 	MilestoneID                        *int       `url:"milestone_id,omitempty" json:"milestone_id,omitempty"`
-	Labels                             *Labels    `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	Labels                             Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
 	CreatedAt                          *time.Time `url:"created_at,omitempty" json:"created_at,omitempty"`
 	DueDate                            *ISOTime   `url:"due_date,omitempty" json:"due_date,omitempty"`
 	MergeRequestToResolveDiscussionsOf *int       `url:"merge_request_to_resolve_discussions_of,omitempty" json:"merge_request_to_resolve_discussions_of,omitempty"`
@@ -400,7 +431,9 @@ type UpdateIssueOptions struct {
 	Confidential     *bool      `url:"confidential,omitempty" json:"confidential,omitempty"`
 	AssigneeIDs      []int      `url:"assignee_ids,omitempty" json:"assignee_ids,omitempty"`
 	MilestoneID      *int       `url:"milestone_id,omitempty" json:"milestone_id,omitempty"`
-	Labels           *Labels    `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	Labels           Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	AddLabels        Labels     `url:"add_labels,comma,omitempty" json:"add_labels,omitempty"`
+	RemoveLabels     Labels     `url:"remove_labels,comma,omitempty" json:"remove_labels,omitempty"`
 	StateEvent       *string    `url:"state_event,omitempty" json:"state_event,omitempty"`
 	UpdatedAt        *time.Time `url:"updated_at,omitempty" json:"updated_at,omitempty"`
 	DueDate          *ISOTime   `url:"due_date,omitempty" json:"due_date,omitempty"`
@@ -644,4 +677,29 @@ func (s *IssuesService) ResetSpentTime(pid interface{}, issue int, options ...Re
 // https://docs.gitlab.com/ce/api/issues.html#get-time-tracking-stats
 func (s *IssuesService) GetTimeSpent(pid interface{}, issue int, options ...RequestOptionFunc) (*TimeStats, *Response, error) {
 	return s.timeStats.getTimeSpent(pid, "issues", issue, options...)
+}
+
+// GetParticipants gets a list of issue participants.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/issues.html#participants-on-issues
+func (s *IssuesService) GetParticipants(pid interface{}, issue int, options ...RequestOptionFunc) ([]*BasicUser, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/issues/%d/participants", pathEscape(project), issue)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var bu []*BasicUser
+	resp, err := s.client.Do(req, &bu)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return bu, resp, err
 }

--- a/vendor/github.com/xanzy/go-gitlab/issues_statistics.go
+++ b/vendor/github.com/xanzy/go-gitlab/issues_statistics.go
@@ -51,8 +51,8 @@ func (n IssuesStatistics) String() string {
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/issues_statistics.html#get-issues-statistics
 type GetIssuesStatisticsOptions struct {
-	Labels           *Labels    `url:"labels,omitempty" json:"labels,omitempty"`
-	Milestone        *Milestone `url:"milestone,omitempty" json:"milestone,omitempty"`
+	Labels           Labels     `url:"labels,omitempty" json:"labels,omitempty"`
+	Milestone        *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
 	Scope            *string    `url:"scope,omitempty" json:"scope,omitempty"`
 	AuthorID         *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
 	AuthorUsername   *string    `url:"author_username,omitempty" json:"author_username,omitempty"`
@@ -95,7 +95,7 @@ func (s *IssuesStatisticsService) GetIssuesStatistics(opt *GetIssuesStatisticsOp
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/issues_statistics.html#get-group-issues-statistics
 type GetGroupIssuesStatisticsOptions struct {
-	Labels           *Labels    `url:"labels,omitempty" json:"labels,omitempty"`
+	Labels           Labels     `url:"labels,omitempty" json:"labels,omitempty"`
 	IIDs             []int      `url:"iids,omitempty" json:"iids,omitempty"`
 	Milestone        *Milestone `url:"milestone,omitempty" json:"milestone,omitempty"`
 	Scope            *string    `url:"scope,omitempty" json:"scope,omitempty"`
@@ -144,7 +144,7 @@ func (s *IssuesStatisticsService) GetGroupIssuesStatistics(gid interface{}, opt 
 // https://docs.gitlab.com/ee/api/issues_statistics.html#get-project-issues-statistics
 type GetProjectIssuesStatisticsOptions struct {
 	IIDs             []int      `url:"iids,omitempty" json:"iids,omitempty"`
-	Labels           *Labels    `url:"labels,omitempty" json:"labels,omitempty"`
+	Labels           Labels     `url:"labels,omitempty" json:"labels,omitempty"`
 	Milestone        *Milestone `url:"milestone,omitempty" json:"milestone,omitempty"`
 	Scope            *string    `url:"scope,omitempty" json:"scope,omitempty"`
 	AuthorID         *int       `url:"author_id,omitempty" json:"author_id,omitempty"`

--- a/vendor/github.com/xanzy/go-gitlab/merge_requests.go
+++ b/vendor/github.com/xanzy/go-gitlab/merge_requests.go
@@ -133,25 +133,28 @@ func (m MergeRequestDiffVersion) String() string {
 // https://docs.gitlab.com/ce/api/merge_requests.html#list-merge-requests
 type ListMergeRequestsOptions struct {
 	ListOptions
-	State           *string    `url:"state,omitempty" json:"state,omitempty"`
-	OrderBy         *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort            *string    `url:"sort,omitempty" json:"sort,omitempty"`
-	Milestone       *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
-	View            *string    `url:"view,omitempty" json:"view,omitempty"`
-	Labels          Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
-	CreatedAfter    *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
-	CreatedBefore   *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
-	UpdatedAfter    *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
-	UpdatedBefore   *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
-	Scope           *string    `url:"scope,omitempty" json:"scope,omitempty"`
-	AuthorID        *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
-	AssigneeID      *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
-	MyReactionEmoji *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
-	SourceBranch    *string    `url:"source_branch,omitempty" json:"source_branch,omitempty"`
-	TargetBranch    *string    `url:"target_branch,omitempty" json:"target_branch,omitempty"`
-	Search          *string    `url:"search,omitempty" json:"search,omitempty"`
-	In              *string    `url:"in,omitempty" json:"in,omitempty"`
-	WIP             *string    `url:"wip,omitempty" json:"wip,omitempty"`
+	State                  *string    `url:"state,omitempty" json:"state,omitempty"`
+	OrderBy                *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort                   *string    `url:"sort,omitempty" json:"sort,omitempty"`
+	Milestone              *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
+	View                   *string    `url:"view,omitempty" json:"view,omitempty"`
+	Labels                 Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	NotLabels              Labels     `url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
+	WithLabelsDetails      *bool      `url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
+	WithMergeStatusRecheck *bool      `url:"with_merge_status_recheck,omitempty" json:"with_merge_status_recheck,omitempty"`
+	CreatedAfter           *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
+	CreatedBefore          *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
+	UpdatedAfter           *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
+	UpdatedBefore          *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
+	Scope                  *string    `url:"scope,omitempty" json:"scope,omitempty"`
+	AuthorID               *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
+	AssigneeID             *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
+	MyReactionEmoji        *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
+	SourceBranch           *string    `url:"source_branch,omitempty" json:"source_branch,omitempty"`
+	TargetBranch           *string    `url:"target_branch,omitempty" json:"target_branch,omitempty"`
+	Search                 *string    `url:"search,omitempty" json:"search,omitempty"`
+	In                     *string    `url:"in,omitempty" json:"in,omitempty"`
+	WIP                    *string    `url:"wip,omitempty" json:"wip,omitempty"`
 }
 
 // ListMergeRequests gets all merge requests. The state parameter can be used
@@ -183,23 +186,26 @@ func (s *MergeRequestsService) ListMergeRequests(opt *ListMergeRequestsOptions, 
 // https://docs.gitlab.com/ce/api/merge_requests.html#list-group-merge-requests
 type ListGroupMergeRequestsOptions struct {
 	ListOptions
-	State           *string    `url:"state,omitempty" json:"state,omitempty"`
-	OrderBy         *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort            *string    `url:"sort,omitempty" json:"sort,omitempty"`
-	Milestone       *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
-	View            *string    `url:"view,omitempty" json:"view,omitempty"`
-	Labels          *Labels    `url:"labels,omitempty" json:"labels,omitempty"`
-	CreatedAfter    *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
-	CreatedBefore   *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
-	UpdatedAfter    *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
-	UpdatedBefore   *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
-	Scope           *string    `url:"scope,omitempty" json:"scope,omitempty"`
-	AuthorID        *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
-	AssigneeID      *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
-	MyReactionEmoji *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
-	SourceBranch    *string    `url:"source_branch,omitempty" json:"source_branch,omitempty"`
-	TargetBranch    *string    `url:"target_branch,omitempty" json:"target_branch,omitempty"`
-	Search          *string    `url:"search,omitempty" json:"search,omitempty"`
+	State                  *string    `url:"state,omitempty" json:"state,omitempty"`
+	OrderBy                *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort                   *string    `url:"sort,omitempty" json:"sort,omitempty"`
+	Milestone              *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
+	View                   *string    `url:"view,omitempty" json:"view,omitempty"`
+	Labels                 Labels     `url:"labels,omitempty" json:"labels,omitempty"`
+	NotLabels              Labels     `url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
+	WithLabelsDetails      *bool      `url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
+	WithMergeStatusRecheck *bool      `url:"with_merge_status_recheck,omitempty" json:"with_merge_status_recheck,omitempty"`
+	CreatedAfter           *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
+	CreatedBefore          *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
+	UpdatedAfter           *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
+	UpdatedBefore          *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
+	Scope                  *string    `url:"scope,omitempty" json:"scope,omitempty"`
+	AuthorID               *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
+	AssigneeID             *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
+	MyReactionEmoji        *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
+	SourceBranch           *string    `url:"source_branch,omitempty" json:"source_branch,omitempty"`
+	TargetBranch           *string    `url:"target_branch,omitempty" json:"target_branch,omitempty"`
+	Search                 *string    `url:"search,omitempty" json:"search,omitempty"`
 }
 
 // ListGroupMergeRequests gets all merge requests for this group.
@@ -234,25 +240,28 @@ func (s *MergeRequestsService) ListGroupMergeRequests(gid interface{}, opt *List
 // https://docs.gitlab.com/ce/api/merge_requests.html#list-project-merge-requests
 type ListProjectMergeRequestsOptions struct {
 	ListOptions
-	IIDs            []int      `url:"iids[],omitempty" json:"iids,omitempty"`
-	State           *string    `url:"state,omitempty" json:"state,omitempty"`
-	OrderBy         *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort            *string    `url:"sort,omitempty" json:"sort,omitempty"`
-	Milestone       *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
-	View            *string    `url:"view,omitempty" json:"view,omitempty"`
-	Labels          *Labels    `url:"labels,omitempty" json:"labels,omitempty"`
-	CreatedAfter    *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
-	CreatedBefore   *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
-	UpdatedAfter    *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
-	UpdatedBefore   *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
-	Scope           *string    `url:"scope,omitempty" json:"scope,omitempty"`
-	AuthorID        *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
-	AssigneeID      *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
-	MyReactionEmoji *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
-	SourceBranch    *string    `url:"source_branch,omitempty" json:"source_branch,omitempty"`
-	TargetBranch    *string    `url:"target_branch,omitempty" json:"target_branch,omitempty"`
-	Search          *string    `url:"search,omitempty" json:"search,omitempty"`
-	WIP             *string    `url:"wip,omitempty" json:"wip,omitempty"`
+	IIDs                   []int      `url:"iids[],omitempty" json:"iids,omitempty"`
+	State                  *string    `url:"state,omitempty" json:"state,omitempty"`
+	OrderBy                *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort                   *string    `url:"sort,omitempty" json:"sort,omitempty"`
+	Milestone              *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
+	View                   *string    `url:"view,omitempty" json:"view,omitempty"`
+	Labels                 Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	NotLabels              Labels     `url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
+	WithLabelsDetails      *bool      `url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
+	WithMergeStatusRecheck *bool      `url:"with_merge_status_recheck,omitempty" json:"with_merge_status_recheck,omitempty"`
+	CreatedAfter           *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
+	CreatedBefore          *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
+	UpdatedAfter           *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
+	UpdatedBefore          *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
+	Scope                  *string    `url:"scope,omitempty" json:"scope,omitempty"`
+	AuthorID               *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
+	AssigneeID             *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
+	MyReactionEmoji        *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
+	SourceBranch           *string    `url:"source_branch,omitempty" json:"source_branch,omitempty"`
+	TargetBranch           *string    `url:"target_branch,omitempty" json:"target_branch,omitempty"`
+	Search                 *string    `url:"search,omitempty" json:"search,omitempty"`
+	WIP                    *string    `url:"wip,omitempty" json:"wip,omitempty"`
 }
 
 // ListProjectMergeRequests gets all merge requests for this project.
@@ -449,6 +458,31 @@ func (s *MergeRequestsService) ListMergeRequestPipelines(pid interface{}, mergeR
 	return p, resp, err
 }
 
+// CreateMergeRequestPipeline creates a new pipeline for a merge request.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/merge_requests.html#create-mr-pipeline
+func (s *MergeRequestsService) CreateMergeRequestPipeline(pid interface{}, mergeRequest int, options ...RequestOptionFunc) (*PipelineInfo, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/pipelines", pathEscape(project), mergeRequest)
+
+	req, err := s.client.NewRequest("POST", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	p := new(PipelineInfo)
+	resp, err := s.client.Do(req, p)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return p, resp, err
+}
+
 // GetIssuesClosedOnMergeOptions represents the available GetIssuesClosedOnMerge()
 // options.
 //
@@ -492,7 +526,7 @@ type CreateMergeRequestOptions struct {
 	Description        *string `url:"description,omitempty" json:"description,omitempty"`
 	SourceBranch       *string `url:"source_branch,omitempty" json:"source_branch,omitempty"`
 	TargetBranch       *string `url:"target_branch,omitempty" json:"target_branch,omitempty"`
-	Labels             *Labels `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	Labels             Labels  `url:"labels,comma,omitempty" json:"labels,omitempty"`
 	AssigneeID         *int    `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
 	AssigneeIDs        []int   `url:"assignee_ids,omitempty" json:"assignee_ids,omitempty"`
 	TargetProjectID    *int    `url:"target_project_id,omitempty" json:"target_project_id,omitempty"`
@@ -538,7 +572,7 @@ type UpdateMergeRequestOptions struct {
 	TargetBranch       *string `url:"target_branch,omitempty" json:"target_branch,omitempty"`
 	AssigneeID         *int    `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
 	AssigneeIDs        []int   `url:"assignee_ids,omitempty" json:"assignee_ids,omitempty"`
-	Labels             *Labels `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	Labels             Labels  `url:"labels,comma,omitempty" json:"labels,omitempty"`
 	MilestoneID        *int    `url:"milestone_id,omitempty" json:"milestone_id,omitempty"`
 	StateEvent         *string `url:"state_event,omitempty" json:"state_event,omitempty"`
 	RemoveSourceBranch *bool   `url:"remove_source_branch,omitempty" json:"remove_source_branch,omitempty"`

--- a/vendor/github.com/xanzy/go-gitlab/milestones.go
+++ b/vendor/github.com/xanzy/go-gitlab/milestones.go
@@ -44,6 +44,7 @@ type Milestone struct {
 	WebURL      string     `json:"web_url"`
 	UpdatedAt   *time.Time `json:"updated_at"`
 	CreatedAt   *time.Time `json:"created_at"`
+	Expired     *bool      `json:"expired"`
 }
 
 func (m Milestone) String() string {

--- a/vendor/github.com/xanzy/go-gitlab/pipeline_schedules.go
+++ b/vendor/github.com/xanzy/go-gitlab/pipeline_schedules.go
@@ -230,6 +230,25 @@ func (s *PipelineSchedulesService) DeletePipelineSchedule(pid interface{}, sched
 	return s.client.Do(req, nil)
 }
 
+// RunPipelineSchedule triggers a new scheduled pipeline to run immediately.
+//
+// Gitlab API docs:
+// https://docs.gitlab.com/ce/api/pipeline_schedules.html#run-a-scheduled-pipeline-immediately
+func (s *PipelineSchedulesService) RunPipelineSchedule(pid interface{}, schedule int, options ...RequestOptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/pipeline_schedules/%d/play", pathEscape(project), schedule)
+
+	req, err := s.client.NewRequest("POST", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
 // CreatePipelineScheduleVariableOptions represents the available
 // CreatePipelineScheduleVariable() options.
 //

--- a/vendor/github.com/xanzy/go-gitlab/pipelines.go
+++ b/vendor/github.com/xanzy/go-gitlab/pipelines.go
@@ -61,7 +61,7 @@ type Pipeline struct {
 	DetailedStatus *DetailedStatus `json:"detailed_status"`
 }
 
-// DetailedStatus contains detailed information about the status of a pipeline
+// DetailedStatus contains detailed information about the status of a pipeline.
 type DetailedStatus struct {
 	Icon         string `json:"icon"`
 	Text         string `json:"text"`
@@ -77,6 +77,43 @@ type DetailedStatus struct {
 }
 
 func (p Pipeline) String() string {
+	return Stringify(p)
+}
+
+// PipelineTestReport contains a detailed report of a test run.
+type PipelineTestReport struct {
+	TotalTime    int                  `json:"total_time"`
+	TotalCount   int                  `json:"total_count"`
+	SuccessCount int                  `json:"success_count"`
+	FailedCount  int                  `json:"failed_count"`
+	SkippedCount int                  `json:"skipped_count"`
+	ErrorCount   int                  `json:"error_count"`
+	TestSuites   []PipelineTestSuites `json:"test_suites"`
+}
+
+// PipelineTestSuites contains test suites results.
+type PipelineTestSuites struct {
+	Name         string              `json:"name"`
+	TotalTime    int                 `json:"total_time"`
+	TotalCount   int                 `json:"total_count"`
+	SuccessCount int                 `json:"success_count"`
+	FailedCount  int                 `json:"failed_count"`
+	SkippedCount int                 `json:"skipped_count"`
+	ErrorCount   int                 `json:"error_count"`
+	TestCases    []PipelineTestCases `json:"test_cases"`
+}
+
+// PipelineTestCases contains test cases details.
+type PipelineTestCases struct {
+	Status        string `json:"status"`
+	Name          string `json:"name"`
+	Classname     string `json:"classname"`
+	ExecutionTime int    `json:"execution_time"`
+	SystemOutput  string `json:"system_output"`
+	StackTrace    string `json:"stack_trace"`
+}
+
+func (p PipelineTestReport) String() string {
 	return Stringify(p)
 }
 
@@ -179,6 +216,30 @@ func (s *PipelinesService) GetPipelineVariables(pid interface{}, pipeline int, o
 
 	var p []*PipelineVariable
 	resp, err := s.client.Do(req, &p)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return p, resp, err
+}
+
+// GetPipelineTestReport gets the test report of a single project pipeline.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/pipelines.html#get-a-pipelines-test-report
+func (s *PipelinesService) GetPipelineTestReport(pid interface{}, pipeline int) (*PipelineTestReport, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/pipelines/%d/test_report", pathEscape(project), pipeline)
+
+	req, err := s.client.NewRequest("GET", u, nil, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	p := new(PipelineTestReport)
+	resp, err := s.client.Do(req, p)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/vendor/github.com/xanzy/go-gitlab/project_members.go
+++ b/vendor/github.com/xanzy/go-gitlab/project_members.go
@@ -117,6 +117,31 @@ func (s *ProjectMembersService) GetProjectMember(pid interface{}, user int, opti
 	return pm, resp, err
 }
 
+// GetInheritedProjectMember gets a project team member, including inherited
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/members.html#get-a-member-of-a-group-or-project-including-inherited-members
+func (s *ProjectMembersService) GetInheritedProjectMember(pid interface{}, user int, options ...RequestOptionFunc) (*ProjectMember, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/members/all/%d", pathEscape(project), user)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	pm := new(ProjectMember)
+	resp, err := s.client.Do(req, pm)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return pm, resp, err
+}
+
 // AddProjectMemberOptions represents the available AddProjectMember() options.
 //
 // GitLab API docs:

--- a/vendor/github.com/xanzy/go-gitlab/projects.go
+++ b/vendor/github.com/xanzy/go-gitlab/projects.go
@@ -89,6 +89,7 @@ type Project struct {
 	MirrorTriggerBuilds                       bool               `json:"mirror_trigger_builds"`
 	OnlyMirrorProtectedBranches               bool               `json:"only_mirror_protected_branches"`
 	MirrorOverwritesDivergedBranches          bool               `json:"mirror_overwrites_diverged_branches"`
+	PackagesEnabled                           bool               `json:"packages_enabled"`
 	ServiceDeskEnabled                        bool               `json:"service_desk_enabled"`
 	ServiceDeskAddress                        string             `json:"service_desk_address"`
 	IssuesAccessLevel                         AccessControlValue `json:"issues_access_level"`
@@ -503,6 +504,7 @@ type CreateProjectOptions struct {
 	MirrorTriggerBuilds                       *bool               `url:"mirror_trigger_builds,omitempty" json:"mirror_trigger_builds,omitempty"`
 	InitializeWithReadme                      *bool               `url:"initialize_with_readme,omitempty" json:"initialize_with_readme,omitempty"`
 	TemplateName                              *string             `url:"template_name,omitempty" json:"template_name,omitempty"`
+	TemplateProjectID                         *int                `url:"template_project_id,omitempty" json:"template_project_id,omitempty"`
 	UseCustomTemplate                         *bool               `url:"use_custom_template,omitempty" json:"use_custom_template,omitempty"`
 	GroupWithProjectTemplatesID               *int                `url:"group_with_project_templates_id,omitempty" json:"group_with_project_templates_id,omitempty"`
 	PackagesEnabled                           *bool               `url:"packages_enabled,omitempty" json:"packages_enabled,omitempty"`
@@ -1189,19 +1191,20 @@ func (s *ProjectsService) ListProjectForks(pid interface{}, opt *ListProjectsOpt
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/projects.html#push-rules
 type ProjectPushRules struct {
-	ID                    int        `json:"id"`
-	ProjectID             int        `json:"project_id"`
-	CommitMessageRegex    string     `json:"commit_message_regex"`
-	BranchNameRegex       string     `json:"branch_name_regex"`
-	DenyDeleteTag         bool       `json:"deny_delete_tag"`
-	CreatedAt             *time.Time `json:"created_at"`
-	MemberCheck           bool       `json:"member_check"`
-	PreventSecrets        bool       `json:"prevent_secrets"`
-	AuthorEmailRegex      string     `json:"author_email_regex"`
-	FileNameRegex         string     `json:"file_name_regex"`
-	MaxFileSize           int        `json:"max_file_size"`
-	CommitCommitterCheck  bool       `json:"commit_committer_check"`
-	RejectUnsignedCommits bool       `json:"reject_unsigned_commits"`
+	ID                         int        `json:"id"`
+	ProjectID                  int        `json:"project_id"`
+	CommitMessageRegex         string     `json:"commit_message_regex"`
+	CommitMessageNegativeRegex string     `json:"commit_message_negative_regex"`
+	BranchNameRegex            string     `json:"branch_name_regex"`
+	DenyDeleteTag              bool       `json:"deny_delete_tag"`
+	CreatedAt                  *time.Time `json:"created_at"`
+	MemberCheck                bool       `json:"member_check"`
+	PreventSecrets             bool       `json:"prevent_secrets"`
+	AuthorEmailRegex           string     `json:"author_email_regex"`
+	FileNameRegex              string     `json:"file_name_regex"`
+	MaxFileSize                int        `json:"max_file_size"`
+	CommitCommitterCheck       bool       `json:"commit_committer_check"`
+	RejectUnsignedCommits      bool       `json:"reject_unsigned_commits"`
 }
 
 // GetProjectPushRules gets the push rules of a project.
@@ -1235,14 +1238,17 @@ func (s *ProjectsService) GetProjectPushRules(pid interface{}, options ...Reques
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/projects.html#add-project-push-rule
 type AddProjectPushRuleOptions struct {
-	DenyDeleteTag      *bool   `url:"deny_delete_tag,omitempty" json:"deny_delete_tag,omitempty"`
-	MemberCheck        *bool   `url:"member_check,omitempty" json:"member_check,omitempty"`
-	PreventSecrets     *bool   `url:"prevent_secrets,omitempty" json:"prevent_secrets,omitempty"`
-	CommitMessageRegex *string `url:"commit_message_regex,omitempty" json:"commit_message_regex,omitempty"`
-	BranchNameRegex    *string `url:"branch_name_regex,omitempty" json:"branch_name_regex,omitempty"`
-	AuthorEmailRegex   *string `url:"author_email_regex,omitempty" json:"author_email_regex,omitempty"`
-	FileNameRegex      *string `url:"file_name_regex,omitempty" json:"file_name_regex,omitempty"`
-	MaxFileSize        *int    `url:"max_file_size,omitempty" json:"max_file_size,omitempty"`
+	DenyDeleteTag              *bool   `url:"deny_delete_tag,omitempty" json:"deny_delete_tag,omitempty"`
+	MemberCheck                *bool   `url:"member_check,omitempty" json:"member_check,omitempty"`
+	PreventSecrets             *bool   `url:"prevent_secrets,omitempty" json:"prevent_secrets,omitempty"`
+	CommitMessageRegex         *string `url:"commit_message_regex,omitempty" json:"commit_message_regex,omitempty"`
+	CommitMessageNegativeRegex *string `url:"commit_message_negative_regex,omitempty" json:"commit_message_negative_regex,omitempty"`
+	BranchNameRegex            *string `url:"branch_name_regex,omitempty" json:"branch_name_regex,omitempty"`
+	AuthorEmailRegex           *string `url:"author_email_regex,omitempty" json:"author_email_regex,omitempty"`
+	FileNameRegex              *string `url:"file_name_regex,omitempty" json:"file_name_regex,omitempty"`
+	MaxFileSize                *int    `url:"max_file_size,omitempty" json:"max_file_size,omitempty"`
+	CommitCommitterCheck       *bool   `url:"commit_committer_check,omitempty" json:"commit_committer_check,omitempty"`
+	RejectUnsignedCommits      *bool   `url:"reject_unsigned_commits,omitempty" json:"reject_unsigned_commits,omitempty"`
 }
 
 // AddProjectPushRule adds a push rule to a specified project.
@@ -1276,16 +1282,17 @@ func (s *ProjectsService) AddProjectPushRule(pid interface{}, opt *AddProjectPus
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/projects.html#edit-project-push-rule
 type EditProjectPushRuleOptions struct {
-	AuthorEmailRegex      *string `url:"author_email_regex,omitempty" json:"author_email_regex,omitempty"`
-	BranchNameRegex       *string `url:"branch_name_regex,omitempty" json:"branch_name_regex,omitempty"`
-	CommitMessageRegex    *string `url:"commit_message_regex,omitempty" json:"commit_message_regex,omitempty"`
-	FileNameRegex         *string `url:"file_name_regex,omitempty" json:"file_name_regex,omitempty"`
-	DenyDeleteTag         *bool   `url:"deny_delete_tag,omitempty" json:"deny_delete_tag,omitempty"`
-	MemberCheck           *bool   `url:"member_check,omitempty" json:"member_check,omitempty"`
-	PreventSecrets        *bool   `url:"prevent_secrets,omitempty" json:"prevent_secrets,omitempty"`
-	MaxFileSize           *int    `url:"max_file_size,omitempty" json:"max_file_size,omitempty"`
-	CommitCommitterCheck  *bool   `url:"commit_committer_check,omitempty" json:"commit_committer_check,omitempty"`
-	RejectUnsignedCommits *bool   `url:"reject_unsigned_commits,omitempty" json:"reject_unsigned_commits,omitempty"`
+	AuthorEmailRegex           *string `url:"author_email_regex,omitempty" json:"author_email_regex,omitempty"`
+	BranchNameRegex            *string `url:"branch_name_regex,omitempty" json:"branch_name_regex,omitempty"`
+	CommitMessageRegex         *string `url:"commit_message_regex,omitempty" json:"commit_message_regex,omitempty"`
+	CommitMessageNegativeRegex *string `url:"commit_message_negative_regex,omitempty" json:"commit_message_negative_regex,omitempty"`
+	FileNameRegex              *string `url:"file_name_regex,omitempty" json:"file_name_regex,omitempty"`
+	DenyDeleteTag              *bool   `url:"deny_delete_tag,omitempty" json:"deny_delete_tag,omitempty"`
+	MemberCheck                *bool   `url:"member_check,omitempty" json:"member_check,omitempty"`
+	PreventSecrets             *bool   `url:"prevent_secrets,omitempty" json:"prevent_secrets,omitempty"`
+	MaxFileSize                *int    `url:"max_file_size,omitempty" json:"max_file_size,omitempty"`
+	CommitCommitterCheck       *bool   `url:"commit_committer_check,omitempty" json:"commit_committer_check,omitempty"`
+	RejectUnsignedCommits      *bool   `url:"reject_unsigned_commits,omitempty" json:"reject_unsigned_commits,omitempty"`
 }
 
 // EditProjectPushRule edits a push rule for a specified project.

--- a/vendor/github.com/xanzy/go-gitlab/registry.go
+++ b/vendor/github.com/xanzy/go-gitlab/registry.go
@@ -190,9 +190,13 @@ func (s *ContainerRegistryService) DeleteRegistryRepositoryTag(pid interface{}, 
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/container_registry.html#delete-repository-tags-in-bulk
 type DeleteRegistryRepositoryTagsOptions struct {
+	NameRegexpDelete *string `url:"name_regex_delete,omitempty" json:"name_regex_delete,omitempty"`
+	NameRegexpKeep   *string `url:"name_regex_keep,omitempty" json:"name_regex_keep,omitempty"`
+	KeepN            *int    `url:"keep_n,omitempty" json:"keep_n,omitempty"`
+	OlderThan        *string `url:"older_than,omitempty" json:"older_than,omitempty"`
+
+	// Deprecated members
 	NameRegexp *string `url:"name_regex,omitempty" json:"name_regex,omitempty"`
-	KeepN      *int    `url:"keep_n,omitempty" json:"keep_n,omitempty"`
-	OlderThan  *string `url:"older_than,omitempty" json:"older_than,omitempty"`
 }
 
 // DeleteRegistryRepositoryTags deletes repository tags in bulk based on

--- a/vendor/github.com/xanzy/go-gitlab/services.go
+++ b/vendor/github.com/xanzy/go-gitlab/services.go
@@ -54,6 +54,30 @@ type Service struct {
 	WikiPageEvents           bool       `json:"wiki_page_events"`
 }
 
+// ListServices gets a list of all active services.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/services.html#list-all-active-services
+func (s *ServicesService) ListServices(pid interface{}, options ...RequestOptionFunc) ([]*Service, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/services", pathEscape(project))
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var svcs []*Service
+	resp, err := s.client.Do(req, &svcs)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return svcs, resp, err
+}
+
 // DroneCIService represents Drone CI service settings.
 //
 // GitLab API docs:

--- a/vendor/github.com/xanzy/go-gitlab/tags.go
+++ b/vendor/github.com/xanzy/go-gitlab/tags.go
@@ -58,6 +58,7 @@ func (t Tag) String() string {
 type ListTagsOptions struct {
 	ListOptions
 	OrderBy *string `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Search  *string `url:"search,omitempty" json:"search,omitempty"`
 	Sort    *string `url:"sort,omitempty" json:"sort,omitempty"`
 }
 

--- a/vendor/github.com/xanzy/go-gitlab/types.go
+++ b/vendor/github.com/xanzy/go-gitlab/types.go
@@ -402,14 +402,23 @@ func Time(v time.Time) *time.Time {
 // BoolValue is a boolean value with advanced json unmarshaling features.
 type BoolValue bool
 
-// UnmarshalJSON allows 1 and 0 to be considered as boolean values
-// Needed for https://gitlab.com/gitlab-org/gitlab-ce/issues/50122
+// UnmarshalJSON allows 1, 0, "true", and "false" to be considered as boolean values
+// Needed for:
+// https://gitlab.com/gitlab-org/gitlab-ce/issues/50122
+// https://gitlab.com/gitlab-org/gitlab/-/issues/233941
+// https://github.com/gitlabhq/terraform-provider-gitlab/issues/348
 func (t *BoolValue) UnmarshalJSON(b []byte) error {
 	switch string(b) {
 	case `"1"`:
 		*t = true
 		return nil
 	case `"0"`:
+		*t = false
+		return nil
+	case `"true"`:
+		*t = true
+		return nil
+	case `"false"`:
 		*t = false
 		return nil
 	default:

--- a/vendor/github.com/xanzy/go-gitlab/users.go
+++ b/vendor/github.com/xanzy/go-gitlab/users.go
@@ -59,6 +59,7 @@ type User struct {
 	Email                     string             `json:"email"`
 	Name                      string             `json:"name"`
 	State                     string             `json:"state"`
+	WebURL                    string             `json:"web_url"`
 	CreatedAt                 *time.Time         `json:"created_at"`
 	Bio                       string             `json:"bio"`
 	Location                  string             `json:"location"`

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -228,7 +228,7 @@ github.com/ulikunitz/xz/lzma
 # github.com/vmihailenco/msgpack v4.0.1+incompatible
 github.com/vmihailenco/msgpack
 github.com/vmihailenco/msgpack/codes
-# github.com/xanzy/go-gitlab v0.34.1
+# github.com/xanzy/go-gitlab v0.38.1
 ## explicit
 github.com/xanzy/go-gitlab
 # github.com/zclconf/go-cty v1.2.1


### PR DESCRIPTION
With [GitLab 13.3](https://about.gitlab.com/releases/2020/08/22/gitlab-13-3-released/) the packages feature is generally available.
This PR creates an argument `packages_enabled` based on the [GitLab API](https://docs.gitlab.com/ee/api/projects.html#create-project) field of the same name to control the activation of this feature.