### PR TITLE
fix deploy_token expiration

### DIFF
--- a/docs/resources/deploy_token.md
+++ b/docs/resources/deploy_token.md
@@ -41,7 +41,7 @@ The following arguments are supported:
 
 * `username` - (Optional, string) A username for the deploy token. Default is `gitlab+deploy-token-{n}`.
 
-* `expires_at` - (Optional, string) Time the token will expire it, RFC3339 format.
+* `expires_at` - (Optional, string) Time the token will expire it, RFC3339 format. Will not expire per default.
 
 * `scopes` - (Required, set of strings) Valid values: `read_repository`, `read_registry`.
 


### PR DESCRIPTION
These changes will fix the expiry behavior of deploy tokens.

Current state:
- Leaving `expires_at` at null in terraform results in the created token automatically being expired.
- Using an unrealistically high date as a workaround results in terraform segfaults, because gitlab internally sets them to never expire and the API will not return a valid date afterwards

Changes:
- Tokens will not expire per default, which makes more sense than creating an already expired Token
- Changes to the read behavior to check for `nil` before converting the date, as to not run into the terraform segfaults