### PR TITLE
Fix EE test mounting license as a directory

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - config-ce:/etc/gitlab
       - logs-ce:/var/log/gitlab
       - data-ce:/var/opt/gitlab
-      - ./scripts/healthcheck-and-setup.sh:/healthcheck-and-setup.sh
+      - ${PWD}/scripts/healthcheck-and-setup.sh:/healthcheck-and-setup.sh
     healthcheck:
       test: /healthcheck-and-setup.sh
       interval: 10s
@@ -36,8 +36,8 @@ services:
       - config-ee:/etc/gitlab
       - logs-ee:/var/log/gitlab
       - data-ee:/var/opt/gitlab
-      - ./scripts/healthcheck-and-setup.sh:/healthcheck-and-setup.sh
-      - ./Gitlab-license.txt:/Gitlab-license.txt
+      - ${PWD}/scripts/healthcheck-and-setup.sh:/healthcheck-and-setup.sh
+      - ${PWD}/Gitlab-license.txt:/Gitlab-license.txt
     healthcheck:
       test: /healthcheck-and-setup.sh
       interval: 10s

--- a/scripts/await-healthy.sh
+++ b/scripts/await-healthy.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env sh
 
-echo 'Waiting for GitLab container to become healthy'
+printf 'Waiting for GitLab container to become healthy'
 
 until test -n "$(docker ps --quiet --filter label=terraform-provider-gitlab/owned --filter health=healthy)"; do
   printf '.'
   sleep 5
 done
 
+echo
 echo 'GitLab is healthy'
+
+# Print the version, since it is useful debugging information.
+curl --silent --show-error --header 'PRIVATE-TOKEN: ACCTEST' http://127.0.0.1:8080/api/v4/version
+echo


### PR DESCRIPTION
See https://stackoverflow.com/questions/42248198/how-to-mount-a-single-file-in-a-volume

I noticed that the Gitlab-license.txt file was being replaced by an empty directory of the same name, on my local machine. Changing the volume to an absolute path seems to have fixed it for my latest run.