### PR TITLE
gitlab_project_variable: fix nondeterministic reads when using environment_scope

### DIFF
--- a/gitlab/resource_gitlab_project_variable_test.go
+++ b/gitlab/resource_gitlab_project_variable_test.go
@@ -2,7 +2,9 @@ package gitlab
 
 import (
 	"fmt"
+	"os"
 	"regexp"
+	"strconv"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
@@ -11,254 +13,341 @@ import (
 	"github.com/xanzy/go-gitlab"
 )
 
+// testAccGitlabProjectContext encapsulates a GitLab client and test project to be used during an
+// acceptance test.
+type testAccGitlabProjectContext struct {
+	t       *testing.T
+	client  *gitlab.Client
+	project *gitlab.Project
+}
+
+// finish deletes the test project. Call this when the test is finished, usually in a defer.
+func (c testAccGitlabProjectContext) finish() {
+	if _, err := c.client.Projects.DeleteProject(c.project.ID); err != nil {
+		c.t.Fatalf("could not delete test project: %v", err)
+	}
+}
+
+// testAccGitlabProjectStart initializes the GitLab client and creates a test project. Remember to
+// call testAccGitlabProjectContext.finish() when finished with the testAccGitlabProjectContext.
+func testAccGitlabProjectStart(t *testing.T) testAccGitlabProjectContext {
+	if os.Getenv(resource.TestEnvVar) == "" {
+		t.Skip(fmt.Sprintf("Acceptance tests skipped unless env '%s' set", resource.TestEnvVar))
+		return testAccGitlabProjectContext{}
+	}
+
+	var options []gitlab.ClientOptionFunc
+	baseURL := os.Getenv("GITLAB_BASE_URL")
+	if baseURL != "" {
+		options = append(options, gitlab.WithBaseURL(baseURL))
+	}
+
+	client, err := gitlab.NewClient(os.Getenv("GITLAB_TOKEN"), options...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	project, _, err := client.Projects.CreateProject(&gitlab.CreateProjectOptions{
+		Name:        gitlab.String(acctest.RandomWithPrefix("acctest")),
+		Description: gitlab.String("Terraform acceptance tests"),
+		// So that acceptance tests can be run in a gitlab organization with no billing
+		Visibility: gitlab.Visibility(gitlab.PublicVisibility),
+	})
+	if err != nil {
+		t.Fatalf("could not create test project: %v", err)
+	}
+
+	return testAccGitlabProjectContext{
+		t:       t,
+		client:  client,
+		project: project,
+	}
+}
+
+func testAccCheckGitlabProjectVariableExists(client *gitlab.Client, name string) resource.TestCheckFunc {
+	var (
+		key              string
+		value            string
+		variableType     string
+		protected        string
+		masked           string
+		environmentScope string
+	)
+
+	return resource.ComposeTestCheckFunc(
+		// Load the real resource values using the GitLab API.
+		func(state *terraform.State) error {
+			attributes := state.RootModule().Resources[name].Primary.Attributes
+
+			got, err := getProjectVariable(client, attributes["project"], attributes["key"], attributes["environment_scope"])
+			if err != nil {
+				return err
+			}
+
+			key = got.Key
+			value = got.Value
+			variableType = string(got.VariableType)
+			protected = strconv.FormatBool(got.Protected)
+			masked = strconv.FormatBool(got.Masked)
+			environmentScope = got.EnvironmentScope
+
+			return nil
+		},
+
+		// Check that the real values match what was configured in the resource.
+		resource.ComposeAggregateTestCheckFunc(
+			resource.TestCheckResourceAttrPtr(name, "key", &key),
+			resource.TestCheckResourceAttrPtr(name, "value", &value),
+			resource.TestCheckResourceAttrPtr(name, "variable_type", &variableType),
+			resource.TestCheckResourceAttrPtr(name, "masked", &masked),
+			resource.TestCheckResourceAttrPtr(name, "protected", &protected),
+			resource.TestCheckResourceAttrPtr(name, "environment_scope", &environmentScope),
+		),
+	)
+}
+
+func testAccGitlabProjectVariableCheckAllVariablesDestroyed(ctx testAccGitlabProjectContext) func(state *terraform.State) error {
+	return func(state *terraform.State) error {
+		vars, _, err := ctx.client.ProjectVariables.ListVariables(ctx.project.ID, nil)
+		if err != nil {
+			return err
+		}
+
+		if len(vars) > 0 {
+			return fmt.Errorf("expected no project variables but found %d variables %v", len(vars), vars)
+		}
+
+		return nil
+	}
+}
+
 func TestAccGitlabProjectVariable_basic(t *testing.T) {
-	var projectVariable gitlab.ProjectVariable
-	rString := acctest.RandString(5)
+	ctx := testAccGitlabProjectStart(t)
+	defer ctx.finish()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckGitlabProjectVariableDestroy,
+		CheckDestroy: testAccGitlabProjectVariableCheckAllVariablesDestroyed(ctx),
 		Steps: []resource.TestStep{
-			// Create a project and variable with default options
+			// Create a project variable from a project name.
 			{
-				Config: testAccGitlabProjectVariableConfig(rString),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabProjectVariableExists("gitlab_project_variable.foo", &projectVariable),
-					testAccCheckGitlabProjectVariableAttributes(&projectVariable, &testAccGitlabProjectVariableExpectedAttributes{
-						Key:   fmt.Sprintf("key_%s", rString),
-						Value: fmt.Sprintf("value-%s", rString),
-					}),
-				),
+				Config: fmt.Sprintf(`
+resource "gitlab_project_variable" "foo" {
+  project = "%s"
+  key = "my_key"
+  value = "my_value"
+}
+`, ctx.project.PathWithNamespace),
+				Check: testAccCheckGitlabProjectVariableExists(ctx.client, "gitlab_project_variable.foo"),
 			},
-			// Update the project variable to toggle all the values to their inverse
 			{
-				Config: testAccGitlabProjectVariableUpdateConfig(rString),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabProjectVariableExists("gitlab_project_variable.foo", &projectVariable),
-					testAccCheckGitlabProjectVariableAttributes(&projectVariable, &testAccGitlabProjectVariableExpectedAttributes{
-						Key:       fmt.Sprintf("key_%s", rString),
-						Value:     fmt.Sprintf("value-inverse-%s", rString),
-						Protected: true,
-					}),
-				),
+				ResourceName:      "gitlab_project_variable.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
 			},
-			// Update the project variable to toggle the options back
+			// Same, using the project id.
 			{
-				Config: testAccGitlabProjectVariableConfig(rString),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabProjectVariableExists("gitlab_project_variable.foo", &projectVariable),
-					testAccCheckGitlabProjectVariableAttributes(&projectVariable, &testAccGitlabProjectVariableExpectedAttributes{
-						Key:       fmt.Sprintf("key_%s", rString),
-						Value:     fmt.Sprintf("value-%s", rString),
-						Protected: false,
-					}),
-				),
+				Config: fmt.Sprintf(`
+resource "gitlab_project_variable" "foo" {
+  project = %d
+  key = "my_key"
+  value = "my_value"
+}
+`, ctx.project.ID),
+				Check: testAccCheckGitlabProjectVariableExists(ctx.client, "gitlab_project_variable.foo"),
 			},
-			// Update the project variable to enable "masked" for a value that does not meet masking requirements, and expect an error with no state change.
+			// Check that the variable is recreated if deleted out-of-band.
+			{
+				PreConfig: func() {
+					if _, err := ctx.client.ProjectVariables.RemoveVariable(ctx.project.ID, "my_key"); err != nil {
+						t.Fatalf("failed to remove variable: %v", err)
+					}
+				},
+				Config: fmt.Sprintf(`
+resource "gitlab_project_variable" "foo" {
+  project = %d
+  key = "my_key"
+  value = "my_value"
+}
+`, ctx.project.ID),
+				Check: testAccCheckGitlabProjectVariableExists(ctx.client, "gitlab_project_variable.foo"),
+			},
+			// Update the variable_type.
+			{
+				Config: fmt.Sprintf(`
+resource "gitlab_project_variable" "foo" {
+  project = %d
+  key = "my_key"
+  value = "my_value"
+  variable_type = "file"
+}
+`, ctx.project.ID),
+				Check: testAccCheckGitlabProjectVariableExists(ctx.client, "gitlab_project_variable.foo"),
+			},
+			// Update all other attributes.
+			{
+				Config: fmt.Sprintf(`
+resource "gitlab_project_variable" "foo" {
+  project = %d
+  key = "my_key"
+  value = "my_value_2"
+  protected = true
+  masked = true
+}
+`, ctx.project.ID),
+				Check: testAccCheckGitlabProjectVariableExists(ctx.client, "gitlab_project_variable.foo"),
+			},
+			{
+				ResourceName:      "gitlab_project_variable.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Try to update with an illegal masked variable.
 			// ref: https://docs.gitlab.com/ce/ci/variables/README.html#masked-variable-requirements
 			{
-				Config: testAccGitlabProjectVariableUpdateConfigMaskedBad(rString),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabProjectVariableExists("gitlab_project_variable.foo", &projectVariable),
-					testAccCheckGitlabProjectVariableAttributes(&projectVariable, &testAccGitlabProjectVariableExpectedAttributes{
-						Key:   fmt.Sprintf("key_%s", rString),
-						Value: fmt.Sprintf("value-%s", rString),
-					}),
-				),
+				Config: fmt.Sprintf(`
+resource "gitlab_project_variable" "foo" {
+  project = %d
+  key = "my_key"
+  value = <<EOF
+i am multiline
+EOF
+  masked = true
+}
+`, ctx.project.ID),
 				ExpectError: regexp.MustCompile(regexp.QuoteMeta(
 					"Invalid value for a masked variable. Check the masked variable requirements: https://docs.gitlab.com/ee/ci/variables/#masked-variable-requirements",
 				)),
-			},
-			// Update the project variable to to enable "masked" and meet masking requirements
-			// ref: https://docs.gitlab.com/ce/ci/variables/README.html#masked-variable-requirements
-			{
-				Config: testAccGitlabProjectVariableUpdateConfigMaskedGood(rString),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabProjectVariableExists("gitlab_project_variable.foo", &projectVariable),
-					testAccCheckGitlabProjectVariableAttributes(&projectVariable, &testAccGitlabProjectVariableExpectedAttributes{
-						Key:    fmt.Sprintf("key_%s", rString),
-						Value:  fmt.Sprintf("value-%s", rString),
-						Masked: true,
-					}),
-				),
-			},
-			// Update the project variable to toggle the options back
-			{
-				Config: testAccGitlabProjectVariableConfig(rString),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabProjectVariableExists("gitlab_project_variable.foo", &projectVariable),
-					testAccCheckGitlabProjectVariableAttributes(&projectVariable, &testAccGitlabProjectVariableExpectedAttributes{
-						Key:       fmt.Sprintf("key_%s", rString),
-						Value:     fmt.Sprintf("value-%s", rString),
-						Protected: false,
-					}),
-				),
 			},
 		},
 	})
 }
 
-func testAccCheckGitlabProjectVariableExists(n string, projectVariable *gitlab.ProjectVariable) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not Found: %s", n)
-		}
+func TestAccGitlabProjectVariable_scoped(t *testing.T) {
+	ctx := testAccGitlabProjectStart(t)
+	defer ctx.finish()
 
-		repoName := rs.Primary.Attributes["project"]
-		if repoName == "" {
-			return fmt.Errorf("No project ID is set")
-		}
-		key := rs.Primary.Attributes["key"]
-		if key == "" {
-			return fmt.Errorf("No variable key is set")
-		}
-		conn := testAccProvider.Meta().(*gitlab.Client)
-
-		gotVariable, _, err := conn.ProjectVariables.GetVariable(repoName, key)
-		if err != nil {
-			return err
-		}
-		*projectVariable = *gotVariable
-		return nil
-	}
-}
-
-type testAccGitlabProjectVariableExpectedAttributes struct {
-	Key       string
-	Value     string
-	Protected bool
-	Masked    bool
-}
-
-func testAccCheckGitlabProjectVariableAttributes(variable *gitlab.ProjectVariable, want *testAccGitlabProjectVariableExpectedAttributes) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		if variable.Key != want.Key {
-			return fmt.Errorf("got key %s; want %s", variable.Key, want.Key)
-		}
-
-		if variable.Value != want.Value {
-			return fmt.Errorf("got value %s; value %s", variable.Value, want.Value)
-		}
-
-		if variable.Protected != want.Protected {
-			return fmt.Errorf("got protected %t; want %t", variable.Protected, want.Protected)
-		}
-
-		if variable.Masked != want.Masked {
-			return fmt.Errorf("got masked %t; want %t", variable.Masked, want.Masked)
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckGitlabProjectVariableDestroy(s *terraform.State) error {
-	conn := testAccProvider.Meta().(*gitlab.Client)
-
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "gitlab_project" {
-			continue
-		}
-
-		gotRepo, resp, err := conn.Projects.GetProject(rs.Primary.ID, nil)
-		if err == nil {
-			if gotRepo != nil && fmt.Sprintf("%d", gotRepo.ID) == rs.Primary.ID {
-				if gotRepo.MarkedForDeletionAt == nil {
-					return fmt.Errorf("Repository still exists")
-				}
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		CheckDestroy: func(state *terraform.State) error {
+			// Destroy behavior is nondeterministic for variables with scopes in GitLab versions prior to 13.4
+			// ref: https://gitlab.com/gitlab-org/gitlab/-/merge_requests/39209
+			if isAtLeast134, err := isGitLabVersionAtLeast(ctx.client, "13.4"); err != nil {
+				return err
+			} else if isAtLeast134 {
+				return testAccGitlabProjectVariableCheckAllVariablesDestroyed(ctx)(state)
 			}
-		}
-		if resp.StatusCode != 404 {
-			return err
-		}
-		return nil
-	}
-	return nil
-}
-
-func testAccGitlabProjectVariableConfig(rString string) string {
-	return fmt.Sprintf(`
-resource "gitlab_project" "foo" {
-  name = "foo-%s"
-  description = "Terraform acceptance tests"
-
-  # So that acceptance tests can be run in a gitlab organization
-  # with no billing
-  visibility_level = "public"
-}
-
+			return nil
+		},
+		Steps: []resource.TestStep{
+			// Create a project variable from a project id
+			{
+				Config: fmt.Sprintf(`
 resource "gitlab_project_variable" "foo" {
-  project = "${gitlab_project.foo.id}"
-  key = "key_%s"
-  value = "value-%s"
-  variable_type = "env_var"
+  project = %d
+  key = "my_key"
+  value = "my_value"
 }
-	`, rString, rString, rString)
-}
-
-func testAccGitlabProjectVariableUpdateConfig(rString string) string {
-	return fmt.Sprintf(`
-resource "gitlab_project" "foo" {
-  name = "foo-%s"
-  description = "Terraform acceptance tests"
-
-  # So that acceptance tests can be run in a gitlab organization
-  # with no billing
-  visibility_level = "public"
-}
-
+`, ctx.project.ID),
+				Check: testAccCheckGitlabProjectVariableExists(ctx.client, "gitlab_project_variable.foo"),
+			},
+			// Update the scope.
+			{
+				Config: fmt.Sprintf(`
 resource "gitlab_project_variable" "foo" {
-  project = "${gitlab_project.foo.id}"
-  key = "key_%s"
-  value = "value-inverse-%s"
-  protected = true
+  project = %d
+  key = "my_key"
+  value = "my_value"
+  environment_scope = "foo"
 }
-	`, rString, rString, rString)
-}
-
-func testAccGitlabProjectVariableUpdateConfigMaskedBad(rString string) string {
-	return fmt.Sprintf(`
-resource "gitlab_project" "foo" {
-  name = "foo-%s"
-  description = "Terraform acceptance tests"
-
-  # So that acceptance tests can be run in a gitlab organization
-  # with no billing
-  visibility_level = "public"
-}
-
+`, ctx.project.ID),
+				Check: testAccCheckGitlabProjectVariableExists(ctx.client, "gitlab_project_variable.foo"),
+			},
+			// Add a second variable with the same key and different scope.
+			{
+				Config: fmt.Sprintf(`
 resource "gitlab_project_variable" "foo" {
-  project = "${gitlab_project.foo.id}"
-  key = "key_%s"
-  value = <<EOF
-value-%s"
-i am multiline
-EOF
-  variable_type = "env_var"
-  masked = true
-}
-	`, rString, rString, rString)
+  project = %[1]d
+  key = "my_key"
+  value = "my_value"
+  environment_scope = "foo"
 }
 
-func testAccGitlabProjectVariableUpdateConfigMaskedGood(rString string) string {
-	return fmt.Sprintf(`
-resource "gitlab_project" "foo" {
-  name = "foo-%s"
-  description = "Terraform acceptance tests"
-
-  # So that acceptance tests can be run in a gitlab organization
-  # with no billing
-  visibility_level = "public"
+resource "gitlab_project_variable" "bar" {
+  project = %[1]d
+  key = "my_key"
+  value = "my_value_2"
+  environment_scope = "bar"
 }
-
+`, ctx.project.ID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGitlabProjectVariableExists(ctx.client, "gitlab_project_variable.foo"),
+					testAccCheckGitlabProjectVariableExists(ctx.client, "gitlab_project_variable.bar"),
+				),
+			},
+			{
+				ResourceName:      "gitlab_project_variable.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				ResourceName:      "gitlab_project_variable.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			// Update an attribute on one of the variables.
+			// Updating a variable with a non-unique key only works reliably on GitLab v13.4+.
+			{
+				SkipFunc: func() (bool, error) {
+					isAtLeast134, err := isGitLabVersionAtLeast(ctx.client, "13.4")
+					return !isAtLeast134, err
+				},
+				Config: fmt.Sprintf(`
 resource "gitlab_project_variable" "foo" {
-  project = "${gitlab_project.foo.id}"
-  key = "key_%s"
-  value = "value-%s"
-  variable_type = "env_var"
-  masked = true
+  project = %[1]d
+  key = "my_key"
+  value = "my_value"
+  environment_scope = "foo"
 }
-	`, rString, rString, rString)
+
+resource "gitlab_project_variable" "bar" {
+  project = %[1]d
+  key = "my_key"
+  value = "my_value_2_updated"
+  environment_scope = "bar"
+}
+`, ctx.project.ID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGitlabProjectVariableExists(ctx.client, "gitlab_project_variable.foo"),
+					testAccCheckGitlabProjectVariableExists(ctx.client, "gitlab_project_variable.bar"),
+				),
+			},
+			// Try to have two variables with the same keys and scopes.
+			// On versions of GitLab < 13.4 this can sometimes result in an inconsistent state instead of an error.
+			{
+				SkipFunc: func() (bool, error) {
+					isAtLeast134, err := isGitLabVersionAtLeast(ctx.client, "13.4")
+					return !isAtLeast134, err
+				},
+				Config: fmt.Sprintf(`
+resource "gitlab_project_variable" "foo" {
+  project = %[1]d
+  key = "my_key"
+  value = "my_value"
+  environment_scope = "foo"
+}
+
+resource "gitlab_project_variable" "bar" {
+  project = %[1]d
+  key = "my_key"
+  value = "my_value_2"
+  environment_scope = "foo"
+}
+`, ctx.project.ID),
+				ExpectError: regexp.MustCompile(regexp.QuoteMeta("(my_key) has already been taken")),
+			},
+		},
+	})
 }

--- a/gitlab/resource_gitlab_project_variable_test.go
+++ b/gitlab/resource_gitlab_project_variable_test.go
@@ -234,7 +234,7 @@ func TestAccGitlabProjectVariable_scoped(t *testing.T) {
 		CheckDestroy: func(state *terraform.State) error {
 			// Destroy behavior is nondeterministic for variables with scopes in GitLab versions prior to 13.4
 			// ref: https://gitlab.com/gitlab-org/gitlab/-/merge_requests/39209
-			if isAtLeast134, err := isGitLabVersionAtLeast(ctx.client, "13.4"); err != nil {
+			if isAtLeast134, err := isGitLabVersionAtLeast(ctx.client, "13.4")(); err != nil {
 				return err
 			} else if isAtLeast134 {
 				return testAccGitlabProjectVariableCheckAllVariablesDestroyed(ctx)(state)
@@ -300,10 +300,7 @@ resource "gitlab_project_variable" "bar" {
 			// Update an attribute on one of the variables.
 			// Updating a variable with a non-unique key only works reliably on GitLab v13.4+.
 			{
-				SkipFunc: func() (bool, error) {
-					isAtLeast134, err := isGitLabVersionAtLeast(ctx.client, "13.4")
-					return !isAtLeast134, err
-				},
+				SkipFunc: isGitLabVersionLessThan(ctx.client, "13.4"),
 				Config: fmt.Sprintf(`
 resource "gitlab_project_variable" "foo" {
   project = %[1]d
@@ -327,10 +324,7 @@ resource "gitlab_project_variable" "bar" {
 			// Try to have two variables with the same keys and scopes.
 			// On versions of GitLab < 13.4 this can sometimes result in an inconsistent state instead of an error.
 			{
-				SkipFunc: func() (bool, error) {
-					isAtLeast134, err := isGitLabVersionAtLeast(ctx.client, "13.4")
-					return !isAtLeast134, err
-				},
+				SkipFunc: isGitLabVersionLessThan(ctx.client, "13.4"),
 				Config: fmt.Sprintf(`
 resource "gitlab_project_variable" "foo" {
   project = %[1]d

--- a/gitlab/util.go
+++ b/gitlab/util.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -181,9 +182,24 @@ func parseTwoPartID(id string) (string, string, error) {
 	return parts[0], parts[1], nil
 }
 
+// parseThreePartID returns the pieces of id `a:b:c` as a, b, c.
+func parseThreePartID(id string) (string, string, string, error) {
+	parts := strings.SplitN(id, ":", 3)
+	if len(parts) != 3 {
+		return "", "", "", fmt.Errorf("Unexpected ID format (%q). Expected string:string:string", id)
+	}
+
+	return parts[0], parts[1], parts[2], nil
+}
+
 // format the strings into an id `a:b`
 func buildTwoPartID(a, b *string) string {
 	return fmt.Sprintf("%s:%s", *a, *b)
+}
+
+// buildMultiPartID formats the strings into an id `a:b:c`, taking any number of parts.
+func buildMultiPartID(parts ...string) string {
+	return strings.Join(parts, ":")
 }
 
 var accessLevelID = map[string]gitlab.AccessLevelValue{
@@ -216,4 +232,48 @@ func stringSetToStringSlice(stringSet *schema.Set) *[]string {
 		ret = append(ret, envVal.(string))
 	}
 	return &ret
+}
+
+// isGitLabVersionAtLeast checks that the version of GitLab is at least the provided wantVersion.
+// It only checks the major and minor version numbers, not the patch.
+func isGitLabVersionAtLeast(client *gitlab.Client, wantVersion string) (bool, error) {
+	wantMajor, wantMinor, err := parseVersionMajorMinor(wantVersion)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse wanted version %q: %w", wantVersion, err)
+	}
+
+	actualVersion, _, err := client.Version.GetVersion()
+	if err != nil {
+		return false, err
+	}
+
+	actualMajor, actualMinor, err := parseVersionMajorMinor(actualVersion.Version)
+	if err != nil {
+		return false, fmt.Errorf("failed to parse actual version %q: %w", actualVersion.Version, err)
+	}
+
+	if actualMajor == wantMajor {
+		return actualMinor >= wantMinor, nil
+	}
+
+	return actualMajor > wantMajor, nil
+}
+
+func parseVersionMajorMinor(version string) (int, int, error) {
+	parts := strings.SplitN(version, ".", 3)
+	if len(parts) < 2 {
+		return 0, 0, fmt.Errorf("failed to parse version %q", version)
+	}
+
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to parse version %q: %w", version, err)
+	}
+
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to parse version %q: %w", version, err)
+	}
+
+	return major, minor, nil
 }

--- a/website/docs/r/project_variable.html.markdown
+++ b/website/docs/r/project_variable.html.markdown
@@ -12,6 +12,7 @@ This resource allows you to create and manage CI/CD variables for your GitLab pr
 For further information on variables, consult the [gitlab
 documentation](https://docs.gitlab.com/ce/ci/variables/README.html#variables).
 
+~> **Important:** If your GitLab version is older than 13.4, you may see nondeterministic behavior when updating or deleting `gitlab_project_variable` resources with non-unique keys, for example if there is another variable with the same key and different environment scope.
 
 ## Example Usage
 
@@ -40,12 +41,12 @@ The following arguments are supported:
 
 * `masked` - (Optional, boolean) If set to `true`, the variable will be masked if it would have been written to the logs. Defaults to `false`.
 
-* `environment_scope` -  (Optional, string) The environment_scope of the variable
+* `environment_scope` -  (Optional, string) The environment_scope of the variable. Defaults to `*`.
 
 ## Import
 
-GitLab project variables can be imported using an id made up of `projectid:variablename`, e.g.
+GitLab project variables can be imported using an id made up of `project:key:environment_scope`, e.g.
 
 ```
-$ terraform import gitlab_project_variable.example 12345:project_variable_key
+$ terraform import gitlab_project_variable.example '12345:project_variable_key:*'
 ```

--- a/website/docs/r/project_variable.html.markdown
+++ b/website/docs/r/project_variable.html.markdown
@@ -12,7 +12,10 @@ This resource allows you to create and manage CI/CD variables for your GitLab pr
 For further information on variables, consult the [gitlab
 documentation](https://docs.gitlab.com/ce/ci/variables/README.html#variables).
 
-~> **Important:** If your GitLab version is older than 13.4, you may see nondeterministic behavior when updating or deleting `gitlab_project_variable` resources with non-unique keys, for example if there is another variable with the same key and different environment scope.
+~> **Important:** If your GitLab version is older than 13.4, you may see nondeterministic behavior
+when updating or deleting `gitlab_project_variable` resources with non-unique keys, for example if
+there is another variable with the same key and different environment scope. See
+[this GitLab issue](https://gitlab.com/gitlab-org/gitlab/-/issues/9912).
 
 ## Example Usage
 


### PR DESCRIPTION
Supersedes  #324
Fixes #213
Fixes #195
Fixes #278

**tl;dr** I borrowed just the read function logic from #324 and added the `environment_scope` filter query to the update and delete functions.

This PR fixes a behavior where `gitlab_project_variable` resources for keys with multiple environment scopes were not reading data from a unique variable, but could read from any variable with the specified key, causing unexpected drift.

For users with the [feature flag on](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/34490) or who are using [GitLab 13.4+](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/39209), this also lets them change environment scopes and remove variables with environment scopes, for `gitlab_project_variable` resources that have non-unique keys.

Note that one big difference between this and #324 is that I decided to only modify the read function, and not modify the update or delete functions, apart from adding the `environment_scope` filter query. I thought that those functions as implemented in #324 were not idempotent-safe. I would rather wait for a proper fix from GitLab (see previous paragraph) than try to work around the API in the provider for older GitLab versions. The `environment_scope` filter query in those functions ensures that people using the feature flag or on future versions of GitLab will have a better time.

I tried using a `MigrateState` in the schema to handle the ID format change, but it didn't work when I tested it. I ended up with an ID format error. Instead, I have the read function handle both ID formats.

Note that the `gitlab/resource_gitlab_project_variable_test.go` file is easier to review side-by-side than inline, since I rewrote it from scratch to make sure it was exercising all behaviors.

I've tested this locally with GitLab v13.1 and v13.4 to make sure both versions work.

Incidentally this PR is a step toward #205, by having a destroy test that leaves the GitLab project alone and checks that the resources under test are removed from GitLab.