### PR TITLE
Project mirroring

### DIFF
--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -82,6 +82,10 @@ The following arguments are supported:
 
 * `group_with_project_templates_id` - (Optional) For group-level custom templates, specifies ID of group from which all the custom project templates are sourced. Leave empty for instance-level templates. Requires use_custom_template to be true (enterprise edition).
 
+* `mirror` (Optional) Enables pull mirroring in a project.
+
+* `mirror_trigger_builds` (Optional) Pull mirroring triggers builds.
+
 ## Attributes Reference
 
 The following additional attributes are exported:

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -34,6 +34,11 @@ The following arguments are supported:
 
 * `import_url` - (Optional) Git URL to a repository to be imported.
 
+* `mirror` (Optional) Enables pull mirroring in a project. For further information on mirroring, consult the 
+[gitlab documentation](https://docs.gitlab.com/ee/user/project/repository/repository_mirroring.html#repository-mirroring).
+
+* `mirror_trigger_builds` (Optional) Pull mirroring triggers builds.
+
 * `request_access_enabled` - Allow users to request member access.
 
 * `issues_enabled` - (Optional) Enable issue tracking for the project.
@@ -85,10 +90,6 @@ The following arguments are supported:
 * `pages_access_level` - (Optional) Enable pages access control
   Valid values are `disabled`, `private`, `enabled`, `public`.
   `private` is the default.
-
-* `mirror` (Optional) Enables pull mirroring in a project.
-
-* `mirror_trigger_builds` (Optional) Pull mirroring triggers builds.
 
 ## Attributes Reference
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -34,10 +34,10 @@ The following arguments are supported:
 
 * `import_url` - (Optional) Git URL to a repository to be imported.
 
-* `mirror` (Optional) Enables pull mirroring in a project. For further information on mirroring, consult the 
-[gitlab documentation](https://docs.gitlab.com/ee/user/project/repository/repository_mirroring.html#repository-mirroring).
+* `mirror` (Optional) Enables pull mirroring in a project. Default is `false`. For further information on mirroring,
+consult the [gitlab documentation](https://docs.gitlab.com/ee/user/project/repository/repository_mirroring.html#repository-mirroring).
 
-* `mirror_trigger_builds` (Optional) Pull mirroring triggers builds.
+* `mirror_trigger_builds` (Optional) Pull mirroring triggers builds. Default is `false`.
 
 * `request_access_enabled` - Allow users to request member access.
 

--- a/docs/resources/project_mirror.md
+++ b/docs/resources/project_mirror.md
@@ -2,6 +2,12 @@
 
 This resource allows you to add a mirror target for the repository, all changes will be synced to the remote target.
 
+-> This is for *pushing* changes to a remote repository. *Pull Mirroring* can be configured using a combination of the 
+`import_url`, `mirror` and `mirror_trigger_builds` properties on the `gitlab_project` resource.
+
+For further information on mirroring, consult the 
+[gitlab documentation](https://docs.gitlab.com/ee/user/project/repository/repository_mirroring.html#repository-mirroring).
+
 ## Example Usage
 
 ```hcl

--- a/docs/resources/project_mirror.md
+++ b/docs/resources/project_mirror.md
@@ -3,7 +3,7 @@
 This resource allows you to add a mirror target for the repository, all changes will be synced to the remote target.
 
 -> This is for *pushing* changes to a remote repository. *Pull Mirroring* can be configured using a combination of the 
-`import_url`, `mirror` and `mirror_trigger_builds` properties on the `gitlab_project` resource.
+`import_url`, `mirror`, and `mirror_trigger_builds` properties on the `gitlab_project` resource.
 
 For further information on mirroring, consult the 
 [gitlab documentation](https://docs.gitlab.com/ee/user/project/repository/repository_mirroring.html#repository-mirroring).

--- a/gitlab/data_source_gitlab_projects.go
+++ b/gitlab/data_source_gitlab_projects.go
@@ -2,11 +2,12 @@ package gitlab
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 	"github.com/mitchellh/hashstructure"
 	"github.com/xanzy/go-gitlab"
-	"log"
 )
 
 // Schemas

--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -268,6 +268,14 @@ var resourceGitLabProjectSchema = map[string]*schema.Schema{
 		Type:     schema.TypeInt,
 		Optional: true,
 	},
+	"mirror": {
+		Type:     schema.TypeBool,
+		Optional: true,
+	},
+	"mirror_trigger_builds": {
+		Type:     schema.TypeBool,
+		Optional: true,
+	},
 }
 
 func resourceGitlabProject() *schema.Resource {
@@ -313,6 +321,8 @@ func resourceGitlabProjectSetToState(d *schema.ResourceData, project *gitlab.Pro
 	d.Set("archived", project.Archived)
 	d.Set("remove_source_branch_after_merge", project.RemoveSourceBranchAfterMerge)
 	d.Set("packages_enabled", project.PackagesEnabled)
+	d.Set("mirror", project.Mirror)
+	d.Set("mirror_trigger_builds", project.MirrorTriggerBuilds)
 }
 
 func resourceGitlabProjectCreate(d *schema.ResourceData, meta interface{}) error {
@@ -336,6 +346,8 @@ func resourceGitlabProjectCreate(d *schema.ResourceData, meta interface{}) error
 		SharedRunnersEnabled:                      gitlab.Bool(d.Get("shared_runners_enabled").(bool)),
 		RemoveSourceBranchAfterMerge:              gitlab.Bool(d.Get("remove_source_branch_after_merge").(bool)),
 		PackagesEnabled:                           gitlab.Bool(d.Get("packages_enabled").(bool)),
+		Mirror:                                    gitlab.Bool(d.Get("mirror").(bool)),
+		MirrorTriggerBuilds:                       gitlab.Bool(d.Get("mirror_trigger_builds").(bool)),
 	}
 
 	if v, ok := d.GetOk("path"); ok {
@@ -556,6 +568,14 @@ func resourceGitlabProjectUpdate(d *schema.ResourceData, meta interface{}) error
 
 	if d.HasChange("packages_enabled") {
 		options.PackagesEnabled = gitlab.Bool(d.Get("packages_enabled").(bool))
+	}
+
+	if d.HasChange("mirror") {
+		options.Mirror = gitlab.Bool(d.Get("mirror").(bool))
+	}
+
+	if d.HasChange("mirror_trigger_builds") {
+		options.MirrorTriggerBuilds = gitlab.Bool(d.Get("mirror_trigger_builds").(bool))
 	}
 
 	if *options != (gitlab.EditProjectOptions{}) {

--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -589,10 +589,16 @@ func resourceGitlabProjectUpdate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	if d.HasChange("mirror") {
+		// It appears that GitLab API requires that import_url is also set when `mirror` is updated/changed
+		// Ref: https://github.com/gitlabhq/terraform-provider-gitlab/pull/449#discussion_r549729230
+		options.ImportURL = gitlab.String(d.Get("import_url").(string))
 		options.Mirror = gitlab.Bool(d.Get("mirror").(bool))
 	}
 
 	if d.HasChange("mirror_trigger_builds") {
+		// It appears that GitLab API requires that import_url is also set when `mirror_trigger_builds` is updated/changed
+		// Ref: https://github.com/gitlabhq/terraform-provider-gitlab/pull/449#discussion_r549729230
+		options.ImportURL = gitlab.String(d.Get("import_url").(string))
 		options.MirrorTriggerBuilds = gitlab.Bool(d.Get("mirror_trigger_builds").(bool))
 	}
 

--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -329,6 +329,8 @@ func resourceGitlabProjectSetToState(d *schema.ResourceData, project *gitlab.Pro
 	d.Set("remove_source_branch_after_merge", project.RemoveSourceBranchAfterMerge)
 	d.Set("packages_enabled", project.PackagesEnabled)
 	d.Set("pages_access_level", string(project.PagesAccessLevel))
+	d.Set("mirror", project.Mirror)
+	d.Set("mirror_trigger_builds", project.MirrorTriggerBuilds)
 }
 
 func resourceGitlabProjectCreate(d *schema.ResourceData, meta interface{}) error {
@@ -582,6 +584,14 @@ func resourceGitlabProjectUpdate(d *schema.ResourceData, meta interface{}) error
 
 	if d.HasChange("pages_access_level") {
 		options.PagesAccessLevel = stringToAccessControlValue(d.Get("pages_access_level").(string))
+	}
+
+	if d.HasChange("mirror") {
+		options.Mirror = gitlab.Bool(d.Get("mirror").(bool))
+	}
+
+	if d.HasChange("mirror_trigger_builds") {
+		options.MirrorTriggerBuilds = gitlab.Bool(d.Get("mirror_trigger_builds").(bool))
 	}
 
 	if *options != (gitlab.EditProjectOptions{}) {

--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -278,12 +278,12 @@ var resourceGitLabProjectSchema = map[string]*schema.Schema{
 	"mirror": {
 		Type:     schema.TypeBool,
 		Optional: true,
-		Default: false,
+		Default:  false,
 	},
 	"mirror_trigger_builds": {
 		Type:     schema.TypeBool,
 		Optional: true,
-		Default: false,
+		Default:  false,
 	},
 }
 

--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -278,10 +278,12 @@ var resourceGitLabProjectSchema = map[string]*schema.Schema{
 	"mirror": {
 		Type:     schema.TypeBool,
 		Optional: true,
+		Default: false,
 	},
 	"mirror_trigger_builds": {
 		Type:     schema.TypeBool,
 		Optional: true,
+		Default: false,
 	},
 }
 

--- a/gitlab/resource_gitlab_project_test.go
+++ b/gitlab/resource_gitlab_project_test.go
@@ -566,6 +566,7 @@ func TestAccGitlabProject_importURLMirrored(t *testing.T) {
 			{
 				// First, import, as mirrored
 				Config: testAccGitlabProjectConfigImportURLMirror(rInt, baseProject.HTTPURLToRepo),
+				SkipFunc: isRunningInCE,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabProjectExists("gitlab_project.imported", &mirror),
 					resource.TestCheckResourceAttr("gitlab_project.imported", "import_url", baseProject.HTTPURLToRepo),
@@ -589,6 +590,7 @@ func TestAccGitlabProject_importURLMirrored(t *testing.T) {
 			{
 				// Second, disable mirroring, using the original ImportURL acceptance test
 				Config: testAccGitlabProjectConfigImportURLMirrorDisabled(rInt, baseProject.HTTPURLToRepo),
+				SkipFunc: isRunningInCE,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabProjectExists("gitlab_project.imported", &mirror),
 					resource.TestCheckResourceAttr("gitlab_project.imported", "import_url", baseProject.HTTPURLToRepo),

--- a/gitlab/resource_gitlab_project_test.go
+++ b/gitlab/resource_gitlab_project_test.go
@@ -545,7 +545,7 @@ func TestAccGitlabProject_importURLMirrored(t *testing.T) {
 		CheckDestroy: testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccGitlabProjectConfigImportURL(rInt, baseProject.HTTPURLToRepo),
+				Config: testAccGitlabProjectConfigImportURLMirrored(rInt, baseProject.HTTPURLToRepo),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("gitlab_project.imported", "import_url", baseProject.HTTPURLToRepo),
 					resource.TestCheckResourceAttr("gitlab_project.mirrored", "mirrored", "true"),

--- a/gitlab/resource_gitlab_project_test.go
+++ b/gitlab/resource_gitlab_project_test.go
@@ -509,6 +509,64 @@ func TestAccGitlabProject_importURL(t *testing.T) {
 	})
 }
 
+func TestAccGitlabProject_importURLMirrored(t *testing.T) {
+	// Since we do some manual setup in this test, we need to handle the test skip first.
+	if os.Getenv(resource.TestEnvVar) == "" {
+		t.Skip(fmt.Sprintf("Acceptance tests skipped unless env '%s' set", resource.TestEnvVar))
+	}
+
+	client := testAccProvider.Meta().(*gitlab.Client)
+	rInt := acctest.RandInt()
+
+	// Create a base project for importing.
+	baseProject, _, err := client.Projects.CreateProject(&gitlab.CreateProjectOptions{
+		Name:       gitlab.String(fmt.Sprintf("base-%d", rInt)),
+		Visibility: gitlab.Visibility(gitlab.PublicVisibility),
+	})
+	if err != nil {
+		t.Fatalf("failed to create base project: %v", err)
+	}
+
+	defer client.Projects.DeleteProject(baseProject.ID)
+
+	// Add a file to the base project, for later verifying the import.
+	_, _, err = client.RepositoryFiles.CreateFile(baseProject.ID, "foo.txt", &gitlab.CreateFileOptions{
+		Branch:        gitlab.String("master"),
+		CommitMessage: gitlab.String("add file"),
+		Content:       gitlab.String(""),
+	})
+	if err != nil {
+		t.Fatalf("failed to commit file to base project: %v", err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGitlabProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGitlabProjectConfigImportURL(rInt, baseProject.HTTPURLToRepo),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("gitlab_project.imported", "import_url", baseProject.HTTPURLToRepo),
+					resource.TestCheckResourceAttr("gitlab_project.mirrored", "mirrored", "true"),
+					resource.TestCheckResourceAttr("gitlab_project.mirror_target_builds", "mirror_target_builds", "true"),
+
+					func(state *terraform.State) error {
+						projectID := state.RootModule().Resources["gitlab_project.imported"].Primary.ID
+
+						_, _, err := client.RepositoryFiles.GetFile(projectID, "foo.txt", &gitlab.GetFileOptions{Ref: gitlab.String("master")}, nil)
+						if err != nil {
+							return fmt.Errorf("failed to get file from imported project: %w", err)
+						}
+
+						return nil
+					},
+				),
+			},
+		},
+	})
+}
+
 func TestAccGitlabProjec_templateMutualExclusiveNameAndID(t *testing.T) {
 	rInt := acctest.RandInt()
 
@@ -830,6 +888,22 @@ resource "gitlab_project" "imported" {
   name = "imported-%d"
   default_branch = "master"
   import_url = "%s"
+
+  # So that acceptance tests can be run in a gitlab organization
+  # with no billing
+  visibility_level = "public"
+}
+`, rInt, importURL)
+}
+
+func testAccGitlabProjectConfigImportURLMirrored(rInt int, importURL string) string {
+	return fmt.Sprintf(`
+resource "gitlab_project" "imported" {
+  name = "imported-%d"
+  default_branch = "master"
+  import_url = "%s"
+  mirrored = true
+  mirror_target_builds = true
 
   # So that acceptance tests can be run in a gitlab organization
   # with no billing

--- a/gitlab/resource_gitlab_project_test.go
+++ b/gitlab/resource_gitlab_project_test.go
@@ -565,7 +565,7 @@ func TestAccGitlabProject_importURLMirrored(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// First, import, as mirrored
-				Config: testAccGitlabProjectConfigImportURLMirror(rInt, baseProject.HTTPURLToRepo),
+				Config:   testAccGitlabProjectConfigImportURLMirror(rInt, baseProject.HTTPURLToRepo),
 				SkipFunc: isRunningInCE,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabProjectExists("gitlab_project.imported", &mirror),
@@ -589,7 +589,7 @@ func TestAccGitlabProject_importURLMirrored(t *testing.T) {
 			},
 			{
 				// Second, disable mirroring, using the original ImportURL acceptance test
-				Config: testAccGitlabProjectConfigImportURLMirrorDisabled(rInt, baseProject.HTTPURLToRepo),
+				Config:   testAccGitlabProjectConfigImportURLMirrorDisabled(rInt, baseProject.HTTPURLToRepo),
 				SkipFunc: isRunningInCE,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabProjectExists("gitlab_project.imported", &mirror),

--- a/gitlab/resource_gitlab_project_test.go
+++ b/gitlab/resource_gitlab_project_test.go
@@ -549,7 +549,7 @@ func TestAccGitlabProject_importURLMirrored(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("gitlab_project.imported", "import_url", baseProject.HTTPURLToRepo),
 					resource.TestCheckResourceAttr("gitlab_project.imported", "mirror", "true"),
-					resource.TestCheckResourceAttr("gitlab_project.imported", "mirror_target_builds", "true"),
+					resource.TestCheckResourceAttr("gitlab_project.imported", "mirror_trigger_builds", "true"),
 
 					func(state *terraform.State) error {
 						projectID := state.RootModule().Resources["gitlab_project.imported"].Primary.ID
@@ -903,7 +903,7 @@ resource "gitlab_project" "imported" {
   default_branch = "master"
   import_url = "%s"
   mirror = true
-  mirror_target_builds = true
+  mirror_trigger_builds = true
 
   # So that acceptance tests can be run in a gitlab organization
   # with no billing

--- a/gitlab/resource_gitlab_project_test.go
+++ b/gitlab/resource_gitlab_project_test.go
@@ -546,7 +546,7 @@ func TestAccGitlabProject_importURLMirrored(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				// First, import, as mirrored
-				Config: testAccGitlabProjectConfigImportURLMirrored(rInt, baseProject.HTTPURLToRepo),
+				Config: testAccGitlabProjectConfigImportURLMirror(rInt, baseProject.HTTPURLToRepo),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("gitlab_project.imported", "import_url", baseProject.HTTPURLToRepo),
 					resource.TestCheckResourceAttr("gitlab_project.imported", "mirror", "true"),
@@ -566,7 +566,7 @@ func TestAccGitlabProject_importURLMirrored(t *testing.T) {
 			},
 			{
 				// Second, disable mirroring, using the original ImportURL acceptance test
-				Config: testAccGitlabProjectConfigImportURL(rInt, baseProject.HTTPURLToRepo),
+				Config: testAccGitlabProjectConfigImportURLMirrorDisabled(rInt, baseProject.HTTPURLToRepo),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("gitlab_project.imported", "import_url", baseProject.HTTPURLToRepo),
 					resource.TestCheckResourceAttr("gitlab_project.imported", "mirror", "false"),
@@ -918,7 +918,7 @@ resource "gitlab_project" "imported" {
 `, rInt, importURL)
 }
 
-func testAccGitlabProjectConfigImportURLMirrored(rInt int, importURL string) string {
+func testAccGitlabProjectConfigImportURLMirror(rInt int, importURL string) string {
 	return fmt.Sprintf(`
 resource "gitlab_project" "imported" {
   name = "imported-%d"
@@ -926,6 +926,22 @@ resource "gitlab_project" "imported" {
   import_url = "%s"
   mirror = true
   mirror_trigger_builds = true
+
+  # So that acceptance tests can be run in a gitlab organization
+  # with no billing
+  visibility_level = "public"
+}
+`, rInt, importURL)
+}
+
+func testAccGitlabProjectConfigImportURLMirrorDisabled(rInt int, importURL string) string {
+	return fmt.Sprintf(`
+resource "gitlab_project" "imported" {
+  name = "imported-%d"
+  default_branch = "master"
+  import_url = "%s"
+  mirror = false
+  mirror_trigger_builds = false
 
   # So that acceptance tests can be run in a gitlab organization
   # with no billing

--- a/gitlab/resource_gitlab_project_test.go
+++ b/gitlab/resource_gitlab_project_test.go
@@ -809,8 +809,6 @@ resource "gitlab_project" "foo" {
   archived = true
   packages_enabled = false
   pages_access_level = "disabled"
-  mirror = false
-  mirror_target_builds = false
 }
 	`, rInt, rInt)
 }

--- a/gitlab/resource_gitlab_project_test.go
+++ b/gitlab/resource_gitlab_project_test.go
@@ -802,7 +802,9 @@ resource "gitlab_project" "foo" {
   lfs_enabled = false
   shared_runners_enabled = false
   archived = true
-  packages_enabled = false
+	packages_enabled = false
+	mirror = false
+	mirror_target_builds = false
 }
 	`, rInt, rInt)
 }

--- a/gitlab/resource_gitlab_project_test.go
+++ b/gitlab/resource_gitlab_project_test.go
@@ -521,7 +521,7 @@ func testAccCheckGitlabProjectMirroredAttributes(project *gitlab.Project, want *
 		}
 
 		if project.MirrorTriggerBuilds != want.MirrorTriggerBuilds {
-			return fmt.Errorf("got mirror %t; want %t", project.MirrorTriggerBuilds, want.MirrorTriggerBuilds)
+			return fmt.Errorf("got mirror_trigger_builds %t; want %t", project.MirrorTriggerBuilds, want.MirrorTriggerBuilds)
 		}
 		return nil
 	}

--- a/gitlab/resource_gitlab_project_test.go
+++ b/gitlab/resource_gitlab_project_test.go
@@ -802,9 +802,9 @@ resource "gitlab_project" "foo" {
   lfs_enabled = false
   shared_runners_enabled = false
   archived = true
-	packages_enabled = false
-	mirror = false
-	mirror_target_builds = false
+  packages_enabled = false
+  mirror = false
+  mirror_target_builds = false
 }
 	`, rInt, rInt)
 }

--- a/gitlab/resource_gitlab_project_test.go
+++ b/gitlab/resource_gitlab_project_test.go
@@ -548,7 +548,7 @@ func TestAccGitlabProject_importURLMirrored(t *testing.T) {
 				Config: testAccGitlabProjectConfigImportURLMirrored(rInt, baseProject.HTTPURLToRepo),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("gitlab_project.imported", "import_url", baseProject.HTTPURLToRepo),
-					resource.TestCheckResourceAttr("gitlab_project.imported", "mirrored", "true"),
+					resource.TestCheckResourceAttr("gitlab_project.imported", "mirror", "true"),
 					resource.TestCheckResourceAttr("gitlab_project.imported", "mirror_target_builds", "true"),
 
 					func(state *terraform.State) error {
@@ -902,7 +902,7 @@ resource "gitlab_project" "imported" {
   name = "imported-%d"
   default_branch = "master"
   import_url = "%s"
-  mirrored = true
+  mirror = true
   mirror_target_builds = true
 
   # So that acceptance tests can be run in a gitlab organization

--- a/gitlab/resource_gitlab_project_test.go
+++ b/gitlab/resource_gitlab_project_test.go
@@ -548,8 +548,8 @@ func TestAccGitlabProject_importURLMirrored(t *testing.T) {
 				Config: testAccGitlabProjectConfigImportURLMirrored(rInt, baseProject.HTTPURLToRepo),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("gitlab_project.imported", "import_url", baseProject.HTTPURLToRepo),
-					resource.TestCheckResourceAttr("gitlab_project.mirrored", "mirrored", "true"),
-					resource.TestCheckResourceAttr("gitlab_project.mirror_target_builds", "mirror_target_builds", "true"),
+					resource.TestCheckResourceAttr("gitlab_project.imported", "mirrored", "true"),
+					resource.TestCheckResourceAttr("gitlab_project.imported", "mirror_target_builds", "true"),
 
 					func(state *terraform.State) error {
 						projectID := state.RootModule().Resources["gitlab_project.imported"].Primary.ID

--- a/gitlab/resource_gitlab_project_test.go
+++ b/gitlab/resource_gitlab_project_test.go
@@ -570,7 +570,7 @@ func TestAccGitlabProject_importURLMirrored(t *testing.T) {
 					testAccCheckGitlabProjectExists("gitlab_project.imported", &mirror),
 					resource.TestCheckResourceAttr("gitlab_project.imported", "import_url", baseProject.HTTPURLToRepo),
 					testAccCheckGitlabProjectMirroredAttributes(&mirror, &testAccGitlabProjectMirroredExpectedAttributes{
-						Mirror: true, 
+						Mirror:              true,
 						MirrorTriggerBuilds: true,
 					}),
 
@@ -593,7 +593,7 @@ func TestAccGitlabProject_importURLMirrored(t *testing.T) {
 					testAccCheckGitlabProjectExists("gitlab_project.imported", &mirror),
 					resource.TestCheckResourceAttr("gitlab_project.imported", "import_url", baseProject.HTTPURLToRepo),
 					testAccCheckGitlabProjectMirroredAttributes(&mirror, &testAccGitlabProjectMirroredExpectedAttributes{
-						Mirror: false, 
+						Mirror:              false,
 						MirrorTriggerBuilds: false,
 					}),
 


### PR DESCRIPTION
Adds `mirror` and `mirror_trigger_builds` fields to Project

Related to Pull Request: https://github.com/gitlabhq/terraform-provider-gitlab/pull/449

Setup so EE tests can run against changes 