### PR TITLE
Check for state change on user delete

### DIFF
--- a/gitlab/resource_gitlab_user_test.go
+++ b/gitlab/resource_gitlab_user_test.go
@@ -19,7 +19,7 @@ func TestAccGitlabUser_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckGitlabGroupDestroy,
+		CheckDestroy: testAccCheckGitlabUserDestroy,
 		Steps: []resource.TestStep{
 			// Create a user
 			{


### PR DESCRIPTION
Fixes #533 

I analyzed the test debug output and found that the problem was some inconsistency after a user is deleted.

I see `DELETE /api/v4/users/114 HTTP/1.1` return `HTTP/1.1 204 No Content`, and then later in the test during the destroy check, `GET /api/v4/users/114 HTTP/1.1` returns `HTTP/1.1 200 OK`.

This fix adds `WaitForState` to the `gitlab_user` delete function.