### PR TITLE
Update set-env github action command. 

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -18,11 +18,11 @@ jobs:
     # https://help.github.com/en/actions/reference/workflow-commands-for-github-actions
     - name: Set build variables
       run: |
-        echo "::set-env name=MAKE_TARGET::testacc"
-        echo "::set-env name=GO_FLAGS::-mod=vendor"
-        echo "::set-env name=GO111MODULE::on"
-        echo "::set-env name=GITLAB_TOKEN::20char-testing-token"
-        echo "::set-env name=GITLAB_BASE_URL::http://127.0.0.1:8080/api/v4"
+        echo "MAKE_TARGET=testacc >> $GITHUB_ENV"
+        echo "GO_FLAGS=-mod=vendor >> $GITHUB_ENV"
+        echo "GO111MODULE=on >> $GITHUB_ENV"
+        echo "GITLAB_TOKEN=20char-testing-token >> $GITHUB_ENV"
+        echo "GITLAB_BASE_URL=http://127.0.0.1:8080/api/v4 >> $GITHUB_ENV"
 
     - name: Start Gitlab and run acceptance tests
       run: |
@@ -50,17 +50,17 @@ jobs:
         [[ -n "${{ secrets.LICENSE_ENCRYPTION_PASSWORD }}" ]] && echo decrypt
         [[ -n "${{ secrets.LICENSE_ENCRYPTION_PASSWORD }}" ]] && openssl enc  -d -aes-256-cbc -pbkdf2 -iter 20000 -in Gitlab-license.encrypted -out license/Gitlab-license.txt -pass "pass:${{ secrets.LICENSE_ENCRYPTION_PASSWORD }}"
         chmod 666 license/Gitlab-license.txt || true
-        echo "::set-env name=GITLAB_LICENSE_FILE::Gitlab-license.txt"
+        echo "GITLAB_LICENSE_FILE=Gitlab-license.txt >> $GITHUB_ENV"
 
     # https://help.github.com/en/actions/reference/workflow-commands-for-github-actions
     - name: Set build variables
       run: |
-        echo "::set-env name=MAKE_TARGET::testacc"
-        echo "::set-env name=GO_FLAGS::-mod=vendor"
-        echo "::set-env name=GO111MODULE::on"
-        echo "::set-env name=GITLAB_TOKEN::20char-testing-token"
-        echo "::set-env name=GITLAB_BASE_URL::http://127.0.0.1:8080/api/v4"
-        echo "::set-env name=TF_LOG::DEBUG"
+        echo "MAKE_TARGET=testacc >> $GITHUB_ENV"
+        echo "GO_FLAGS=-mod=vendor >> $GITHUB_ENV"
+        echo "GO111MODULE=on >> $GITHUB_ENV"
+        echo "GITLAB_TOKEN=20char-testing-token >> $GITHUB_ENV"
+        echo "GITLAB_BASE_URL=http://127.0.0.1:8080/api/v4 >> $GITHUB_ENV"
+        echo "TF_LOG=DEBUG"
 
     - name: Start Gitlab and run acceptance tests
       run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -24,9 +24,9 @@ jobs:
     # https://help.github.com/en/actions/reference/workflow-commands-for-github-actions
     - name: Set build variables
       run: |
-        echo "::set-env name=MAKE_TARGET::${{ matrix.make_target }}"
-        echo "::set-env name=GO_FLAGS::-mod=vendor"
-        echo "::set-env name=GO111MODULE::on"
+        echo "MAKE_TARGET=${{ matrix.make_target }}"
+        echo "GO_FLAGS=-mod=vendor"
+        echo "GO111MODULE=on"
 
     - name: Run ${{matrix.make_target}}
       run: |


### PR DESCRIPTION
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

set-env is deprecating right now. So, we should update! :)