### PR TITLE
Fix EE tests actually running against CE

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -44,7 +44,7 @@ jobs:
         chmod 666 Gitlab-license.txt || true
 
     - name: Start Gitlab
-      run: make testacc-up
+      run: make testacc-up SERVICE=gitlab-ee
 
     - name: Run acceptance tests
       run: make testacc


### PR DESCRIPTION
In master, all acceptance tests are running against gitlab-ce. Problem was introduced in #535.