### PR TITLE
Mark gitlab_project.default_branch as Computed

### DIFF
--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -44,6 +44,7 @@ var resourceGitLabProjectSchema = map[string]*schema.Schema{
 	"default_branch": {
 		Type:     schema.TypeString,
 		Optional: true,
+		Computed: true,
 		DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 			// `old` is the current value on GitLab side
 			// `new` is the value that Terraform plans to set there


### PR DESCRIPTION
This makes it possible for other resources, such as `gitlab_branch_protection`, to depend on knowing the default branch once created.

Example:

```tf
resource "gitlab_project" "example" {
  namespace_id = 1234
  path         = "example"
  name         = "example"
}

resource "gitlab_branch_protection" "default" {
  project                      = gitlab_project.example.id
  branch                       = gitlab_project.example.default_branch
  merge_access_level           = "developer"
  push_access_level            = "maintainer"
}
```

If not marked as `Computed`, the `default_branch` attribute comes out as `""` instead when used in other resources, unless explicitly set by the user.