### PR TITLE
Remove old-style variable interpolation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ Use the navigation to the left to read about the available resources.
 ```hcl
 # Configure the GitLab Provider
 provider "gitlab" {
-    token = "${var.gitlab_token}"
+    token = var.gitlab_token
 }
 
 # Add a project owned by the user
@@ -21,20 +21,20 @@ resource "gitlab_project" "sample_project" {
 
 # Add a hook to the project
 resource "gitlab_project_hook" "sample_project_hook" {
-    project = "${gitlab_project.sample_project.id}"
+    project = gitlab_project.sample_project.id
     url = "https://example.com/project_hook"
 }
 
 # Add a variable to the project
 resource "gitlab_project_variable" "sample_project_variable" {
-    project = "${gitlab_project.sample_project.id}"
+    project = gitlab_project.sample_project.id
     key = "project_variable_key"
     value = "project_variable_value"
 }
 
 # Add a deploy key to the project
 resource "gitlab_deploy_key" "sample_deploy_key" {
-    project = "${gitlab_project.sample_project.id}"
+    project = gitlab_project.sample_project.id
     title = "terraform example"
     key = "ssh-rsa AAAA..."
 }
@@ -49,7 +49,7 @@ resource "gitlab_group" "sample_group" {
 # Add a project to the group - example/example
 resource "gitlab_project" "sample_group_project" {
     name = "example"
-    namespace_id = "${gitlab_group.sample_group.id}"
+    namespace_id = gitlab_group.sample_group.id
 }
 ```
 


### PR DESCRIPTION
It's now considered bad form in Terraform to use interpolation with only variables and Terraform will raise a lint warning for it.