### PR TITLE
Remove non existing parameter from push rules docs

### DIFF
--- a/website/docs/r/project_push_rules.html.markdown
+++ b/website/docs/r/project_push_rules.html.markdown
@@ -46,8 +46,6 @@ The following arguments are supported:
 
 * `max_file_size` - (Optional, int) Maximum file size (MB)
 
-* `commit_committer_check` - (Optional, bool) Users can only push commits to this repository that were committed with one of their own verified emails
-
 ## Attributes Reference
 
 The resource exports the following attributes:


### PR DESCRIPTION
The parameter `commit_committer_check` does not exist in the current version of the project push rules resource: https://github.com/gitlabhq/terraform-provider-gitlab/blob/master/gitlab/resource_gitlab_project_push_rules.go