### PR TITLE
Fix "Run failed" on forks

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -24,7 +24,7 @@ jobs:
   acceptance-ee:
     timeout-minutes: 60
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' }}
+    if: github.event_name == 'push' && github.repository_owner == 'gitlabhq'
     steps:
     - name: Set up Go
       uses: actions/setup-go@v1
@@ -38,10 +38,7 @@ jobs:
     - name: Set up Enterprise Edition License file
       run: |
         openssl version
-        mkdir license
-        [[ -n "${{ secrets.LICENSE_ENCRYPTION_PASSWORD }}" ]] && echo decrypt
-        [[ -n "${{ secrets.LICENSE_ENCRYPTION_PASSWORD }}" ]] && openssl enc  -d -aes-256-cbc -pbkdf2 -iter 20000 -in Gitlab-license.encrypted -out Gitlab-license.txt -pass "pass:${{ secrets.LICENSE_ENCRYPTION_PASSWORD }}"
-        chmod 666 Gitlab-license.txt || true
+        openssl enc -d -aes-256-cbc -pbkdf2 -iter 20000 -in Gitlab-license.encrypted -out Gitlab-license.txt -pass "pass:${{ secrets.LICENSE_ENCRYPTION_PASSWORD }}"
 
     - name: Start Gitlab
       run: make testacc-up SERVICE=gitlab-ee


### PR DESCRIPTION
The acceptance-ee job is failing on the forked repo anytime someone makes a PR, which results in annoying notifications to the contributor. The fix is to only run the job if the repo is in the gitlabhq org.

I've verified that, with this fix, the job is enabled on pushes to this repo, but is disabled on forks.