### PR TITLE
[Breaking] Fix gitlab_project and gitlab_project_share relationship

### DIFF
--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -74,11 +74,6 @@ The following arguments are supported:
 
 * `shared_runners_enabled` - (Optional) Enable shared runners for this project.
 
-* `shared_with_groups` - (Optional) Enable sharing the project with a list of groups (maps).
-  * `group_id` - (Required) Group id of the group you want to share the project with.
-  * `group_access_level` - (Required) Group's sharing permissions. See [group members permission][group_members_permissions] for more info.
-  Valid values are `guest`, `reporter`, `developer`, `maintainer`.
-
 * `archived` - (Optional) Whether the project is in read-only mode (archived). Repositories can be archived/unarchived by toggling this parameter.
 
 * `initialize_with_readme` - (Optional) Create master branch with first commit containing a README.md file.
@@ -100,9 +95,6 @@ The following additional attributes are exported:
 * `web_url` - URL that can be used to find the project in a browser.
 
 * `runners_token` - Registration token to use during runner setup.
-
-* `shared_with_groups` - List of the groups the project is shared with.
-  * `group_name` - Group's name.
 
 * `remove_source_branch_after_merge` - Enable `Delete source branch` option by default for all new merge requests.
 

--- a/gitlab/data_source_gitlab_projects.go
+++ b/gitlab/data_source_gitlab_projects.go
@@ -850,3 +850,19 @@ func dataSourceGitlabProjectsRead(d *schema.ResourceData, meta interface{}) (err
 	}
 	return err
 }
+
+func flattenSharedWithGroupsOptions(project *gitlab.Project) []interface{} {
+	var sharedWithGroupsList []interface{}
+
+	for _, option := range project.SharedWithGroups {
+		values := map[string]interface{}{
+			"group_id":           option.GroupID,
+			"group_access_level": accessLevelValueToName[gitlab.AccessLevelValue(option.GroupAccessLevel)],
+			"group_name":         option.GroupName,
+		}
+
+		sharedWithGroupsList = append(sharedWithGroupsList, values)
+	}
+
+	return sharedWithGroupsList
+}

--- a/gitlab/helper_test.go
+++ b/gitlab/helper_test.go
@@ -28,18 +28,6 @@ func testAccCompareGitLabAttribute(attr string, expected, received *schema.Resou
 	return nil
 }
 
-func testAccIsSkippedAttribute(needle string, haystack []string) bool {
-	if needle == "" {
-		return false
-	}
-	for _, hay := range haystack {
-		if hay == needle {
-			return true
-		}
-	}
-	return false
-}
-
 // Returns true if the acceptance test is running Gitlab EE.
 // Meant to be used as SkipFunc to skip tests that work only on Gitlab CE.
 func isRunningInEE() (bool, error) {


### PR DESCRIPTION
- resource/gitlab_project: remove `shared_with_groups` attribute
- resource/gitlab_project_share: fix update failing to change `access_level`

Part of #411 preparation

See discussion in #416 

Fixes #219 
