### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/

This bot is built into GitHub, and it will open a PR any time there's a minor update to one of our dependencies (like go-gitlab).