### PR TITLE
Link badges in README to proper workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Terraform Provider for Gitlab
 - [![Gitter chat](https://badges.gitter.im/hashicorp-terraform/Lobby.png)](https://gitter.im/hashicorp-terraform/Lobby)
 - Mailing list: [Google Groups](http://groups.google.com/group/terraform-tool)
 - Build status:
-  - ![Unit Tests](https://github.com/gitlabhq/terraform-provider-gitlab/workflows/Unit%20Tests/badge.svg?branch=master)
-  - ![Acceptance Tests](https://github.com/gitlabhq/terraform-provider-gitlab/workflows/Acceptance%20Tests/badge.svg?branch=master)
+  - [![Unit Tests](https://github.com/gitlabhq/terraform-provider-gitlab/workflows/Unit%20Tests/badge.svg?branch=master)](https://github.com/gitlabhq/terraform-provider-gitlab/actions?query=workflow%3A%22Unit+Tests%22+branch%3Amaster)
+  - [![Acceptance Tests](https://github.com/gitlabhq/terraform-provider-gitlab/workflows/Acceptance%20Tests/badge.svg?branch=master)](https://github.com/gitlabhq/terraform-provider-gitlab/actions?query=workflow%3A%22Acceptance+Tests%22+branch%3Amaster)
   - ![Website Build](https://github.com/gitlabhq/terraform-provider-gitlab/workflows/Website%20Build/badge.svg?branch=master)
 
 Requirements


### PR DESCRIPTION
It's nice being able to click on those and getting redirected to the corresponding workflow.