### PR TITLE
import of release workflow from provider scafolding

### DIFF
--- a/.github/.goreleaser.yml
+++ b/.github/.goreleaser.yml
@@ -1,0 +1,54 @@
+# Visit https://goreleaser.com for documentation on how to customize this
+# behavior.
+before:
+    hooks:
+      # this is just an example and not a requirement for provider building/publishing
+      - go mod tidy
+  builds:
+  - env:
+      # goreleaser does not work with CGO, it could also complicate
+      # usage by users in CI/CD systems like Terraform Cloud where
+      # they are unable to install libraries.
+      - CGO_ENABLED=0
+    mod_timestamp: '{{ .CommitTimestamp }}'
+    flags:
+      - -trimpath
+    ldflags:
+      - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+    goos:
+      - freebsd
+      - windows
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - '386'
+      - arm
+      - arm64
+    ignore:
+      - goos: darwin
+        goarch: '386'
+    binary: '{{ .ProjectName }}_v{{ .Version }}'
+  archives:
+  - format: zip
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+  checksum:
+    name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+    algorithm: sha256
+  signs:
+    - artifacts: checksum
+      args:
+        # if you are using this is a GitHub action or some other automated pipeline, you 
+        # need to pass the batch flag to indicate its not interactive.
+        - "--batch"
+        - "--local-user"
+        - "{{ .Env.GPG_FINGERPRINT }}" # set this environment variable for your signing key
+        - "--output"
+        - "${signature}"
+        - "--detach-sign"
+        - "${artifact}"
+  release:
+    # If you want to manually examine the release before its live, uncomment this line:
+    # draft: true
+  changelog:
+    skip: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+# This GitHub action can publish assets for release when a tag is created.
+# Currently its setup to run on any tag that matches the pattern "v*" (ie. v0.1.0).
+#
+# This uses an action (paultyng/ghaction-import-gpg) that assumes you set your 
+# private key in the `GPG_PRIVATE_KEY` secret and passphrase in the `PASSPHRASE`
+# secret. If you would rather own your own GPG handling, please fork this action
+# or use an alternative one for key handling.
+#
+# You will need to pass the `--batch` flag to `gpg` in your signing step 
+# in `goreleaser` to indicate this is being used in a non-interactive mode.
+#
+name: release
+on:
+  push:
+    tags:
+      - 'v*'
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Unshallow
+        run: git fetch --prune --unshallow
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.14
+      -
+        name: Import GPG key
+        id: import_gpg
+        uses: paultyng/ghaction-import-gpg@v2.1.0
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
As taken from [terraform-provider-scaffolding](https://github.com/hashicorp/terraform-provider-scaffolding)

This workflow creates a draft release with all the required binary artifacts that the hashicorp registry requires. It requires an admin to set a github secret called GPG_PRIVATE_KEY which is the gpg  key with which the binaries will be signed

This workflow is a required step for achieving #411 