### PR TITLE
gitlab_user: Do not set skip_confirmation on read

### DIFF
--- a/gitlab/resource_gitlab_user.go
+++ b/gitlab/resource_gitlab_user.go
@@ -55,6 +55,7 @@ func resourceGitlabUser() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  true,
+				ForceNew: true,
 			},
 			"projects_limit": {
 				Type:     schema.TypeInt,
@@ -87,7 +88,6 @@ func resourceGitlabUserSetToState(d *schema.ResourceData, user *gitlab.User) {
 	d.Set("is_admin", user.IsAdmin)
 	d.Set("is_external", user.External)
 	d.Set("note", user.Note)
-	d.Set("skip_confirmation", user.ConfirmedAt != nil && !user.ConfirmedAt.IsZero())
 }
 
 func resourceGitlabUserCreate(d *schema.ResourceData, meta interface{}) error {

--- a/gitlab/resource_gitlab_user.go
+++ b/gitlab/resource_gitlab_user.go
@@ -32,6 +32,7 @@ func resourceGitlabUser() *schema.Resource {
 				Type:      schema.TypeString,
 				Optional:  true,
 				Sensitive: true,
+				ForceNew:  true,
 			},
 			"email": {
 				Type:     schema.TypeString,
@@ -70,6 +71,7 @@ func resourceGitlabUser() *schema.Resource {
 			"reset_password": {
 				Type:     schema.TypeBool,
 				Optional: true,
+				ForceNew: true,
 			},
 			"note": {
 				Type:     schema.TypeString,

--- a/gitlab/resource_gitlab_user_test.go
+++ b/gitlab/resource_gitlab_user_test.go
@@ -43,6 +43,7 @@ func TestAccGitlabUser_basic(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"password",
+					"skip_confirmation",
 				},
 			},
 			// Update the user to change the name, email, projects_limit and more
@@ -68,6 +69,7 @@ func TestAccGitlabUser_basic(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"password",
+					"skip_confirmation",
 				},
 			},
 			// Update the user to put the name back
@@ -92,6 +94,7 @@ func TestAccGitlabUser_basic(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"password",
+					"skip_confirmation",
 				},
 			},
 			// Update the user to disable skip confirmation
@@ -116,6 +119,7 @@ func TestAccGitlabUser_basic(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"password",
+					"skip_confirmation",
 				},
 			},
 			// Update the user to initial config
@@ -140,6 +144,7 @@ func TestAccGitlabUser_basic(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"password",
+					"skip_confirmation",
 				},
 			},
 		},
@@ -171,6 +176,8 @@ func TestAccGitlabUser_password_reset(t *testing.T) {
 				ImportStateVerify: true,
 				ImportStateVerifyIgnore: []string{
 					"password",
+					"reset_password",
+					"skip_confirmation",
 				},
 			},
 		},

--- a/gitlab/resource_gitlab_user_test.go
+++ b/gitlab/resource_gitlab_user_test.go
@@ -27,17 +27,23 @@ func TestAccGitlabUser_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabUserExists("gitlab_user.foo", &user),
 					testAccCheckGitlabUserAttributes(&user, &testAccGitlabUserExpectedAttributes{
-						Email:            fmt.Sprintf("listest%d@ssss.com", rInt),
-						Password:         fmt.Sprintf("test%dtt", rInt),
-						Username:         fmt.Sprintf("listest%d", rInt),
-						Name:             fmt.Sprintf("foo %d", rInt),
-						ProjectsLimit:    0,
-						Admin:            false,
-						CanCreateGroup:   false,
-						SkipConfirmation: true,
-						External:         false,
+						Email:          fmt.Sprintf("listest%d@ssss.com", rInt),
+						Username:       fmt.Sprintf("listest%d", rInt),
+						Name:           fmt.Sprintf("foo %d", rInt),
+						ProjectsLimit:  0,
+						Admin:          false,
+						CanCreateGroup: false,
+						External:       false,
 					}),
 				),
+			},
+			{
+				ResourceName:      "gitlab_user.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"password",
+				},
 			},
 			// Update the user to change the name, email, projects_limit and more
 			{
@@ -45,18 +51,24 @@ func TestAccGitlabUser_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabUserExists("gitlab_user.foo", &user),
 					testAccCheckGitlabUserAttributes(&user, &testAccGitlabUserExpectedAttributes{
-						Email:            fmt.Sprintf("listest%d@tttt.com", rInt),
-						Password:         fmt.Sprintf("test%dtt", rInt),
-						Username:         fmt.Sprintf("listest%d", rInt),
-						Name:             fmt.Sprintf("bar %d", rInt),
-						ProjectsLimit:    10,
-						Admin:            true,
-						CanCreateGroup:   true,
-						SkipConfirmation: false,
-						External:         false,
-						Note:             fmt.Sprintf("note%d", rInt),
+						Email:          fmt.Sprintf("listest%d@tttt.com", rInt),
+						Username:       fmt.Sprintf("listest%d", rInt),
+						Name:           fmt.Sprintf("bar %d", rInt),
+						ProjectsLimit:  10,
+						Admin:          true,
+						CanCreateGroup: true,
+						External:       false,
+						Note:           fmt.Sprintf("note%d", rInt),
 					}),
 				),
+			},
+			{
+				ResourceName:      "gitlab_user.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"password",
+				},
 			},
 			// Update the user to put the name back
 			{
@@ -64,15 +76,61 @@ func TestAccGitlabUser_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabUserExists("gitlab_user.foo", &user),
 					testAccCheckGitlabUserAttributes(&user, &testAccGitlabUserExpectedAttributes{
-						Email:            fmt.Sprintf("listest%d@ssss.com", rInt),
-						Password:         fmt.Sprintf("test%dtt", rInt),
-						Username:         fmt.Sprintf("listest%d", rInt),
-						Name:             fmt.Sprintf("foo %d", rInt),
-						ProjectsLimit:    0,
-						Admin:            false,
-						CanCreateGroup:   false,
-						SkipConfirmation: false,
-						External:         false,
+						Email:          fmt.Sprintf("listest%d@ssss.com", rInt),
+						Username:       fmt.Sprintf("listest%d", rInt),
+						Name:           fmt.Sprintf("foo %d", rInt),
+						ProjectsLimit:  0,
+						Admin:          false,
+						CanCreateGroup: false,
+						External:       false,
+					}),
+				),
+			},
+			{
+				ResourceName:      "gitlab_user.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"password",
+				},
+			},
+			// Update the user to disable skip confirmation
+			{
+				Config: testAccGitlabUserUpdateConfigNoSkipConfirmation(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabUserExists("gitlab_user.foo", &user),
+					testAccCheckGitlabUserAttributes(&user, &testAccGitlabUserExpectedAttributes{
+						Email:          fmt.Sprintf("listest%d@ssss.com", rInt),
+						Username:       fmt.Sprintf("listest%d", rInt),
+						Name:           fmt.Sprintf("foo %d", rInt),
+						ProjectsLimit:  0,
+						Admin:          false,
+						CanCreateGroup: false,
+						External:       false,
+					}),
+				),
+			},
+			{
+				ResourceName:      "gitlab_user.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"password",
+				},
+			},
+			// Update the user to initial config
+			{
+				Config: testAccGitlabUserConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabUserExists("gitlab_user.foo", &user),
+					testAccCheckGitlabUserAttributes(&user, &testAccGitlabUserExpectedAttributes{
+						Email:          fmt.Sprintf("listest%d@ssss.com", rInt),
+						Username:       fmt.Sprintf("listest%d", rInt),
+						Name:           fmt.Sprintf("foo %d", rInt),
+						ProjectsLimit:  0,
+						Admin:          false,
+						CanCreateGroup: false,
+						External:       false,
 					}),
 				),
 			},
@@ -107,6 +165,14 @@ func TestAccGitlabUser_password_reset(t *testing.T) {
 				Config: testAccGitlabUserConfigPasswordReset(rInt),
 				Check:  testAccCheckGitlabUserExists("gitlab_user.foo", &user),
 			},
+			{
+				ResourceName:      "gitlab_user.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"password",
+				},
+			},
 		},
 	})
 }
@@ -136,16 +202,14 @@ func testAccCheckGitlabUserExists(n string, user *gitlab.User) resource.TestChec
 }
 
 type testAccGitlabUserExpectedAttributes struct {
-	Email            string
-	Password         string
-	Username         string
-	Name             string
-	ProjectsLimit    int
-	Admin            bool
-	CanCreateGroup   bool
-	SkipConfirmation bool
-	External         bool
-	Note             string
+	Email          string
+	Username       string
+	Name           string
+	ProjectsLimit  int
+	Admin          bool
+	CanCreateGroup bool
+	External       bool
+	Note           string
 }
 
 func testAccCheckGitlabUserAttributes(user *gitlab.User, want *testAccGitlabUserExpectedAttributes) resource.TestCheckFunc {
@@ -239,6 +303,22 @@ resource "gitlab_user" "foo" {
   note             = "note%d"
 }
   `, rInt, rInt, rInt, rInt, rInt)
+}
+
+func testAccGitlabUserUpdateConfigNoSkipConfirmation(rInt int) string {
+	return fmt.Sprintf(`
+resource "gitlab_user" "foo" {
+  name              = "foo %d"
+  username          = "listest%d"
+  password          = "test%dtt"
+  email             = "listest%d@ssss.com"
+  is_admin          = false
+  projects_limit    = 0
+  can_create_group  = false
+  is_external       = false
+  skip_confirmation = false
+}
+  `, rInt, rInt, rInt, rInt)
 }
 
 func testAccGitlabUserConfigPasswordReset(rInt int) string {


### PR DESCRIPTION
Follow-up on #490 @roidelapluie 

I looked at it again, and I don't think `skip_confirmation` should ever be set during reads or imports, since it is an attribute that only has effect during initial creation. ([API ref](https://docs.gitlab.com/ee/api/users.html))

This change should fix an issue where, if the resource is created with `skip_confirmation=false`, then when the user confirms their email, it would result in an unnecessary resource diff of `skip_confirmation=true`.