### PR TITLE
support additional attributes in `gitlab_project_hook`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ website/node_modules
 *.iml
 *.test
 *.iml
+.envrc
 
 website/vendor
 

--- a/docs/resources/project_hook.md
+++ b/docs/resources/project_hook.md
@@ -48,6 +48,8 @@ The following arguments are supported:
 * `pipeline_events` - (Optional) Invoke the hook for pipeline events.
 
 * `wiki_page_events` - (Optional) Invoke the hook for wiki page events.
+  
+* `deployment_events` - (Optional) Invoke the hook for deployment events.
 
 ## Attributes Reference
 

--- a/docs/resources/project_hook.md
+++ b/docs/resources/project_hook.md
@@ -25,18 +25,23 @@ The following arguments are supported:
 
 * `token` - (Optional) A token to present when invoking the hook.
 
-* `enable_ssl_verification` - (Optional) Enable ssl verification when invoking
-the hook.
+* `enable_ssl_verification` - (Optional) Enable ssl verification when invoking the hook.
 
 * `push_events` - (Optional) Invoke the hook for push events.
 
+* `push_events_branch_filter` - (Optional) Invoke the hook for push events on matching branches only.
+
 * `issues_events` - (Optional) Invoke the hook for issues events.
+
+* `confidential_issues_events` - (Optional) Invoke the hook for confidential issues events.
 
 * `merge_requests_events` - (Optional) Invoke the hook for merge requests.
 
 * `tag_push_events` - (Optional) Invoke the hook for tag push events.
 
 * `note_events` - (Optional) Invoke the hook for notes events.
+
+* `confidential_note_events` - (Optional) Invoke the hook for confidential notes events.
 
 * `job_events` - (Optional) Invoke the hook for job events.
 

--- a/gitlab/resource_gitlab_project_hook.go
+++ b/gitlab/resource_gitlab_project_hook.go
@@ -35,7 +35,16 @@ func resourceGitlabProjectHook() *schema.Resource {
 				Optional: true,
 				Default:  true,
 			},
+			"push_events_branch_filter": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"issues_events": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"confidential_issues_events": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
@@ -51,6 +60,11 @@ func resourceGitlabProjectHook() *schema.Resource {
 				Default:  false,
 			},
 			"note_events": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"confidential_note_events": {
 				Type:     schema.TypeBool,
 				Optional: true,
 				Default:  false,
@@ -83,16 +97,19 @@ func resourceGitlabProjectHookCreate(d *schema.ResourceData, meta interface{}) e
 	client := meta.(*gitlab.Client)
 	project := d.Get("project").(string)
 	options := &gitlab.AddProjectHookOptions{
-		URL:                   gitlab.String(d.Get("url").(string)),
-		PushEvents:            gitlab.Bool(d.Get("push_events").(bool)),
-		IssuesEvents:          gitlab.Bool(d.Get("issues_events").(bool)),
-		MergeRequestsEvents:   gitlab.Bool(d.Get("merge_requests_events").(bool)),
-		TagPushEvents:         gitlab.Bool(d.Get("tag_push_events").(bool)),
-		NoteEvents:            gitlab.Bool(d.Get("note_events").(bool)),
-		JobEvents:             gitlab.Bool(d.Get("job_events").(bool)),
-		PipelineEvents:        gitlab.Bool(d.Get("pipeline_events").(bool)),
-		WikiPageEvents:        gitlab.Bool(d.Get("wiki_page_events").(bool)),
-		EnableSSLVerification: gitlab.Bool(d.Get("enable_ssl_verification").(bool)),
+		URL:                      gitlab.String(d.Get("url").(string)),
+		PushEvents:               gitlab.Bool(d.Get("push_events").(bool)),
+		PushEventsBranchFilter:   gitlab.String(d.Get("push_events_branch_filter").(string)),
+		IssuesEvents:             gitlab.Bool(d.Get("issues_events").(bool)),
+		ConfidentialIssuesEvents: gitlab.Bool(d.Get("confidential_issues_events").(bool)),
+		MergeRequestsEvents:      gitlab.Bool(d.Get("merge_requests_events").(bool)),
+		TagPushEvents:            gitlab.Bool(d.Get("tag_push_events").(bool)),
+		NoteEvents:               gitlab.Bool(d.Get("note_events").(bool)),
+		ConfidentialNoteEvents:   gitlab.Bool(d.Get("confidential_note_events").(bool)),
+		JobEvents:                gitlab.Bool(d.Get("job_events").(bool)),
+		PipelineEvents:           gitlab.Bool(d.Get("pipeline_events").(bool)),
+		WikiPageEvents:           gitlab.Bool(d.Get("wiki_page_events").(bool)),
+		EnableSSLVerification:    gitlab.Bool(d.Get("enable_ssl_verification").(bool)),
 	}
 
 	if v, ok := d.GetOk("token"); ok {
@@ -127,10 +144,13 @@ func resourceGitlabProjectHookRead(d *schema.ResourceData, meta interface{}) err
 
 	d.Set("url", hook.URL)
 	d.Set("push_events", hook.PushEvents)
+	d.Set("push_events_branch_filter", hook.PushEventsBranchFilter)
 	d.Set("issues_events", hook.IssuesEvents)
+	d.Set("confidential_issues_events", hook.ConfidentialIssuesEvents)
 	d.Set("merge_requests_events", hook.MergeRequestsEvents)
 	d.Set("tag_push_events", hook.TagPushEvents)
 	d.Set("note_events", hook.NoteEvents)
+	d.Set("confidential_note_events", hook.ConfidentialNoteEvents)
 	d.Set("job_events", hook.JobEvents)
 	d.Set("pipeline_events", hook.PipelineEvents)
 	d.Set("wiki_page_events", hook.WikiPageEvents)
@@ -146,16 +166,19 @@ func resourceGitlabProjectHookUpdate(d *schema.ResourceData, meta interface{}) e
 		return err
 	}
 	options := &gitlab.EditProjectHookOptions{
-		URL:                   gitlab.String(d.Get("url").(string)),
-		PushEvents:            gitlab.Bool(d.Get("push_events").(bool)),
-		IssuesEvents:          gitlab.Bool(d.Get("issues_events").(bool)),
-		MergeRequestsEvents:   gitlab.Bool(d.Get("merge_requests_events").(bool)),
-		TagPushEvents:         gitlab.Bool(d.Get("tag_push_events").(bool)),
-		NoteEvents:            gitlab.Bool(d.Get("note_events").(bool)),
-		JobEvents:             gitlab.Bool(d.Get("job_events").(bool)),
-		PipelineEvents:        gitlab.Bool(d.Get("pipeline_events").(bool)),
-		WikiPageEvents:        gitlab.Bool(d.Get("wiki_page_events").(bool)),
-		EnableSSLVerification: gitlab.Bool(d.Get("enable_ssl_verification").(bool)),
+		URL:                      gitlab.String(d.Get("url").(string)),
+		PushEvents:               gitlab.Bool(d.Get("push_events").(bool)),
+		PushEventsBranchFilter:   gitlab.String(d.Get("push_events_branch_filter").(string)),
+		IssuesEvents:             gitlab.Bool(d.Get("issues_events").(bool)),
+		ConfidentialIssuesEvents: gitlab.Bool(d.Get("confidential_issues_events").(bool)),
+		MergeRequestsEvents:      gitlab.Bool(d.Get("merge_requests_events").(bool)),
+		TagPushEvents:            gitlab.Bool(d.Get("tag_push_events").(bool)),
+		NoteEvents:               gitlab.Bool(d.Get("note_events").(bool)),
+		ConfidentialNoteEvents:   gitlab.Bool(d.Get("confidential_note_events").(bool)),
+		JobEvents:                gitlab.Bool(d.Get("job_events").(bool)),
+		PipelineEvents:           gitlab.Bool(d.Get("pipeline_events").(bool)),
+		WikiPageEvents:           gitlab.Bool(d.Get("wiki_page_events").(bool)),
+		EnableSSLVerification:    gitlab.Bool(d.Get("enable_ssl_verification").(bool)),
 	}
 
 	if d.HasChange("token") {

--- a/gitlab/resource_gitlab_project_hook.go
+++ b/gitlab/resource_gitlab_project_hook.go
@@ -84,6 +84,11 @@ func resourceGitlabProjectHook() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"deployment_events": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
 			"enable_ssl_verification": {
 				Type:     schema.TypeBool,
 				Optional: true,
@@ -109,6 +114,7 @@ func resourceGitlabProjectHookCreate(d *schema.ResourceData, meta interface{}) e
 		JobEvents:                gitlab.Bool(d.Get("job_events").(bool)),
 		PipelineEvents:           gitlab.Bool(d.Get("pipeline_events").(bool)),
 		WikiPageEvents:           gitlab.Bool(d.Get("wiki_page_events").(bool)),
+		DeploymentEvents:         gitlab.Bool(d.Get("deployment_events").(bool)),
 		EnableSSLVerification:    gitlab.Bool(d.Get("enable_ssl_verification").(bool)),
 	}
 
@@ -154,6 +160,7 @@ func resourceGitlabProjectHookRead(d *schema.ResourceData, meta interface{}) err
 	d.Set("job_events", hook.JobEvents)
 	d.Set("pipeline_events", hook.PipelineEvents)
 	d.Set("wiki_page_events", hook.WikiPageEvents)
+	d.Set("deployment_events", hook.DeploymentEvents)
 	d.Set("enable_ssl_verification", hook.EnableSSLVerification)
 	return nil
 }
@@ -178,6 +185,7 @@ func resourceGitlabProjectHookUpdate(d *schema.ResourceData, meta interface{}) e
 		JobEvents:                gitlab.Bool(d.Get("job_events").(bool)),
 		PipelineEvents:           gitlab.Bool(d.Get("pipeline_events").(bool)),
 		WikiPageEvents:           gitlab.Bool(d.Get("wiki_page_events").(bool)),
+		DeploymentEvents:         gitlab.Bool(d.Get("deployment_events").(bool)),
 		EnableSSLVerification:    gitlab.Bool(d.Get("enable_ssl_verification").(bool)),
 	}
 

--- a/gitlab/resource_gitlab_project_hook_test.go
+++ b/gitlab/resource_gitlab_project_hook_test.go
@@ -50,6 +50,7 @@ func TestAccGitlabProjectHook_basic(t *testing.T) {
 						JobEvents:                true,
 						PipelineEvents:           true,
 						WikiPageEvents:           true,
+						DeploymentEvents:         true,
 						EnableSSLVerification:    false,
 					}),
 				),
@@ -109,6 +110,7 @@ type testAccGitlabProjectHookExpectedAttributes struct {
 	JobEvents                bool
 	PipelineEvents           bool
 	WikiPageEvents           bool
+	DeploymentEvents         bool
 	EnableSSLVerification    bool
 }
 
@@ -164,6 +166,10 @@ func testAccCheckGitlabProjectHookAttributes(hook *gitlab.ProjectHook, want *tes
 
 		if hook.WikiPageEvents != want.WikiPageEvents {
 			return fmt.Errorf("got wiki_page_events %t; want %t", hook.WikiPageEvents, want.WikiPageEvents)
+		}
+
+		if hook.DeploymentEvents != want.DeploymentEvents {
+			return fmt.Errorf("got deployment_events %t; want %t", hook.DeploymentEvents, want.DeploymentEvents)
 		}
 
 		return nil
@@ -238,6 +244,7 @@ resource "gitlab_project_hook" "foo" {
   job_events = true
   pipeline_events = true
   wiki_page_events = true
+  deployment_events = true
 }
 	`, rInt, rInt)
 }

--- a/gitlab/resource_gitlab_project_hook_test.go
+++ b/gitlab/resource_gitlab_project_hook_test.go
@@ -38,16 +38,19 @@ func TestAccGitlabProjectHook_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabProjectHookExists("gitlab_project_hook.foo", &hook),
 					testAccCheckGitlabProjectHookAttributes(&hook, &testAccGitlabProjectHookExpectedAttributes{
-						URL:                   fmt.Sprintf("https://example.com/hook-%d", rInt),
-						PushEvents:            false,
-						IssuesEvents:          true,
-						MergeRequestsEvents:   true,
-						TagPushEvents:         true,
-						NoteEvents:            true,
-						JobEvents:             true,
-						PipelineEvents:        true,
-						WikiPageEvents:        true,
-						EnableSSLVerification: false,
+						URL:                      fmt.Sprintf("https://example.com/hook-%d", rInt),
+						PushEvents:               true,
+						PushEventsBranchFilter:   "devel",
+						IssuesEvents:             false,
+						ConfidentialIssuesEvents: false,
+						MergeRequestsEvents:      true,
+						TagPushEvents:            true,
+						NoteEvents:               true,
+						ConfidentialNoteEvents:   true,
+						JobEvents:                true,
+						PipelineEvents:           true,
+						WikiPageEvents:           true,
+						EnableSSLVerification:    false,
 					}),
 				),
 			},
@@ -94,16 +97,19 @@ func testAccCheckGitlabProjectHookExists(n string, hook *gitlab.ProjectHook) res
 }
 
 type testAccGitlabProjectHookExpectedAttributes struct {
-	URL                   string
-	PushEvents            bool
-	IssuesEvents          bool
-	MergeRequestsEvents   bool
-	TagPushEvents         bool
-	NoteEvents            bool
-	JobEvents             bool
-	PipelineEvents        bool
-	WikiPageEvents        bool
-	EnableSSLVerification bool
+	URL                      string
+	PushEvents               bool
+	PushEventsBranchFilter   string
+	IssuesEvents             bool
+	ConfidentialIssuesEvents bool
+	MergeRequestsEvents      bool
+	TagPushEvents            bool
+	NoteEvents               bool
+	ConfidentialNoteEvents   bool
+	JobEvents                bool
+	PipelineEvents           bool
+	WikiPageEvents           bool
+	EnableSSLVerification    bool
 }
 
 func testAccCheckGitlabProjectHookAttributes(hook *gitlab.ProjectHook, want *testAccGitlabProjectHookExpectedAttributes) resource.TestCheckFunc {
@@ -120,8 +126,16 @@ func testAccCheckGitlabProjectHookAttributes(hook *gitlab.ProjectHook, want *tes
 			return fmt.Errorf("got push_events %t; want %t", hook.PushEvents, want.PushEvents)
 		}
 
+		if hook.PushEventsBranchFilter != want.PushEventsBranchFilter {
+			return fmt.Errorf("got push_events_branch_filter %q; want %q", hook.PushEventsBranchFilter, want.PushEventsBranchFilter)
+		}
+
 		if hook.IssuesEvents != want.IssuesEvents {
 			return fmt.Errorf("got issues_events %t; want %t", hook.IssuesEvents, want.IssuesEvents)
+		}
+
+		if hook.ConfidentialIssuesEvents != want.ConfidentialIssuesEvents {
+			return fmt.Errorf("got confidential_issues_events %t; want %t", hook.ConfidentialIssuesEvents, want.ConfidentialIssuesEvents)
 		}
 
 		if hook.MergeRequestsEvents != want.MergeRequestsEvents {
@@ -134,6 +148,10 @@ func testAccCheckGitlabProjectHookAttributes(hook *gitlab.ProjectHook, want *tes
 
 		if hook.NoteEvents != want.NoteEvents {
 			return fmt.Errorf("got note_events %t; want %t", hook.NoteEvents, want.NoteEvents)
+		}
+
+		if hook.ConfidentialNoteEvents != want.ConfidentialNoteEvents {
+			return fmt.Errorf("got confidential_note_events %t; want %t", hook.ConfidentialNoteEvents, want.ConfidentialNoteEvents)
 		}
 
 		if hook.JobEvents != want.JobEvents {
@@ -209,11 +227,14 @@ resource "gitlab_project_hook" "foo" {
   project = "${gitlab_project.foo.id}"
   url = "https://example.com/hook-%d"
   enable_ssl_verification = false
-  push_events = false
-  issues_events = true
+  push_events = true
+  push_events_branch_filter = "devel"
+  issues_events = false
+  confidential_issues_events = false
   merge_requests_events = true
   tag_push_events = true
   note_events = true
+  confidential_note_events = true
   job_events = true
   pipeline_events = true
   wiki_page_events = true


### PR DESCRIPTION
Adds support for `push_events_branch_filter`, `confidential_issues_events` and `confidential_note_events` in `gitlab_project_hook` resource. See related issue #520.

Note that `deployment_events` is not yet supported in the currently vendored version of `go-gitlab`. Once #523 is merged I can prepare a separate PR for `deployment_events`.