### PR TITLE
Allow `full_path` in addition to `id` in gitlab_project data source

### DIFF
--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -10,11 +10,17 @@ data "gitlab_project" "example" {
 }
 ```
 
+```hcl
+data "gitlab_project" "example" {
+	id = "foo/bar/baz"
+}
+```
+
 ## Argument Reference
 
 The following arguments are supported:
 
-* `id` - (Required) The integer that uniquely identifies the project within the gitlab install.
+* `id` - (Required) The integer or path with namespace that uniquely identifies the project within the gitlab install.
 
 ## Attributes Reference
 

--- a/gitlab/data_source_gitlab_project.go
+++ b/gitlab/data_source_gitlab_project.go
@@ -16,7 +16,7 @@ func dataSourceGitlabProject() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"id": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeString,
 				Required: true,
 			},
 			"name": {

--- a/gitlab/data_source_gitlab_project_test.go
+++ b/gitlab/data_source_gitlab_project_test.go
@@ -17,6 +17,11 @@ func TestAccDataGitlabProject_basic(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
+				Config: testAccDataGitlabProjectConfigByPathWithNamespace(projectname),
+				Check: testAccDataSourceGitlabProject("gitlab_project.test", "data.gitlab_project.foo",
+					[]string{"id", "name", "path", "visibility", "description"}),
+			},
+			{
 				Config: testAccDataGitlabProjectConfig(projectname),
 				Check: testAccDataSourceGitlabProject("gitlab_project.test", "data.gitlab_project.foo",
 					[]string{"id", "name", "path", "visibility", "description"}),
@@ -64,6 +69,21 @@ resource "gitlab_project" "test"{
 
 data "gitlab_project" "foo" {
 	id = "${gitlab_project.test.id}"
+}
+	`, projectname, projectname)
+}
+
+func testAccDataGitlabProjectConfigByPathWithNamespace(projectname string) string {
+	return fmt.Sprintf(`
+resource "gitlab_project" "test"{
+	name = "%s"
+	path = "%s"
+	description = "Terraform acceptance tests"
+	visibility_level = "public"
+}
+
+data "gitlab_project" "foo" {
+	id = gitlab_project.test.path_with_namespace
 }
 	`, projectname, projectname)
 }


### PR DESCRIPTION
Fixes #140.