### PR TITLE
Adding support for project templates

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -21,6 +21,7 @@ jobs:
         echo "::set-env name=MAKE_TARGET::testacc"
         echo "::set-env name=GO_FLAGS::-mod=vendor"
         echo "::set-env name=GO111MODULE::on"
+        echo "::set-env name=GITLAB_EE::no"
         echo "::set-env name=GITLAB_TOKEN::20char-testing-token"
         echo "::set-env name=GITLAB_BASE_URL::http://127.0.0.1:8080/api/v4"
 
@@ -58,6 +59,7 @@ jobs:
         echo "::set-env name=MAKE_TARGET::testacc"
         echo "::set-env name=GO_FLAGS::-mod=vendor"
         echo "::set-env name=GO111MODULE::on"
+        echo "::set-env name=GITLAB_EE::yes"
         echo "::set-env name=GITLAB_TOKEN::20char-testing-token"
         echo "::set-env name=GITLAB_BASE_URL::http://127.0.0.1:8080/api/v4"
         echo "::set-env name=TF_LOG::DEBUG"

--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -208,6 +208,22 @@ var resourceGitLabProjectSchema = map[string]*schema.Schema{
 		Type:     schema.TypeBool,
 		Optional: true,
 	},
+	"template_name": {
+		Type:     schema.TypeString,
+		Optional: true,
+	},
+	"template_project_id": {
+		Type:     schema.TypeInt,
+		Optional: true,
+	},
+	"use_custom_template": {
+		Type:     schema.TypeBool,
+		Optional: true,
+	},
+	"group_with_project_templates_id": {
+		Type:     schema.TypeInt,
+		Optional: true,
+	},
 }
 
 func resourceGitlabProject() *schema.Resource {
@@ -299,6 +315,22 @@ func resourceGitlabProjectCreate(d *schema.ResourceData, meta interface{}) error
 
 	if v, ok := d.GetOk("import_url"); ok {
 		options.ImportURL = gitlab.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("template_name"); ok {
+		options.TemplateName = gitlab.String(v.(string))
+	}
+
+	if v, ok := d.GetOk("template_project_id"); ok {
+		options.TemplateProjectID = gitlab.Int(v.(int))
+	}
+
+	if v, ok := d.GetOk("use_custom_template"); ok {
+		options.UseCustomTemplate = gitlab.Bool(v.(bool))
+	}
+
+	if v, ok := d.GetOk("group_with_project_templates_id"); ok {
+		options.GroupWithProjectTemplatesID = gitlab.Int(v.(int))
 	}
 
 	log.Printf("[DEBUG] create gitlab project %q", *options.Name)

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,10 @@
 module github.com/gitlabhq/terraform-provider-gitlab
 
 require (
+	github.com/hashicorp/go-retryablehttp v0.6.4
 	github.com/hashicorp/terraform-plugin-sdk v1.13.1
 	github.com/mitchellh/hashstructure v1.0.0
-	github.com/xanzy/go-gitlab v0.34.1
+	github.com/xanzy/go-gitlab v0.37.0
 )
 
 go 1.14

--- a/go.sum
+++ b/go.sum
@@ -194,6 +194,8 @@ github.com/vmihailenco/msgpack v4.0.1+incompatible h1:RMF1enSPeKTlXrXdOcqjFUElyw
 github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/xanzy/go-gitlab v0.34.1 h1:Dtqla2gWIQIevfZVS6FY4qjgrKf+5LYLzW6XBNstGSw=
 github.com/xanzy/go-gitlab v0.34.1/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
+github.com/xanzy/go-gitlab v0.37.0 h1:Z/CQkjj5VwbWVYVL7S70kS/TFj5H/pJumV7xbJ0YUQ8=
+github.com/xanzy/go-gitlab v0.37.0/go.mod h1:sPLojNBn68fMUWSxIJtdVVIP8uSBYqesTfDUseX11Ug=
 github.com/zclconf/go-cty v1.0.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.1.0/go.mod h1:xnAOWiHeOqg2nWS62VtQ7pbOu17FtxJNW8RLEih+O3s=
 github.com/zclconf/go-cty v1.2.1 h1:vGMsygfmeCl4Xb6OA5U5XVAaQZ69FvoG7X2jUtQujb8=

--- a/scripts/start-gitlab.sh
+++ b/scripts/start-gitlab.sh
@@ -41,4 +41,24 @@ echo "Creating access token"
 ) |
 docker exec -i gitlab gitlab-rails console
 
-
+# Works on CE too
+echo
+echo "Creating an instance level template group with a simple template based on rails"
+(
+  echo -n 'group_template = Group.new('
+  echo -n 'name: :terraform, '
+  echo -n 'path: :terraform);'
+  echo -n 'group_template.save!;'
+  echo -n 'application_settings = ApplicationSetting.find_by "";'
+  echo -n 'application_settings.custom_project_templates_group_id = group_template.id;'
+  echo -n 'application_settings.save!;'
+  echo -n 'attrs = {'
+  echo -n 'name: :myrails, '
+  echo -n 'path: :myrails, '
+  echo -n 'namespace_id: group_template.id, '
+  echo -n 'template_name: :rails, '
+  echo -n 'id: 999};'
+  echo -n 'project = ::Projects::CreateService.new(User.find_by_username("root"), attrs).execute;'
+  echo -n 'project.saved?;'
+) |
+docker exec -i gitlab gitlab-rails console

--- a/vendor/github.com/xanzy/go-gitlab/client_options.go
+++ b/vendor/github.com/xanzy/go-gitlab/client_options.go
@@ -24,6 +24,16 @@ func WithCustomBackoff(backoff retryablehttp.Backoff) ClientOptionFunc {
 	}
 }
 
+// WithCustomLimiter injects a custom rate limiter to the client.
+func WithCustomLimiter(limiter RateLimiter) ClientOptionFunc {
+	return func(c *Client) error {
+		c.configureLimiterOnce.Do(func() {
+			c.limiter = limiter
+		})
+		return nil
+	}
+}
+
 // WithCustomRetry can be used to configure a custom retry policy.
 func WithCustomRetry(checkRetry retryablehttp.CheckRetry) ClientOptionFunc {
 	return func(c *Client) error {

--- a/vendor/github.com/xanzy/go-gitlab/epics.go
+++ b/vendor/github.com/xanzy/go-gitlab/epics.go
@@ -30,16 +30,12 @@ type Epic struct {
 	ID                      int         `json:"id"`
 	IID                     int         `json:"iid"`
 	GroupID                 int         `json:"group_id"`
-	Author                  *EpicAuthor `json:"author"`
+	ParentID                int         `json:"parent_id"`
+	Title                   string      `json:"title"`
 	Description             string      `json:"description"`
 	State                   string      `json:"state"`
-	Upvotes                 int         `json:"upvotes"`
-	Downvotes               int         `json:"downvotes"`
-	Labels                  []string    `json:"labels"`
-	Title                   string      `json:"title"`
-	UpdatedAt               *time.Time  `json:"updated_at"`
-	CreatedAt               *time.Time  `json:"created_at"`
-	UserNotesCount          int         `json:"user_notes_count"`
+	WebURL                  string      `json:"web_url"`
+	Author                  *EpicAuthor `json:"author"`
 	StartDate               *ISOTime    `json:"start_date"`
 	StartDateIsFixed        bool        `json:"start_date_is_fixed"`
 	StartDateFixed          *ISOTime    `json:"start_date_fixed"`
@@ -48,6 +44,13 @@ type Epic struct {
 	DueDateIsFixed          bool        `json:"due_date_is_fixed"`
 	DueDateFixed            *ISOTime    `json:"due_date_fixed"`
 	DueDateFromMilestones   *ISOTime    `json:"due_date_from_milestones"`
+	CreatedAt               *time.Time  `json:"created_at"`
+	UpdatedAt               *time.Time  `json:"updated_at"`
+	Labels                  []string    `json:"labels"`
+	Upvotes                 int         `json:"upvotes"`
+	Downvotes               int         `json:"downvotes"`
+	UserNotesCount          int         `json:"user_notes_count"`
+	URL                     string      `json:"url"`
 }
 
 func (e Epic) String() string {
@@ -59,12 +62,20 @@ func (e Epic) String() string {
 // GitLab API docs: https://docs.gitlab.com/ee/api/epics.html#list-epics-for-a-group
 type ListGroupEpicsOptions struct {
 	ListOptions
-	State    *string `url:"state,omitempty" json:"state,omitempty"`
-	Labels   Labels  `url:"labels,comma,omitempty" json:"labels,omitempty"`
-	AuthorID *int    `url:"author_id,omitempty" json:"author_id,omitempty"`
-	OrderBy  *string `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort     *string `url:"sort,omitempty" json:"sort,omitempty"`
-	Search   *string `url:"search,omitempty" json:"search,omitempty"`
+	AuthorID                *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
+	Labels                  Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	WithLabelDetails        *bool      `url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
+	OrderBy                 *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort                    *string    `url:"sort,omitempty" json:"sort,omitempty"`
+	Search                  *string    `url:"search,omitempty" json:"search,omitempty"`
+	State                   *string    `url:"state,omitempty" json:"state,omitempty"`
+	CreatedAfter            *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
+	CreatedBefore           *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
+	UpdatedAfter            *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
+	UpdatedBefore           *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
+	IncludeAncestorGroups   *bool      `url:"include_ancestor_groups,omitempty" json:"include_ancestor_groups,omitempty"`
+	IncludeDescendantGroups *bool      `url:"include_descendant_groups,omitempty" json:"include_descendant_groups,omitempty"`
+	MyReactionEmoji         *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
 }
 
 // ListGroupEpics gets a list of group epics. This function accepts pagination
@@ -109,6 +120,30 @@ func (s *EpicsService) GetEpic(gid interface{}, epic int, options ...RequestOpti
 
 	e := new(Epic)
 	resp, err := s.client.Do(req, e)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return e, resp, err
+}
+
+// GetEpicLinks gets all child epics of an epic.
+//
+// GitLab API docs: https://docs.gitlab.com/ee/api/epic_links.html
+func (s *EpicsService) GetEpicLinks(gid interface{}, epic int, options ...RequestOptionFunc) ([]*Epic, *Response, error) {
+	group, err := parseID(gid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("groups/%s/epics/%d/epics", pathEscape(group), epic)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var e []*Epic
+	resp, err := s.client.Do(req, &e)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/vendor/github.com/xanzy/go-gitlab/gitlab.go
+++ b/vendor/github.com/xanzy/go-gitlab/gitlab.go
@@ -80,7 +80,7 @@ type Client struct {
 	configureLimiterOnce sync.Once
 
 	// Limiter is used to limit API calls and prevent 429 responses.
-	limiter *rate.Limiter
+	limiter RateLimiter
 
 	// Token type used to make authenticated API calls.
 	authType authType
@@ -127,6 +127,7 @@ type Client struct {
 	GroupVariables        *GroupVariablesService
 	Groups                *GroupsService
 	InstanceCluster       *InstanceClustersService
+	InstanceVariables     *InstanceVariablesService
 	IssueLinks            *IssueLinksService
 	Issues                *IssuesService
 	IssuesStatistics      *IssuesStatisticsService
@@ -183,6 +184,11 @@ type ListOptions struct {
 
 	// For paginated result sets, the number of results to include per page.
 	PerPage int `url:"per_page,omitempty" json:"per_page,omitempty"`
+}
+
+// RateLimiter describes the interface that all (custom) rate limiters must implement.
+type RateLimiter interface {
+	Wait(context.Context) error
 }
 
 // NewClient returns a new GitLab API client. To use API methods which require
@@ -626,15 +632,16 @@ func (c *Client) Do(req *retryablehttp.Request, v interface{}) (*Response, error
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusUnauthorized && c.authType == basicAuth {
+		resp.Body.Close()
 		// The token most likely expired, so we need to request a new one and try again.
 		if _, err := c.requestOAuthToken(req.Context(), basicAuthToken); err != nil {
 			return nil, err
 		}
 		return c.Do(req, v)
 	}
+	defer resp.Body.Close()
 
 	response := newResponse(resp)
 
@@ -667,8 +674,8 @@ func (c *Client) requestOAuthToken(ctx context.Context, token string) (string, e
 
 	config := &oauth2.Config{
 		Endpoint: oauth2.Endpoint{
-			AuthURL:  fmt.Sprintf("%s://%s/oauth/authorize", c.BaseURL().Scheme, c.BaseURL().Host),
-			TokenURL: fmt.Sprintf("%s://%s/oauth/token", c.BaseURL().Scheme, c.BaseURL().Host),
+			AuthURL:  strings.TrimSuffix(c.baseURL.String(), apiVersionPath) + "oauth/authorize",
+			TokenURL: strings.TrimSuffix(c.baseURL.String(), apiVersionPath) + "oauth/token",
 		},
 	}
 

--- a/vendor/github.com/xanzy/go-gitlab/groups.go
+++ b/vendor/github.com/xanzy/go-gitlab/groups.go
@@ -398,7 +398,7 @@ func (s *GroupsService) ListGroupLDAPLinks(gid interface{}, options ...RequestOp
 type AddGroupLDAPLinkOptions struct {
 	CN          *string `url:"cn,omitempty" json:"cn,omitempty"`
 	GroupAccess *int    `url:"group_access,omitempty" json:"group_access,omitempty"`
-	Provider    *string `url:"provider,omitempty" json:"provider,ommitempty"`
+	Provider    *string `url:"provider,omitempty" json:"provider,omitempty"`
 }
 
 // AddGroupLDAPLink creates a new group LDAP link. Available only for users who

--- a/vendor/github.com/xanzy/go-gitlab/instance_clusters.go
+++ b/vendor/github.com/xanzy/go-gitlab/instance_clusters.go
@@ -56,7 +56,7 @@ func (v InstanceCluster) String() string {
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/instance_clusters.html#list-instance-clusters
 func (s *InstanceClustersService) ListClusters(options ...RequestOptionFunc) ([]*InstanceCluster, *Response, error) {
-	u := fmt.Sprintf("admin/clusters")
+	u := "admin/clusters"
 
 	req, err := s.client.NewRequest("GET", u, nil, options)
 	if err != nil {
@@ -98,7 +98,7 @@ func (s *InstanceClustersService) GetCluster(cluster int, options ...RequestOpti
 // GitLab API docs:
 // https://docs.gitlab.com/ee/api/instance_clusters.html#add-existing-instance-cluster
 func (s *InstanceClustersService) AddCluster(opt *AddClusterOptions, options ...RequestOptionFunc) (*InstanceCluster, *Response, error) {
-	u := fmt.Sprintf("admin/clusters/add")
+	u := "admin/clusters/add"
 
 	req, err := s.client.NewRequest("POST", u, opt, options)
 	if err != nil {

--- a/vendor/github.com/xanzy/go-gitlab/instance_variables.go
+++ b/vendor/github.com/xanzy/go-gitlab/instance_variables.go
@@ -1,0 +1,179 @@
+//
+// Copyright 2018, Patrick Webster
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package gitlab
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// InstanceVariablesService handles communication with the
+// instance level CI variables related methods of the GitLab API.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/instance_level_ci_variables.html
+type InstanceVariablesService struct {
+	client *Client
+}
+
+// InstanceVariable represents a GitLab instance level CI Variable.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/instance_level_ci_variables.html
+type InstanceVariable struct {
+	Key          string            `json:"key"`
+	Value        string            `json:"value"`
+	VariableType VariableTypeValue `json:"variable_type"`
+	Protected    bool              `json:"protected"`
+	Masked       bool              `json:"masked"`
+}
+
+func (v InstanceVariable) String() string {
+	return Stringify(v)
+}
+
+// ListInstanceVariablesOptions represents the available options for listing variables
+// for an instance.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/instance_level_ci_variables.html#list-all-instance-variables
+type ListInstanceVariablesOptions ListOptions
+
+// ListVariables gets a list of all variables for an instance.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/instance_level_ci_variables.html#list-all-instance-variables
+func (s *InstanceVariablesService) ListVariables(opt *ListInstanceVariablesOptions, options ...RequestOptionFunc) ([]*InstanceVariable, *Response, error) {
+	u := "admin/ci/variables"
+
+	req, err := s.client.NewRequest("GET", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var vs []*InstanceVariable
+	resp, err := s.client.Do(req, &vs)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return vs, resp, err
+}
+
+// GetVariable gets a variable.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/instance_level_ci_variables.html#show-instance-variable-details
+func (s *InstanceVariablesService) GetVariable(key string, options ...RequestOptionFunc) (*InstanceVariable, *Response, error) {
+	u := fmt.Sprintf("admin/ci/variables/%s", url.PathEscape(key))
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	v := new(InstanceVariable)
+	resp, err := s.client.Do(req, v)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return v, resp, err
+}
+
+// CreateInstanceVariableOptions represents the available CreateVariable()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/instance_level_ci_variables.html#create-instance-variable
+type CreateInstanceVariableOptions struct {
+	Key          *string            `url:"key,omitempty" json:"key,omitempty"`
+	Value        *string            `url:"value,omitempty" json:"value,omitempty"`
+	VariableType *VariableTypeValue `url:"variable_type,omitempty" json:"variable_type,omitempty"`
+	Protected    *bool              `url:"protected,omitempty" json:"protected,omitempty"`
+	Masked       *bool              `url:"masked,omitempty" json:"masked,omitempty"`
+}
+
+// CreateVariable creates a new instance level CI variable.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/instance_level_ci_variables.html#create-instance-variable
+func (s *InstanceVariablesService) CreateVariable(opt *CreateInstanceVariableOptions, options ...RequestOptionFunc) (*InstanceVariable, *Response, error) {
+	u := "admin/ci/variables"
+
+	req, err := s.client.NewRequest("POST", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	v := new(InstanceVariable)
+	resp, err := s.client.Do(req, v)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return v, resp, err
+}
+
+// UpdateInstanceVariableOptions represents the available UpdateVariable()
+// options.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/instance_level_ci_variables.html#update-instance-variable
+type UpdateInstanceVariableOptions struct {
+	Value        *string            `url:"value,omitempty" json:"value,omitempty"`
+	VariableType *VariableTypeValue `url:"variable_type,omitempty" json:"variable_type,omitempty"`
+	Protected    *bool              `url:"protected,omitempty" json:"protected,omitempty"`
+	Masked       *bool              `url:"masked,omitempty" json:"masked,omitempty"`
+}
+
+// UpdateVariable updates the position of an existing
+// instance level CI variable.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/instance_level_ci_variables.html#update-instance-variable
+func (s *InstanceVariablesService) UpdateVariable(key string, opt *UpdateInstanceVariableOptions, options ...RequestOptionFunc) (*InstanceVariable, *Response, error) {
+	u := fmt.Sprintf("admin/ci/variables/%s", url.PathEscape(key))
+
+	req, err := s.client.NewRequest("PUT", u, opt, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	v := new(InstanceVariable)
+	resp, err := s.client.Do(req, v)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return v, resp, err
+}
+
+// RemoveVariable removes an instance level CI variable.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ee/api/instance_level_ci_variables.html#remove-instance-variable
+func (s *InstanceVariablesService) RemoveVariable(key string, options ...RequestOptionFunc) (*Response, error) {
+	u := fmt.Sprintf("admin/ci/variables/%s", url.PathEscape(key))
+
+	req, err := s.client.NewRequest("DELETE", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}

--- a/vendor/github.com/xanzy/go-gitlab/issues.go
+++ b/vendor/github.com/xanzy/go-gitlab/issues.go
@@ -17,6 +17,7 @@
 package gitlab
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -113,6 +114,7 @@ type Issue struct {
 	IssueLinkID          int              `json:"issue_link_id"`
 	MergeRequestCount    int              `json:"merge_requests_count"`
 	EpicIssueID          int              `json:"epic_issue_id"`
+	Epic                 *Epic            `json:"epic"`
 	TaskCompletionStatus struct {
 		Count          int `json:"count"`
 		CompletedCount int `json:"completed_count"`
@@ -162,7 +164,19 @@ type Labels []string
 
 // MarshalJSON implements the json.Marshaler interface.
 func (l *Labels) MarshalJSON() ([]byte, error) {
+	if *l == nil {
+		return []byte(`null`), nil
+	}
 	return json.Marshal(strings.Join(*l, ","))
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (l *Labels) UnmarshalJSON(data []byte) error {
+	type alias Labels
+	if !bytes.HasPrefix(data, []byte("[")) {
+		data = []byte(fmt.Sprintf("[%s]", string(data)))
+	}
+	return json.Unmarshal(data, (*alias)(l))
 }
 
 // EncodeValues implements the query.EncodeValues interface
@@ -186,23 +200,29 @@ type LabelDetails struct {
 // GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#list-issues
 type ListIssuesOptions struct {
 	ListOptions
-	State            *string    `url:"state,omitempty" json:"state,omitempty"`
-	Labels           Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
-	WithLabelDetails *bool      `url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
-	Milestone        *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
-	Scope            *string    `url:"scope,omitempty" json:"scope,omitempty"`
-	AuthorID         *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
-	AssigneeID       *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
-	MyReactionEmoji  *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
-	IIDs             []int      `url:"iids[],omitempty" json:"iids,omitempty"`
-	OrderBy          *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort             *string    `url:"sort,omitempty" json:"sort,omitempty"`
-	Search           *string    `url:"search,omitempty" json:"search,omitempty"`
-	CreatedAfter     *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
-	CreatedBefore    *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
-	UpdatedAfter     *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
-	UpdatedBefore    *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
-	Confidential     *bool      `url:"confidential,omitempty" json:"confidential,omitempty"`
+	State              *string    `url:"state,omitempty" json:"state,omitempty"`
+	Labels             Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	NotLabels          Labels     `url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
+	WithLabelDetails   *bool      `url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
+	Milestone          *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
+	NotMilestone       *string    `url:"not[milestone],omitempty" json:"not[milestone],omitempty"`
+	Scope              *string    `url:"scope,omitempty" json:"scope,omitempty"`
+	AuthorID           *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
+	NotAuthorID        []int      `url:"not[author_id],omitempty" json:"not[author_id],omitempty"`
+	AssigneeID         *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
+	NotAssigneeID      []int      `url:"not[assignee_id],omitempty" json:"not[assignee_id],omitempty"`
+	AssigneeUsername   *string    `url:"assignee_username,omitempty" json:"assignee_username,omitempty"`
+	MyReactionEmoji    *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
+	NotMyReactionEmoji []string   `url:"not[my_reaction_emoji],omitempty" json:"not[my_reaction_emoji],omitempty"`
+	IIDs               []int      `url:"iids[],omitempty" json:"iids,omitempty"`
+	OrderBy            *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort               *string    `url:"sort,omitempty" json:"sort,omitempty"`
+	Search             *string    `url:"search,omitempty" json:"search,omitempty"`
+	CreatedAfter       *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
+	CreatedBefore      *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
+	UpdatedAfter       *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
+	UpdatedBefore      *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
+	Confidential       *bool      `url:"confidential,omitempty" json:"confidential,omitempty"`
 }
 
 // ListIssues gets all issues created by authenticated user. This function
@@ -229,25 +249,30 @@ func (s *IssuesService) ListIssues(opt *ListIssuesOptions, options ...RequestOpt
 // GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#list-group-issues
 type ListGroupIssuesOptions struct {
 	ListOptions
-	State            *string    `url:"state,omitempty" json:"state,omitempty"`
-	Labels           Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
-	WithLabelDetails *bool      `url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
-	IIDs             []int      `url:"iids[],omitempty" json:"iids,omitempty"`
-	Milestone        *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
-	Scope            *string    `url:"scope,omitempty" json:"scope,omitempty"`
-	AuthorID         *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
-	AuthorUsername   *string    `url:"author_username,omitempty" json:"author_username,omitempty"`
-	AssigneeID       *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
-	AssigneeUsername *string    `url:"assignee_username,omitempty" json:"assignee_username,omitempty"`
-	MyReactionEmoji  *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
-	OrderBy          *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort             *string    `url:"sort,omitempty" json:"sort,omitempty"`
-	Search           *string    `url:"search,omitempty" json:"search,omitempty"`
-	In               *string    `url:"in,omitempty" json:"in,omitempty"`
-	CreatedAfter     *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
-	CreatedBefore    *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
-	UpdatedAfter     *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
-	UpdatedBefore    *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
+	State              *string    `url:"state,omitempty" json:"state,omitempty"`
+	Labels             Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	NotLabels          Labels     `url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
+	WithLabelDetails   *bool      `url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
+	IIDs               []int      `url:"iids[],omitempty" json:"iids,omitempty"`
+	Milestone          *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
+	NotMilestone       *string    `url:"not[milestone],omitempty" json:"not[milestone],omitempty"`
+	Scope              *string    `url:"scope,omitempty" json:"scope,omitempty"`
+	AuthorID           *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
+	NotAuthorID        []int      `url:"not[author_id],omitempty" json:"not[author_id],omitempty"`
+	AuthorUsername     *string    `url:"author_username,omitempty" json:"author_username,omitempty"`
+	AssigneeID         *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
+	NotAssigneeID      []int      `url:"not[assignee_id],omitempty" json:"not[assignee_id],omitempty"`
+	AssigneeUsername   *string    `url:"assignee_username,omitempty" json:"assignee_username,omitempty"`
+	MyReactionEmoji    *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
+	NotMyReactionEmoji []string   `url:"not[my_reaction_emoji],omitempty" json:"not[my_reaction_emoji],omitempty"`
+	OrderBy            *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort               *string    `url:"sort,omitempty" json:"sort,omitempty"`
+	Search             *string    `url:"search,omitempty" json:"search,omitempty"`
+	In                 *string    `url:"in,omitempty" json:"in,omitempty"`
+	CreatedAfter       *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
+	CreatedBefore      *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
+	UpdatedAfter       *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
+	UpdatedBefore      *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
 }
 
 // ListGroupIssues gets a list of group issues. This function accepts
@@ -280,24 +305,30 @@ func (s *IssuesService) ListGroupIssues(pid interface{}, opt *ListGroupIssuesOpt
 // GitLab API docs: https://docs.gitlab.com/ce/api/issues.html#list-project-issues
 type ListProjectIssuesOptions struct {
 	ListOptions
-	IIDs             []int      `url:"iids[],omitempty" json:"iids,omitempty"`
-	State            *string    `url:"state,omitempty" json:"state,omitempty"`
-	Labels           Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
-	WithLabelDetails *bool      `url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
-	Milestone        *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
-	Scope            *string    `url:"scope,omitempty" json:"scope,omitempty"`
-	AuthorID         *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
-	AssigneeID       *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
-	MyReactionEmoji  *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
-	OrderBy          *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
-	Sort             *string    `url:"sort,omitempty" json:"sort,omitempty"`
-	Search           *string    `url:"search,omitempty" json:"search,omitempty"`
-	In               *string    `url:"in,omitempty" json:"in,omitempty"`
-	CreatedAfter     *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
-	CreatedBefore    *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
-	UpdatedAfter     *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
-	UpdatedBefore    *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
-	Confidential     *bool      `url:"confidential,omitempty" json:"confidential,omitempty"`
+	IIDs               []int      `url:"iids[],omitempty" json:"iids,omitempty"`
+	State              *string    `url:"state,omitempty" json:"state,omitempty"`
+	Labels             Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	NotLabels          Labels     `url:"not[labels],comma,omitempty" json:"not[labels],omitempty"`
+	WithLabelDetails   *bool      `url:"with_labels_details,omitempty" json:"with_labels_details,omitempty"`
+	Milestone          *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
+	NotMilestone       []string   `url:"not[milestone],omitempty" json:"not[milestone],omitempty"`
+	Scope              *string    `url:"scope,omitempty" json:"scope,omitempty"`
+	AuthorID           *int       `url:"author_id,omitempty" json:"author_id,omitempty"`
+	NotAuthorID        []int      `url:"not[author_id],omitempty" json:"not[author_id],omitempty"`
+	AssigneeID         *int       `url:"assignee_id,omitempty" json:"assignee_id,omitempty"`
+	NotAssigneeID      []int      `url:"not[assignee_id],omitempty" json:"not[assignee_id],omitempty"`
+	AssigneeUsername   *string    `url:"assignee_username,omitempty" json:"assignee_username,omitempty"`
+	MyReactionEmoji    *string    `url:"my_reaction_emoji,omitempty" json:"my_reaction_emoji,omitempty"`
+	NotMyReactionEmoji []string   `url:"not[my_reaction_emoji],omitempty" json:"not[my_reaction_emoji],omitempty"`
+	OrderBy            *string    `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Sort               *string    `url:"sort,omitempty" json:"sort,omitempty"`
+	Search             *string    `url:"search,omitempty" json:"search,omitempty"`
+	In                 *string    `url:"in,omitempty" json:"in,omitempty"`
+	CreatedAfter       *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
+	CreatedBefore      *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
+	UpdatedAfter       *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
+	UpdatedBefore      *time.Time `url:"updated_before,omitempty" json:"updated_before,omitempty"`
+	Confidential       *bool      `url:"confidential,omitempty" json:"confidential,omitempty"`
 }
 
 // ListProjectIssues gets a list of project issues. This function accepts
@@ -401,6 +432,8 @@ type UpdateIssueOptions struct {
 	AssigneeIDs      []int      `url:"assignee_ids,omitempty" json:"assignee_ids,omitempty"`
 	MilestoneID      *int       `url:"milestone_id,omitempty" json:"milestone_id,omitempty"`
 	Labels           *Labels    `url:"labels,comma,omitempty" json:"labels,omitempty"`
+	AddLabels        *Labels    `url:"add_labels,comma,omitempty" json:"add_labels,omitempty"`
+	RemoveLabels     *Labels    `url:"remove_labels,comma,omitempty" json:"remove_labels,omitempty"`
 	StateEvent       *string    `url:"state_event,omitempty" json:"state_event,omitempty"`
 	UpdatedAt        *time.Time `url:"updated_at,omitempty" json:"updated_at,omitempty"`
 	DueDate          *ISOTime   `url:"due_date,omitempty" json:"due_date,omitempty"`
@@ -644,4 +677,29 @@ func (s *IssuesService) ResetSpentTime(pid interface{}, issue int, options ...Re
 // https://docs.gitlab.com/ce/api/issues.html#get-time-tracking-stats
 func (s *IssuesService) GetTimeSpent(pid interface{}, issue int, options ...RequestOptionFunc) (*TimeStats, *Response, error) {
 	return s.timeStats.getTimeSpent(pid, "issues", issue, options...)
+}
+
+// GetParticipants gets a list of issue participants.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/issues.html#participants-on-issues
+func (s *IssuesService) GetParticipants(pid interface{}, issue int, options ...RequestOptionFunc) ([]*BasicUser, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/issues/%d/participants", pathEscape(project), issue)
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var bu []*BasicUser
+	resp, err := s.client.Do(req, &bu)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return bu, resp, err
 }

--- a/vendor/github.com/xanzy/go-gitlab/merge_requests.go
+++ b/vendor/github.com/xanzy/go-gitlab/merge_requests.go
@@ -240,7 +240,7 @@ type ListProjectMergeRequestsOptions struct {
 	Sort            *string    `url:"sort,omitempty" json:"sort,omitempty"`
 	Milestone       *string    `url:"milestone,omitempty" json:"milestone,omitempty"`
 	View            *string    `url:"view,omitempty" json:"view,omitempty"`
-	Labels          *Labels    `url:"labels,omitempty" json:"labels,omitempty"`
+	Labels          Labels     `url:"labels,comma,omitempty" json:"labels,omitempty"`
 	CreatedAfter    *time.Time `url:"created_after,omitempty" json:"created_after,omitempty"`
 	CreatedBefore   *time.Time `url:"created_before,omitempty" json:"created_before,omitempty"`
 	UpdatedAfter    *time.Time `url:"updated_after,omitempty" json:"updated_after,omitempty"`
@@ -442,6 +442,31 @@ func (s *MergeRequestsService) ListMergeRequestPipelines(pid interface{}, mergeR
 
 	var p []*PipelineInfo
 	resp, err := s.client.Do(req, &p)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return p, resp, err
+}
+
+// CreateMergeRequestPipeline creates a new pipeline for a merge request.
+//
+// GitLab API docs:
+// https://docs.gitlab.com/ce/api/merge_requests.html#create-mr-pipeline
+func (s *MergeRequestsService) CreateMergeRequestPipeline(pid interface{}, mergeRequest int, options ...RequestOptionFunc) (*PipelineInfo, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/merge_requests/%d/pipelines", pathEscape(project), mergeRequest)
+
+	req, err := s.client.NewRequest("POST", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	p := new(PipelineInfo)
+	resp, err := s.client.Do(req, p)
 	if err != nil {
 		return nil, resp, err
 	}

--- a/vendor/github.com/xanzy/go-gitlab/pipeline_schedules.go
+++ b/vendor/github.com/xanzy/go-gitlab/pipeline_schedules.go
@@ -230,6 +230,25 @@ func (s *PipelineSchedulesService) DeletePipelineSchedule(pid interface{}, sched
 	return s.client.Do(req, nil)
 }
 
+// RunPipelineSchedule triggers a new scheduled pipeline to run immediately.
+//
+// Gitlab API docs:
+// https://docs.gitlab.com/ce/api/pipeline_schedules.html#run-a-scheduled-pipeline-immediately
+func (s *PipelineSchedulesService) RunPipelineSchedule(pid interface{}, schedule int, options ...RequestOptionFunc) (*Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, err
+	}
+	u := fmt.Sprintf("projects/%s/pipeline_schedules/%d/play", pathEscape(project), schedule)
+
+	req, err := s.client.NewRequest("POST", u, nil, options)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.Do(req, nil)
+}
+
 // CreatePipelineScheduleVariableOptions represents the available
 // CreatePipelineScheduleVariable() options.
 //

--- a/vendor/github.com/xanzy/go-gitlab/projects.go
+++ b/vendor/github.com/xanzy/go-gitlab/projects.go
@@ -503,6 +503,7 @@ type CreateProjectOptions struct {
 	MirrorTriggerBuilds                       *bool               `url:"mirror_trigger_builds,omitempty" json:"mirror_trigger_builds,omitempty"`
 	InitializeWithReadme                      *bool               `url:"initialize_with_readme,omitempty" json:"initialize_with_readme,omitempty"`
 	TemplateName                              *string             `url:"template_name,omitempty" json:"template_name,omitempty"`
+	TemplateProjectID                         *int                `url:"template_project_id,omitempty" json:"template_project_id,omitempty"`
 	UseCustomTemplate                         *bool               `url:"use_custom_template,omitempty" json:"use_custom_template,omitempty"`
 	GroupWithProjectTemplatesID               *int                `url:"group_with_project_templates_id,omitempty" json:"group_with_project_templates_id,omitempty"`
 	PackagesEnabled                           *bool               `url:"packages_enabled,omitempty" json:"packages_enabled,omitempty"`

--- a/vendor/github.com/xanzy/go-gitlab/services.go
+++ b/vendor/github.com/xanzy/go-gitlab/services.go
@@ -54,6 +54,30 @@ type Service struct {
 	WikiPageEvents           bool       `json:"wiki_page_events"`
 }
 
+// ListServices gets a list of all active services.
+//
+// GitLab API docs: https://docs.gitlab.com/ce/api/services.html#list-all-active-services
+func (s *ServicesService) ListServices(pid interface{}, options ...RequestOptionFunc) ([]*Service, *Response, error) {
+	project, err := parseID(pid)
+	if err != nil {
+		return nil, nil, err
+	}
+	u := fmt.Sprintf("projects/%s/services", pathEscape(project))
+
+	req, err := s.client.NewRequest("GET", u, nil, options)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var svcs []*Service
+	resp, err := s.client.Do(req, &svcs)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return svcs, resp, err
+}
+
 // DroneCIService represents Drone CI service settings.
 //
 // GitLab API docs:

--- a/vendor/github.com/xanzy/go-gitlab/tags.go
+++ b/vendor/github.com/xanzy/go-gitlab/tags.go
@@ -58,6 +58,7 @@ func (t Tag) String() string {
 type ListTagsOptions struct {
 	ListOptions
 	OrderBy *string `url:"order_by,omitempty" json:"order_by,omitempty"`
+	Search  *string `url:"search,omitempty" json:"search,omitempty"`
 	Sort    *string `url:"sort,omitempty" json:"sort,omitempty"`
 }
 

--- a/vendor/github.com/xanzy/go-gitlab/types.go
+++ b/vendor/github.com/xanzy/go-gitlab/types.go
@@ -402,14 +402,23 @@ func Time(v time.Time) *time.Time {
 // BoolValue is a boolean value with advanced json unmarshaling features.
 type BoolValue bool
 
-// UnmarshalJSON allows 1 and 0 to be considered as boolean values
-// Needed for https://gitlab.com/gitlab-org/gitlab-ce/issues/50122
+// UnmarshalJSON allows 1, 0, "true", and "false" to be considered as boolean values
+// Needed for:
+// https://gitlab.com/gitlab-org/gitlab-ce/issues/50122
+// https://gitlab.com/gitlab-org/gitlab/-/issues/233941
+// https://github.com/gitlabhq/terraform-provider-gitlab/issues/348
 func (t *BoolValue) UnmarshalJSON(b []byte) error {
 	switch string(b) {
 	case `"1"`:
 		*t = true
 		return nil
 	case `"0"`:
+		*t = false
+		return nil
+	case `"true"`:
+		*t = true
+		return nil
+	case `"false"`:
 		*t = false
 		return nil
 	default:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -94,6 +94,7 @@ github.com/hashicorp/go-multierror
 github.com/hashicorp/go-plugin
 github.com/hashicorp/go-plugin/internal/plugin
 # github.com/hashicorp/go-retryablehttp v0.6.4
+## explicit
 github.com/hashicorp/go-retryablehttp
 # github.com/hashicorp/go-safetemp v1.0.0
 github.com/hashicorp/go-safetemp
@@ -228,7 +229,7 @@ github.com/ulikunitz/xz/lzma
 # github.com/vmihailenco/msgpack v4.0.1+incompatible
 github.com/vmihailenco/msgpack
 github.com/vmihailenco/msgpack/codes
-# github.com/xanzy/go-gitlab v0.34.1
+# github.com/xanzy/go-gitlab v0.37.0
 ## explicit
 github.com/xanzy/go-gitlab
 # github.com/zclconf/go-cty v1.2.1

--- a/website/docs/r/project.html.markdown
+++ b/website/docs/r/project.html.markdown
@@ -83,6 +83,14 @@ The following arguments are supported:
 
 * `initialize_with_readme` - (Optional) Create master branch with first commit containing a README.md file.
 
+* `template_name` - (Optional) When used without use_custom_template, name of a built-in project template. When used with use_custom_template, name of a custom project template.
+
+* `template_project_id` - (Optional)  When used with use_custom_template, project ID of a custom project template. This is preferable to using template_name since template_name may be ambiguous (enterprise edition).
+
+* `use_custom_template` - (Optional) Use either custom instance or group (with group_with_project_templates_id) project template (enterprise edition).
+
+* `group_with_project_templates_id` - (Optional) For group-level custom templates, specifies ID of group from which all the custom project templates are sourced. Leave empty for instance-level templates. Requires use_custom_template to be true (enterprise edition).
+
 ## Attributes Reference
 
 The following additional attributes are exported:


### PR DESCRIPTION
Hello,

I added support to templates and custom templates (recreate from #277)

I re-use the same test than `initializereadme` (no state).

`use_custom_template`, `template_project_id` and `group_with_project_templates_id` are EE features
`template_name` is EE and CE feature.

I see that Gitlab will took probably this repo control #376 so they probably rework all tests to split EE and CE.
We could use `tags` with `go test` but i'm not confortable with that and we have to change everywhere

So to simplify EE tests, I added an environment variable `GITLAB_EE`, when we enter in this test, it's skipped when not EE.

on CE
```
=== RUN   TestAccGitlabProject_templateNameCustom
--- PASS: TestAccGitlabProject_templateNameCustom (0.00s)
=== RUN   TestAccGitlabProject_templateProjectID
--- PASS: TestAccGitlabProject_templateProjectID (0.00s)
```
In other hand, in `start-gitlab`, via rails, I: 
* create a group
* create a template repo (simple git repo)
* declare the group as a template in admin settings

Thoses lines works with CE too (so I don't remove them, if in future Gitlab move thoses EE features to CE, we just have to remove the GITLAB_EE test in tests)
