### PR TITLE
add diffSuppressFunc for 'expires_at' attribute in 'deploy_token'

### DIFF
--- a/gitlab/resource_gitlab_deploy_token.go
+++ b/gitlab/resource_gitlab_deploy_token.go
@@ -43,10 +43,11 @@ func resourceGitlabDeployToken() *schema.Resource {
 				ForceNew: true,
 			},
 			"expires_at": {
-				Type:         schema.TypeString,
-				Optional:     true,
-				ValidateFunc: validation.IsRFC3339Time,
-				ForceNew:     true,
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateFunc:     validation.IsRFC3339Time,
+				DiffSuppressFunc: expiresAtSuppressFunc,
+				ForceNew:         true,
 			},
 			"scopes": {
 				Type:     schema.TypeSet,
@@ -65,6 +66,15 @@ func resourceGitlabDeployToken() *schema.Resource {
 			},
 		},
 	}
+}
+
+func expiresAtSuppressFunc(k, old, new string, d *schema.ResourceData) bool {
+	oldDate, oldDateErr := time.Parse(time.RFC3339, old)
+	newDate, newDateErr := time.Parse(time.RFC3339, new)
+	if oldDateErr != nil || newDateErr != nil {
+		return false
+	}
+	return oldDate == newDate
 }
 
 func resourceGitlabDeployTokenCreate(d *schema.ResourceData, meta interface{}) error {

--- a/gitlab/resource_gitlab_deploy_token_test.go
+++ b/gitlab/resource_gitlab_deploy_token_test.go
@@ -199,10 +199,12 @@ func TestExpiresAtSuppressFunc(t *testing.T) {
 	}
 
 	for _, test := range testcases {
-		actual := expiresAtSuppressFunc("", test.old, test.new, nil)
-		if actual != test.expected {
-			t.Fatalf("FAIL %s - expiresAtSuppressFunc\n\told: %s, new: %s\n\texpected: %t\n\tactual: %t",
-				test.description, test.old, test.new, test.expected, actual)
-		}
+		t.Run(test.description, func(t *testing.T) {
+			actual := expiresAtSuppressFunc("", test.old, test.new, nil)
+			if actual != test.expected {
+				t.Fatalf("FAIL\n\told: %s, new: %s\n\texpected: %t\n\tactual: %t",
+					test.old, test.new, test.expected, actual)
+			}
+		})
 	}
 }

--- a/gitlab/resource_gitlab_deploy_token_test.go
+++ b/gitlab/resource_gitlab_deploy_token_test.go
@@ -156,7 +156,7 @@ resource "gitlab_deploy_token" "foo" {
   name     = "deployToken-%d"
   username = "my-username"
 
-  expires_at = "2021-03-14T07:20:50Z"
+  expires_at = "2021-03-14T07:20:50.000Z"
 
   scopes = [
 	"read_registry",
@@ -164,4 +164,45 @@ resource "gitlab_deploy_token" "foo" {
   ]
 }
   `, rInt, rInt)
+}
+
+type expiresAtSuppressFuncTest struct {
+	description string
+	old         string
+	new         string
+	expected    bool
+}
+
+func TestExpiresAtSuppressFunc(t *testing.T) {
+	testcases := []expiresAtSuppressFuncTest{
+		{
+			description: "same dates without millis",
+			old:         "2025-03-14T00:00:00Z",
+			new:         "2025-03-14T00:00:00Z",
+			expected:    true,
+		}, {
+			description: "different date without millis",
+			old:         "2025-03-14T00:00:00Z",
+			new:         "2025-03-14T11:11:11Z",
+			expected:    false,
+		}, {
+			description: "same date with and without millis",
+			old:         "2025-03-14T00:00:00Z",
+			new:         "2025-03-14T00:00:00.000Z",
+			expected:    true,
+		}, {
+			description: "cannot parse new date",
+			old:         "2025-03-14T00:00:00Z",
+			new:         "invalid-date",
+			expected:    false,
+		},
+	}
+
+	for _, test := range testcases {
+		actual := expiresAtSuppressFunc("", test.old, test.new, nil)
+		if actual != test.expected {
+			t.Fatalf("FAIL %s - expiresAtSuppressFunc\n\told: %s, new: %s\n\texpected: %t\n\tactual: %t",
+				test.description, test.old, test.new, test.expected, actual)
+		}
+	}
 }


### PR DESCRIPTION
Fixes #522 by adding a `diffSuppressFunc` for `expires_at` attribute of resource `deploy_token` that compares the date strings as `time.Time`.