### PR TITLE
gitlab_group: Revert recent change to visibility_level attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 ## 2.12.0 (Unreleased)
 
-NOTES:
-* resource/gitlab_group: Attribute `visibility_level` now defaults to `private`, as was already documented, instead of reading the default from GitLab. This will not affect existing state. [GH-362]
-
 FEATURES:
 * **New Data Source:** `gitlab_group_membership` [GH-264]
 * **New Resource:** `gitlab_project_level_mr_approvals` [GH-356]

--- a/gitlab/resource_gitlab_group.go
+++ b/gitlab/resource_gitlab_group.go
@@ -61,7 +61,7 @@ func resourceGitlabGroup() *schema.Resource {
 			"visibility_level": {
 				Type:         schema.TypeString,
 				Optional:     true,
-				Default:      "private",
+				Computed:     true,
 				ValidateFunc: validation.StringInSlice([]string{"private", "internal", "public"}, true),
 			},
 			"share_with_group_lock": {

--- a/website/docs/r/group.html.markdown
+++ b/website/docs/r/group.html.markdown
@@ -44,7 +44,7 @@ support for projects in this group.
 * `request_access_enabled` - (Optional) Boolean, defaults to false.  Whether to
 enable users to request access to the group.
 
-* `visibility_level` - (Optional) The visibility of the group. Can be `private`, `internal`, or `public`.
+* `visibility_level` - (Optional) The group's visibility. Can be `private`, `internal`, or `public`.
 
 * `share_with_group_lock` - (Optional) Boolean, defaults to false.  Prevent sharing
 a project with another group within this group.

--- a/website/docs/r/group.html.markdown
+++ b/website/docs/r/group.html.markdown
@@ -44,7 +44,7 @@ support for projects in this group.
 * `request_access_enabled` - (Optional) Boolean, defaults to false.  Whether to
 enable users to request access to the group.
 
-* `visibility_level` - (Optional) The group’s visibility. Can be `private`, `internal`, or `public`.
+* `visibility_level` - (Optional) The visibility of the group. Can be `private`, `internal`, or `public`.
 
 * `share_with_group_lock` - (Optional) Boolean, defaults to false.  Prevent sharing
 a project with another group within this group.

--- a/website/docs/r/group.html.markdown
+++ b/website/docs/r/group.html.markdown
@@ -45,7 +45,6 @@ support for projects in this group.
 enable users to request access to the group.
 
 * `visibility_level` - (Optional) The group’s visibility. Can be `private`, `internal`, or `public`.
-The default will be the default value configured in GitLab, usually `private`.
 
 * `share_with_group_lock` - (Optional) Boolean, defaults to false.  Prevent sharing
 a project with another group within this group.

--- a/website/docs/r/group.html.markdown
+++ b/website/docs/r/group.html.markdown
@@ -44,9 +44,8 @@ support for projects in this group.
 * `request_access_enabled` - (Optional) Boolean, defaults to false.  Whether to
 enable users to request access to the group.
 
-* `visibility_level` - (Optional) Set to `public` to create a public group.
-  Valid values are `private`, `internal`, `public`.
-  Groups are created as private by default.
+* `visibility_level` - (Optional) The group’s visibility. Can be `private`, `internal`, or `public`.
+The default will be the default value configured in GitLab, usually `private`.
 
 * `share_with_group_lock` - (Optional) Boolean, defaults to false.  Prevent sharing
 a project with another group within this group.


### PR DESCRIPTION
Reverts an [unreleased breaking change](https://github.com/gitlabhq/terraform-provider-gitlab/commit/01b429b0cbd42be21cad59167f8b2460f4282582#diff-ea50bce9f20ae93ae983c1f538a2d66bR64) as requested by @roidelapluie [here](https://github.com/gitlabhq/terraform-provider-gitlab/pull/362#discussion_r487260162). I also clarified the default behavior in the docs.