### PR TITLE
fix: do not automatically bind the first thing you see

### DIFF
--- a/gitlab/resource_gitlab_branch_protection.go
+++ b/gitlab/resource_gitlab_branch_protection.go
@@ -116,8 +116,16 @@ func resourceGitlabBranchProtectionRead(d *schema.ResourceData, meta interface{}
 
 	d.Set("project", project)
 	d.Set("branch", pb.Name)
-	d.Set("merge_access_level", accessLevel[pb.MergeAccessLevels[0].AccessLevel])
-	d.Set("push_access_level", accessLevel[pb.PushAccessLevels[0].AccessLevel])
+	for _, mergeAccessLevel := range pb.MergeAccessLevels {
+		if &mergeAccessLevel.UserID == nil && &mergeAccessLevel.GroupID == nil {
+			d.Set("merge_access_level", accessLevel[mergeAccessLevel.AccessLevel])
+		}
+	}
+	for _, pushAccessLevel := range pb.PushAccessLevels {
+		if &pushAccessLevel.UserID == nil && &pushAccessLevel.GroupID == nil {
+			d.Set("merge_access_level", accessLevel[pushAccessLevel.AccessLevel])
+		}
+	}
 	d.Set("code_owner_approval_required", pb.CodeOwnerApprovalRequired)
 
 	d.SetId(buildTwoPartID(&project, &pb.Name))


### PR DESCRIPTION
We should ignore merge_access and push_access of individual users and
groups. This feature is not yet implemented in the provider.

Closes: #441