### PR TITLE
Fix nil pointer dereference importing gitlab_user

### DIFF
--- a/gitlab/resource_gitlab_user.go
+++ b/gitlab/resource_gitlab_user.go
@@ -16,23 +16,7 @@ func resourceGitlabUser() *schema.Resource {
 		Update: resourceGitlabUserUpdate,
 		Delete: resourceGitlabUserDelete,
 		Importer: &schema.ResourceImporter{
-			State: func(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
-				client := meta.(*gitlab.Client)
-				log.Printf("[DEBUG] read gitlab user %s", d.Id())
-
-				id, _ := strconv.Atoi(d.Id())
-
-				user, _, err := client.Users.GetUser(id)
-				if err != nil {
-					return nil, err
-				}
-
-				resourceGitlabUserSetToState(d, user)
-				d.Set("email", user.Email)
-				d.Set("is_admin", user.IsAdmin)
-				d.Set("is_external", user.External)
-				return []*schema.ResourceData{d}, nil
-			},
+			State: schema.ImportStatePassthrough,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -94,7 +78,7 @@ func resourceGitlabUserSetToState(d *schema.ResourceData, user *gitlab.User) {
 	d.Set("email", user.Email)
 	d.Set("is_admin", user.IsAdmin)
 	d.Set("is_external", user.External)
-	d.Set("skip_confirmation", !user.ConfirmedAt.IsZero())
+	d.Set("skip_confirmation", user.ConfirmedAt != nil && !user.ConfirmedAt.IsZero())
 }
 
 func resourceGitlabUserCreate(d *schema.ResourceData, meta interface{}) error {

--- a/gitlab/resource_gitlab_user_test.go
+++ b/gitlab/resource_gitlab_user_test.go
@@ -81,7 +81,6 @@ func TestAccGitlabUser_basic(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"password",
-					"skip_confirmation",
 				},
 			},
 		},


### PR DESCRIPTION
Fixes #469

The issue was a missing `nil` check.

An importer test was ignoring the `skip_confirmation` field, probably masking the bug.

Note I replaced the importer with `schema.ImportStatePassthrough` because the importer was duplicated code from the read function, and the read function only uses the `id` attribute to read. The three extra attribute-sets (lines 31-33) are covered already by `resourceGitlabUserSetToState`.