### PR TITLE
Add resource for group shared_with_groups

### DIFF
--- a/docs/resources/group_share_group.md
+++ b/docs/resources/group_share_group.md
@@ -1,0 +1,34 @@
+# gitlab\_group\_share\_group
+
+This resource allows you to share a group with another group
+
+## Example Usage
+
+```hcl
+resource "gitlab_group_share_group" "test" {
+  group_id       = gitlab_group.foo.id
+  share_group_id = gitlab_group.bar.id
+  group_access 	 = "guest"
+  expires_at     = "2099-01-01"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `group_id` - (Required) The id of the main group.
+
+* `share_group_id` - (Required) The id of an additional group which will be shared with the main group.
+
+* `group_access` - (Required) One of five levels of access to the group.
+
+* `expires_at` - (Optional) Share expiration date. Format: `YYYY-MM-DD`
+
+## Import
+
+GitLab group shares can be imported using an id made up of `mainGroupId:shareGroupId`, e.g.
+
+```
+$ terraform import gitlab_group_share_group.test 12345:1337
+```

--- a/gitlab/provider.go
+++ b/gitlab/provider.go
@@ -95,6 +95,7 @@ func Provider() terraform.ResourceProvider {
 			"gitlab_project_level_mr_approvals": resourceGitlabProjectLevelMRApprovals(),
 			"gitlab_project_approval_rule":      resourceGitlabProjectApprovalRule(),
 			"gitlab_instance_variable":          resourceGitlabInstanceVariable(),
+			"gitlab_group_share_group":          resourceGitlabGroupShareGroup(),
 		},
 	}
 

--- a/gitlab/resource_gitlab_group_share_group.go
+++ b/gitlab/resource_gitlab_group_share_group.go
@@ -1,0 +1,146 @@
+package gitlab
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	gitlab "github.com/xanzy/go-gitlab"
+)
+
+// https://docs.gitlab.com/ee/api/groups.html#share-groups-with-groups
+
+func resourceGitlabGroupShareGroup() *schema.Resource {
+	acceptedAccessLevels := make([]string, 0, len(accessLevelID))
+	for k := range accessLevelID {
+		acceptedAccessLevels = append(acceptedAccessLevels, k)
+	}
+
+	return &schema.Resource{
+		Create: resourceGitlabGroupShareGroupCreate,
+		Read:   resourceGitlabGroupShareGroupRead,
+		Delete: resourceGitlabGroupShareGroupDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+		Schema: map[string]*schema.Schema{
+			"group_id": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"share_group_id": {
+				Type:     schema.TypeInt,
+				ForceNew: true,
+				Required: true,
+			},
+			"group_access": {
+				Type:         schema.TypeString,
+				ValidateFunc: validateValueFunc(acceptedAccessLevels),
+				ForceNew:     true,
+				Required:     true,
+			},
+			"expires_at": {
+				Type:         schema.TypeString, // Format YYYY-MM-DD
+				ValidateFunc: validateDateFunc,
+				ForceNew:     true,
+				Optional:     true,
+			},
+		},
+	}
+}
+
+func resourceGitlabGroupShareGroupCreate(d *schema.ResourceData, meta interface{}) error {
+	groupId := d.Get("group_id").(string)
+	shareGroupId := d.Get("share_group_id").(int)
+	groupAccess := accessLevelID[d.Get("group_access").(string)]
+	options := &gitlab.ShareWithGroupOptions{
+		GroupID:     &shareGroupId,
+		GroupAccess: &groupAccess,
+		ExpiresAt:   gitlab.String(d.Get("expires_at").(string)),
+	}
+
+	client := meta.(*gitlab.Client)
+	log.Printf("[DEBUG] create gitlab group share for %d in %s", shareGroupId, groupId)
+
+	_, _, err := client.GroupMembers.ShareWithGroup(groupId, options)
+	if err != nil {
+		return err
+	}
+
+	shareGroupIdString := strconv.Itoa(shareGroupId)
+	d.SetId(buildTwoPartID(&groupId, &shareGroupIdString))
+
+	return resourceGitlabGroupShareGroupRead(d, meta)
+}
+
+func resourceGitlabGroupShareGroupRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	id := d.Id()
+	log.Printf("[DEBUG] read gitlab shared groups %s", id)
+
+	groupId, sharedGroupId, err := groupIdsFromId(id)
+	if err != nil {
+		return err
+	}
+
+	// Query main group
+	group, resp, err := client.Groups.GetGroup(groupId)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			log.Printf("[DEBUG] gitlab group %s not found so removing from state", groupId)
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	// Find shared group data from queried group
+	for _, sharedGroup := range group.SharedWithGroups {
+		if sharedGroupId == sharedGroup.GroupID {
+			convertedAccessLevel := gitlab.AccessLevelValue(sharedGroup.GroupAccessLevel)
+
+			d.Set("group_id", groupId)
+			d.Set("share_group_id", sharedGroup.GroupID)
+			d.Set("group_access", accessLevel[convertedAccessLevel])
+			d.Set("expires_at", sharedGroup.ExpiresAt.String())
+
+			return nil
+		}
+	}
+
+	log.Printf("[DEBUG] gitlab shared group %s not found so removing from state", id)
+	d.SetId("")
+	return nil
+}
+
+func resourceGitlabGroupShareGroupDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	id := d.Id()
+
+	groupId, sharedGroupId, err := groupIdsFromId(id)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("[DEBUG] Delete gitlab share group %d for %s", sharedGroupId, groupId)
+
+	_, err = client.GroupMembers.DeleteShareWithGroup(groupId, sharedGroupId)
+	return err
+}
+
+func groupIdsFromId(id string) (string, int, error) {
+	groupId, sharedGroupIdString, err := parseTwoPartID(id)
+	if err != nil {
+		return "", 0, fmt.Errorf("Error parsing ID: %s", id)
+	}
+
+	sharedGroupId, err := strconv.Atoi(sharedGroupIdString)
+	if err != nil {
+		return "", 0, fmt.Errorf("Can not determine shared group id: %s", sharedGroupIdString)
+	}
+
+	return groupId, sharedGroupId, nil
+}

--- a/gitlab/resource_gitlab_group_share_group_test.go
+++ b/gitlab/resource_gitlab_group_share_group_test.go
@@ -1,0 +1,161 @@
+package gitlab
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/xanzy/go-gitlab"
+)
+
+func TestAccGitlabGroupShareGroup_basic(t *testing.T) {
+	randName := acctest.RandomWithPrefix("acctest")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			// Share a new group with another group
+			{
+				Config: testAccGitlabGroupShareGroupConfig(randName, "guest", "2099-01-01"),
+				Check:  testAccCheckGitlabGroupSharedWithGroup(randName, "2099-01-01", gitlab.GuestPermissions),
+			},
+			// Update the share group
+			{
+				Config: testAccGitlabGroupShareGroupConfig(randName, "reporter", "2099-02-02"),
+				Check:  testAccCheckGitlabGroupSharedWithGroup(randName, "2099-02-02", gitlab.ReporterPermissions),
+			},
+			// Delete the gitlab_group_share_group resource
+			{
+				Config: testAccGitlabGroupShareGroupConfigDelete(randName),
+				Check:  testAccCheckGitlabGroupIsNotShared(randName),
+			},
+		},
+	})
+}
+
+func TestAccGitlabGroupShareGroup_import(t *testing.T) {
+	randName := acctest.RandomWithPrefix("acctest")
+
+	resource.Test(t, resource.TestCase{
+		Providers:    testAccProviders,
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckGitlabGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				// create shared groups
+				Config: testAccGitlabGroupShareGroupConfig(randName, "guest", "2099-03-03"),
+				Check:  testAccCheckGitlabGroupSharedWithGroup(randName, "2099-03-03", gitlab.GuestPermissions),
+			},
+			{
+				// Verify Import
+				ResourceName:      "gitlab_group_share_group.test",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckGitlabGroupSharedWithGroup(
+	groupName string,
+	expireTime string,
+	accessLevel gitlab.AccessLevelValue,
+) resource.TestCheckFunc {
+	return func(_ *terraform.State) error {
+		client := testAccProvider.Meta().(*gitlab.Client)
+
+		mainGroup, _, err := client.Groups.GetGroup(fmt.Sprintf("%s_main", groupName))
+		if err != nil {
+			return err
+		}
+
+		sharedGroupsCount := len(mainGroup.SharedWithGroups)
+		if sharedGroupsCount != 1 {
+			return fmt.Errorf("Number of shared groups was %d (wanted %d)", sharedGroupsCount, 1)
+		}
+
+		sharedGroup := mainGroup.SharedWithGroups[0]
+
+		if sharedGroup.GroupName != fmt.Sprintf("%s_share", groupName) {
+			return fmt.Errorf("group name was %s (wanted %s)", sharedGroup.GroupName, fmt.Sprintf("%s_share", groupName))
+		}
+
+		if gitlab.AccessLevelValue(sharedGroup.GroupAccessLevel) != accessLevel {
+			return fmt.Errorf("groupAccessLevel was %d (wanted %d)", sharedGroup.GroupAccessLevel, accessLevel)
+		}
+
+		if sharedGroup.ExpiresAt.String() != expireTime {
+			return fmt.Errorf("expired time was %s (wanted %s)", sharedGroup.ExpiresAt.String(), expireTime)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckGitlabGroupIsNotShared(groupName string) resource.TestCheckFunc {
+	return func(_ *terraform.State) error {
+		client := testAccProvider.Meta().(*gitlab.Client)
+
+		mainGroup, _, err := client.Groups.GetGroup(fmt.Sprintf("%s_main", groupName))
+		if err != nil {
+			return err
+		}
+
+		sharedGroupsCount := len(mainGroup.SharedWithGroups)
+		if sharedGroupsCount != 0 {
+			return fmt.Errorf("Number of shared groups was %d (wanted %d)", sharedGroupsCount, 0)
+		}
+
+		return nil
+	}
+}
+
+func testAccGitlabGroupShareGroupConfig(
+	randName string,
+	accessLevel string,
+	expireTime string,
+) string {
+	return fmt.Sprintf(
+		`
+		resource "gitlab_group" "test_main" {
+		  name = "%[1]s_main"
+		  path = "%[1]s_main"
+		}
+
+		resource "gitlab_group" "test_share" {
+		  name = "%[1]s_share"
+		  path = "%[1]s_share"
+		}
+
+		resource "gitlab_group_share_group" "test" {
+		  group_id       = gitlab_group.test_main.id
+			share_group_id = gitlab_group.test_share.id
+			group_access 	 = "%[2]s"
+			expires_at     = "%[3]s"
+		}
+		`,
+		randName,
+		accessLevel,
+		expireTime,
+	)
+}
+
+func testAccGitlabGroupShareGroupConfigDelete(randName string) string {
+	return fmt.Sprintf(
+		`
+		resource "gitlab_group" "test_main" {
+		  name = "%[1]s_main"
+		  path = "%[1]s_main"
+		}
+
+		resource "gitlab_group" "test_share" {
+		  name = "%[1]s_share"
+		  path = "%[1]s_share"
+		}
+		`,
+		randName,
+	)
+}


### PR DESCRIPTION
Follow-up from Pull Request review: https://github.com/gitlabhq/terraform-provider-gitlab/pull/369#pullrequestreview-487250800

Fixes #300

This will create a new resource `gitlab_group_share_group` to support sharing groups

Follows the pattern used by `gitlab_project_share_group`: https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/project_share_group