### PR TITLE
gitlab_project_mirror: Fix url attribute drift when using basicauth

### DIFF
--- a/gitlab/helper_test.go
+++ b/gitlab/helper_test.go
@@ -3,7 +3,11 @@ package gitlab
 import (
 	"errors"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"os"
 	"strings"
+	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/xanzy/go-gitlab"
@@ -50,4 +54,55 @@ func isRunningInEE() (bool, error) {
 func isRunningInCE() (bool, error) {
 	isEE, err := isRunningInEE()
 	return !isEE, err
+}
+
+// testAccGitlabProjectContext encapsulates a GitLab client and test project to be used during an
+// acceptance test.
+type testAccGitlabProjectContext struct {
+	t       *testing.T
+	client  *gitlab.Client
+	project *gitlab.Project
+}
+
+// finish deletes the test project. Call this when the test is finished, usually in a defer.
+func (c testAccGitlabProjectContext) finish() {
+	if _, err := c.client.Projects.DeleteProject(c.project.ID); err != nil {
+		c.t.Fatalf("could not delete test project: %v", err)
+	}
+}
+
+// testAccGitlabProjectStart initializes the GitLab client and creates a test project. Remember to
+// call testAccGitlabProjectContext.finish() when finished with the testAccGitlabProjectContext.
+func testAccGitlabProjectStart(t *testing.T) testAccGitlabProjectContext {
+	if os.Getenv(resource.TestEnvVar) == "" {
+		t.Skip(fmt.Sprintf("Acceptance tests skipped unless env '%s' set", resource.TestEnvVar))
+		return testAccGitlabProjectContext{}
+	}
+
+	var options []gitlab.ClientOptionFunc
+	baseURL := os.Getenv("GITLAB_BASE_URL")
+	if baseURL != "" {
+		options = append(options, gitlab.WithBaseURL(baseURL))
+	}
+
+	client, err := gitlab.NewClient(os.Getenv("GITLAB_TOKEN"), options...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	project, _, err := client.Projects.CreateProject(&gitlab.CreateProjectOptions{
+		Name:        gitlab.String(acctest.RandomWithPrefix("acctest")),
+		Description: gitlab.String("Terraform acceptance tests"),
+		// So that acceptance tests can be run in a gitlab organization with no billing
+		Visibility: gitlab.Visibility(gitlab.PublicVisibility),
+	})
+	if err != nil {
+		t.Fatalf("could not create test project: %v", err)
+	}
+
+	return testAccGitlabProjectContext{
+		t:       t,
+		client:  client,
+		project: project,
+	}
 }

--- a/gitlab/resource_gitlab_project_mirror.go
+++ b/gitlab/resource_gitlab_project_mirror.go
@@ -173,5 +173,10 @@ func resourceGitlabProjectMirrorSetToState(d *schema.ResourceData, projectMirror
 	d.Set("keep_divergent_refs", projectMirror.KeepDivergentRefs)
 	d.Set("only_protected_branches", projectMirror.OnlyProtectedBranches)
 	d.Set("project", projectID)
-	d.Set("url", projectMirror.URL)
+
+	if strings.Contains(projectMirror.URL, "*****") {
+		log.Printf("[DEBUG] project mirror %q will not detect any possible change to the url because it is redacted by Gitlab", d.Id())
+	} else {
+		d.Set("url", projectMirror.URL)
+	}
 }

--- a/gitlab/resource_gitlab_project_variable_test.go
+++ b/gitlab/resource_gitlab_project_variable_test.go
@@ -2,67 +2,14 @@ package gitlab
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"strconv"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/xanzy/go-gitlab"
 )
-
-// testAccGitlabProjectContext encapsulates a GitLab client and test project to be used during an
-// acceptance test.
-type testAccGitlabProjectContext struct {
-	t       *testing.T
-	client  *gitlab.Client
-	project *gitlab.Project
-}
-
-// finish deletes the test project. Call this when the test is finished, usually in a defer.
-func (c testAccGitlabProjectContext) finish() {
-	if _, err := c.client.Projects.DeleteProject(c.project.ID); err != nil {
-		c.t.Fatalf("could not delete test project: %v", err)
-	}
-}
-
-// testAccGitlabProjectStart initializes the GitLab client and creates a test project. Remember to
-// call testAccGitlabProjectContext.finish() when finished with the testAccGitlabProjectContext.
-func testAccGitlabProjectStart(t *testing.T) testAccGitlabProjectContext {
-	if os.Getenv(resource.TestEnvVar) == "" {
-		t.Skip(fmt.Sprintf("Acceptance tests skipped unless env '%s' set", resource.TestEnvVar))
-		return testAccGitlabProjectContext{}
-	}
-
-	var options []gitlab.ClientOptionFunc
-	baseURL := os.Getenv("GITLAB_BASE_URL")
-	if baseURL != "" {
-		options = append(options, gitlab.WithBaseURL(baseURL))
-	}
-
-	client, err := gitlab.NewClient(os.Getenv("GITLAB_TOKEN"), options...)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	project, _, err := client.Projects.CreateProject(&gitlab.CreateProjectOptions{
-		Name:        gitlab.String(acctest.RandomWithPrefix("acctest")),
-		Description: gitlab.String("Terraform acceptance tests"),
-		// So that acceptance tests can be run in a gitlab organization with no billing
-		Visibility: gitlab.Visibility(gitlab.PublicVisibility),
-	})
-	if err != nil {
-		t.Fatalf("could not create test project: %v", err)
-	}
-
-	return testAccGitlabProjectContext{
-		t:       t,
-		client:  client,
-		project: project,
-	}
-}
 
 func testAccCheckGitlabProjectVariableExists(client *gitlab.Client, name string) resource.TestCheckFunc {
 	var (


### PR DESCRIPTION
Fixes #504 

**Note** the `testAccGitlabProjectContext` code is not new; it is moved from the `gitlab_project_variable` test into our test utils.

The fix is to conditionally set the "url" attribute only if it does not contain redacted text.

The caveat is that the "url" attribute cannot be imported if it has redacted text. I don't expect this to be a problem. The attribute is `ForceNew: true` so any upstream change to the value is not possible.

As a bonus I fixed the destroy test to actually test the delete function, by creating the Gitlab project outside of the test state. I moved `testAccGitlabProjectContext` into `helper_test.go` now that it is used more than once, but didn't modify it.