### PR TITLE
Fix the mirror-exists check in the mirror test

### DIFF
--- a/gitlab/resource_gitlab_project_mirror_test.go
+++ b/gitlab/resource_gitlab_project_mirror_test.go
@@ -112,11 +112,10 @@ func testAccCheckGitlabProjectMirrorExists(n string, mirror *gitlab.ProjectMirro
 		for _, m := range mirrors {
 			if m.ID == mirrorID {
 				*mirror = *m
-				break
+				return nil
 			}
-			return errors.New("unable to find mirror.")
 		}
-		return nil
+		return errors.New("unable to find mirror")
 	}
 }
 


### PR DESCRIPTION
This was caught by [staticcheck](https://staticcheck.io/), a component of [golangci-lint](https://golangci-lint.run/).

```
gitlab/resource_gitlab_project_mirror_test.go:117:4: SA4004: the surrounding loop is unconditionally terminated (staticcheck)
			return errors.New("unable to find mirror.")
			^
```
