### PR TITLE
Add gitlab_branch resource and data source

### DIFF
--- a/docs/data-sources/branch.md
+++ b/docs/data-sources/branch.md
@@ -1,0 +1,48 @@
+# gitlab\_branch
+
+Provides details about a specific branch in the gitlab provider. 
+
+## Example Usage
+
+
+**Branch name and url encoded project path**
+```hcl
+data "gitlab_branch" "example" {
+  name = "branch-name"
+  project = "namespace/project-name"
+}
+```
+**Branch name and test project ID**
+```hcl
+data "gitlab_branch" "example" {
+  name = "branch-name"
+  project = "270771234"
+}
+```
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the branch.
+
+* `project` - (Required) The full path of the group.
+
+## Attributes Reference
+
+The resource exports the following attributes:
+
+* `web_url` - The url of the created branch (https)
+* `default` - Bool, true if branch is the default branch for the project
+* `can_push` - Bool, true if you can push to the branch
+* `merged` - Bool, true if the branch has been merged into it's parent
+* `commit` - The list of group members.
+  * `id` - The unique id assigned to the commit by gitlab.
+  * `short_id` - The short id assigned to the commit by gitlab
+  * `author_email` - The email of the author.
+  * `author_name` - The name of the author.
+  * `authored_date` - The date which the commit was authored
+  * `commited_date` - The date at which the commit was pushed.
+  * `committer_email` - The email of the user that committed.
+  * `commiter_name` - The name of the user that committed.
+  * `title` - The title of the commit
+  * `message` - The commit message
+  * `parent_ids` - The id of the parents of the commit

--- a/docs/resources/branch.md
+++ b/docs/resources/branch.md
@@ -1,22 +1,14 @@
 # gitlab\_branch
 
-Provides details about a specific branch in the gitlab provider. 
+This resource allows you to create and manage branches for a gitlab project.
 
 ## Example Usage
 
-
-**Branch name and url encoded project path**
 ```hcl
-data "gitlab_branch" "example" {
+resource "gitlab_branch" "example" {
   name = "branch-name"
-  project = "namespace/project-name"
-}
-```
-**Branch name and test project ID**
-```hcl
-data "gitlab_branch" "example" {
-  name = "branch-name"
-  project = "270771234"
+  project = "12345"
+  ref = "existing-branch"
 }
 ```
 
@@ -27,6 +19,8 @@ The following arguments are supported:
 * `name` - (Required) The name of the branch.
 
 * `project` - (Required) The full path of the group.
+
+* `ref` - (Optional) The ref you branch from. Defaults to `master`
 
 ## Attributes Reference
 

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -64,7 +64,7 @@ equire all users in this group to setup Two-factor authentication.
 * `two_factor_grace_period` - (Optional) Int, defaults to 48.
 Time before Two-factor authentication is enforced (in hours).
 
-* `parent_id` - (Optional) Integer, id of the parent group (creates a nested group).
+* `parent_id` - (Optional) Integer, id or full path of the parent group (creates a nested group).
 
 ## Attributes Reference
 

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -24,7 +24,7 @@ The following arguments are supported:
 * `path` - (Optional) The path of the repository.
 
 * `namespace_id` - (Optional) The namespace (group or user) of the project. Defaults to your user.
-  See [`gitlab_group`](group.html) for an example.
+  See [`gitlab_group`](group.html) for an example. Can use ID or full URL path
 
 * `description` - (Optional) A description of the project.
 

--- a/gitlab/data_source_gitlab_branch.go
+++ b/gitlab/data_source_gitlab_branch.go
@@ -53,7 +53,6 @@ func dataSourceGitlabBranch() *schema.Resource {
 				Type:     schema.TypeList,
 				MaxItems: 1,
 				Computed: true,
-				Optional: true,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
@@ -139,6 +138,9 @@ func dataSourceGitlabBranchRead(d *schema.ResourceData, meta interface{}) error 
 	d.Set("merged", branch.Merged)
 	d.Set("developer_can_merge", branch.DevelopersCanMerge)
 	d.Set("developer_can_push", branch.DevelopersCanPush)
-	d.Set("commit", flattenCommit(branch.Commit))
+	commit := flattenCommit(branch.Commit)
+	if err := d.Set("commit", commit); err != nil {
+		return err
+	}
 	return nil
 }

--- a/gitlab/data_source_gitlab_branch.go
+++ b/gitlab/data_source_gitlab_branch.go
@@ -25,23 +25,11 @@ func dataSourceGitlabBranch() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"protected": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
 			"default": {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
 			"can_push": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"developer_can_push": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"developer_can_merge": {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},

--- a/gitlab/data_source_gitlab_branch.go
+++ b/gitlab/data_source_gitlab_branch.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"log"
 
-	// "github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/xanzy/go-gitlab"
 )

--- a/gitlab/data_source_gitlab_branch.go
+++ b/gitlab/data_source_gitlab_branch.go
@@ -4,16 +4,14 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	// "github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/xanzy/go-gitlab"
 )
 
-
 func dataSourceGitlabBranch() *schema.Resource {
-	// TODO project -> project_name
 	return &schema.Resource{
-		Read:   dataSourceGitlabBranchRead,
+		Read: dataSourceGitlabBranchRead,
 		Schema: map[string]*schema.Schema{
 			"name": {
 				Type:     schema.TypeString,
@@ -123,13 +121,8 @@ func dataSourceGitlabBranch() *schema.Resource {
 
 func dataSourceGitlabBranchRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gitlab.Client)
-	nameData, nameOk := d.GetOk("name")
-	projectData, projectOk := d.GetOk("project")
-	if !nameOk || !projectOk {
-		return fmt.Errorf("Name and project must be set for a gitlab branch")
-	}
-	name := nameData.(string)
-	project := projectData.(string)
+	name := d.Get("name").(string)
+	project := d.Get("project").(string)
 	log.Printf("[DEBUG] read gitlab branch %s", name)
 	branch, resp, err := client.Branches.GetBranch(project, name)
 	if err != nil {

--- a/gitlab/data_source_gitlab_branch.go
+++ b/gitlab/data_source_gitlab_branch.go
@@ -1,0 +1,151 @@
+package gitlab
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/xanzy/go-gitlab"
+)
+
+
+func dataSourceGitlabBranch() *schema.Resource {
+	// TODO project -> project_name
+	return &schema.Resource{
+		Read:   dataSourceGitlabBranchRead,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"project": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"web_url": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"protected": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"default": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"can_push": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"developer_can_push": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"developer_can_merge": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"merged": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"commit": {
+				Type:     schema.TypeList,
+				MaxItems: 1,
+				Computed: true,
+				Optional: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"id": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+						"author_email": {
+							Type:     schema.TypeString,
+							Computed: true,
+							Optional: true,
+						},
+						"author_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+							Optional: true,
+						},
+						"authored_date": {
+							Type:     schema.TypeString,
+							Computed: true,
+							Optional: true,
+						},
+						"committed_date": {
+							Type:     schema.TypeString,
+							Computed: true,
+							Optional: true,
+						},
+						"committer_email": {
+							Type:     schema.TypeString,
+							Computed: true,
+							Optional: true,
+						},
+						"committer_name": {
+							Type:     schema.TypeString,
+							Computed: true,
+							Optional: true,
+						},
+						"short_id": {
+							Type:     schema.TypeString,
+							Computed: true,
+							Optional: true,
+						},
+						"title": {
+							Type:     schema.TypeString,
+							Computed: true,
+							Optional: true,
+						},
+						"message": {
+							Type:     schema.TypeString,
+							Computed: true,
+							Optional: true,
+						},
+						"parent_ids": {
+							Type:     schema.TypeSet,
+							Computed: true,
+							Optional: true,
+							Elem:     &schema.Schema{Type: schema.TypeString},
+							Set:      schema.HashString,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceGitlabBranchRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	nameData, nameOk := d.GetOk("name")
+	projectData, projectOk := d.GetOk("project")
+	if !nameOk || !projectOk {
+		return fmt.Errorf("Name and project must be set for a gitlab branch")
+	}
+	name := nameData.(string)
+	project := projectData.(string)
+	log.Printf("[DEBUG] read gitlab branch %s", name)
+	branch, resp, err := client.Branches.GetBranch(project, name)
+	if err != nil {
+		log.Printf("[DEBUG] failed to read gitlab branch %s response %v", name, resp)
+		return err
+	}
+	d.SetId(fmt.Sprintf("%s-%s", project, name))
+	d.Set("name", branch.Name)
+	d.Set("project", project)
+	d.Set("web_url", branch.WebURL)
+	d.Set("default", branch.Default)
+	d.Set("can_push", branch.CanPush)
+	d.Set("protected", branch.Protected)
+	d.Set("merged", branch.Merged)
+	d.Set("developer_can_merge", branch.DevelopersCanMerge)
+	d.Set("developer_can_push", branch.DevelopersCanPush)
+	d.Set("commit", flattenCommit(branch.Commit))
+	return nil
+}

--- a/gitlab/data_source_gitlab_branch_test.go
+++ b/gitlab/data_source_gitlab_branch_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
+// TODO branch with existing protection
 func TestAccDataGitlabBranch_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 

--- a/gitlab/data_source_gitlab_branch_test.go
+++ b/gitlab/data_source_gitlab_branch_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 )
 
-// TODO branch with existing protection
 func TestAccDataGitlabBranch_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
@@ -43,9 +42,6 @@ func testAccDataSourceGitlabBranch(src, n string) resource.TestCheckFunc {
 			"default",
 			"project",
 			"can_push",
-			"protected",
-			"developer_can_push",
-			"developer_can_merge",
 			"merged",
 			"commit",
 			"parent_ids",
@@ -56,7 +52,6 @@ func testAccDataSourceGitlabBranch(src, n string) resource.TestCheckFunc {
 				return fmt.Errorf("expected branch's parameter `%s` to be: %s, but got: `%s`", attribute, branchAttr[attribute], searchAttr[attribute])
 			}
 		}
-
 		return nil
 	}
 }

--- a/gitlab/data_source_gitlab_branch_test.go
+++ b/gitlab/data_source_gitlab_branch_test.go
@@ -1,0 +1,90 @@
+package gitlab
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+)
+
+func TestAccDataGitlabBranch_basic(t *testing.T) {
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataGitlabBranch(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceGitlabBranch("gitlab_branch.foo", "data.gitlab_branch.foo"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceGitlabBranch(src, n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+
+		branch := s.RootModule().Resources[src]
+		branchAttr := branch.Primary.Attributes
+
+		search := s.RootModule().Resources[n]
+		searchAttr := search.Primary.Attributes
+
+		testAttributes := []string{
+			"id",
+			"name",
+			"web_url",
+			"default",
+			"project",
+			"can_push",
+			"protected",
+			"developer_can_push",
+			"developer_can_merge",
+			"merged",
+			"commit",
+			"parent_ids",
+		}
+
+		for _, attribute := range testAttributes {
+			if searchAttr[attribute] != branchAttr[attribute] {
+				return fmt.Errorf("expected branch's parameter `%s` to be: %s, but got: `%s`", attribute, branchAttr[attribute], searchAttr[attribute])
+			}
+		}
+
+		return nil
+	}
+}
+
+func testAccDataGitlabBranch(rInt int) string {
+	return fmt.Sprintf(`
+%s
+
+data "gitlab_branch" "foo" {
+  name = "${gitlab_branch.foo.name}"
+  project = "${gitlab_branch.foo.project}"
+}
+`, testAccDataGitlabBranchSetup(rInt))
+}
+
+func testAccDataGitlabBranchSetup(rInt int) string {
+	return fmt.Sprintf(`
+	resource "gitlab_project" "test" {
+		name = "foo-%d"
+		description = "Terraform acceptance tests"
+	  
+		# So that acceptance tests can be run in a gitlab organization
+		# with no billing
+		visibility_level = "public"
+	}
+	resource "gitlab_branch" "foo" {
+		name = "testbranch-%d"
+		ref = "master"
+		project = gitlab_project.test.id
+	}
+  `, rInt, rInt)
+}

--- a/gitlab/data_source_gitlab_group.go
+++ b/gitlab/data_source_gitlab_group.go
@@ -61,7 +61,7 @@ func dataSourceGitlabGroup() *schema.Resource {
 				Computed: true,
 			},
 			"parent_id": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"runners_token": {
@@ -99,7 +99,10 @@ func dataSourceGitlabGroupRead(d *schema.ResourceData, meta interface{}) error {
 	} else {
 		return fmt.Errorf("one and only one of group_id or full_path must be set")
 	}
-
+	parentID := ""
+	if group.ParentID > 0 {
+		parentID = fmt.Sprintf("%d", group.ParentID)
+	}
 	d.Set("group_id", group.ID)
 	d.Set("full_path", group.FullPath)
 	d.Set("name", group.Name)
@@ -110,7 +113,7 @@ func dataSourceGitlabGroupRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("lfs_enabled", group.LFSEnabled)
 	d.Set("request_access_enabled", group.RequestAccessEnabled)
 	d.Set("visibility_level", group.Visibility)
-	d.Set("parent_id", group.ParentID)
+	d.Set("parent_id", parentID)
 	d.Set("runners_token", group.RunnersToken)
 
 	d.SetId(fmt.Sprintf("%d", group.ID))

--- a/gitlab/provider.go
+++ b/gitlab/provider.go
@@ -64,7 +64,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"gitlab_branch":					 resourceGitlabBranch(),
+			"gitlab_branch":                     resourceGitlabBranch(),
 			"gitlab_branch_protection":          resourceGitlabBranchProtection(),
 			"gitlab_tag_protection":             resourceGitlabTagProtection(),
 			"gitlab_group":                      resourceGitlabGroup(),

--- a/gitlab/provider.go
+++ b/gitlab/provider.go
@@ -64,6 +64,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
+			"gitlab_branch":					 resourceGitlabBranch(),
 			"gitlab_branch_protection":          resourceGitlabBranchProtection(),
 			"gitlab_tag_protection":             resourceGitlabTagProtection(),
 			"gitlab_group":                      resourceGitlabGroup(),

--- a/gitlab/provider.go
+++ b/gitlab/provider.go
@@ -55,6 +55,7 @@ func Provider() terraform.ResourceProvider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
+			"gitlab_branch":           dataSourceGitlabBranch(),
 			"gitlab_group":            dataSourceGitlabGroup(),
 			"gitlab_group_membership": dataSourceGitlabGroupMembership(),
 			"gitlab_project":          dataSourceGitlabProject(),

--- a/gitlab/resource_gitlab_branch.go
+++ b/gitlab/resource_gitlab_branch.go
@@ -2,9 +2,9 @@ package gitlab
 
 import (
 	"fmt"
-	"log"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	gitlab "github.com/xanzy/go-gitlab"
+	"log"
 )
 
 func resourceGitlabBranch() *schema.Resource {
@@ -91,7 +91,7 @@ func resourceGitlabBranchRead(d *schema.ResourceData, meta interface{}) error {
 		log.Printf("[DEBUG] failed to read gitlab branch %s response %v", name, resp)
 		return err
 	}
-	d.SetId(fmt.Sprintf("%s-%s",project, name))
+	d.SetId(fmt.Sprintf("%s-%s", project, name))
 	d.Set("name", branch.Name)
 	d.Set("project", project)
 	d.Set("ref", ref)

--- a/gitlab/resource_gitlab_branch.go
+++ b/gitlab/resource_gitlab_branch.go
@@ -12,6 +12,7 @@ import (
 func resourceGitlabBranch() *schema.Resource {
 	// removed guest TODO check acceptable access levels
 	// ref force new false --- TODO resolve if incorrect
+	// TODO project -> project_name
 	// acceptedAccessLevels := []string{ "reporter", "developer", "maintainer"}
 
 	return &schema.Resource{

--- a/gitlab/resource_gitlab_branch.go
+++ b/gitlab/resource_gitlab_branch.go
@@ -33,23 +33,11 @@ func resourceGitlabBranch() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"protected": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
 			"default": {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
 			"can_push": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"developer_can_push": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
-			"developer_can_merge": {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
@@ -59,9 +47,8 @@ func resourceGitlabBranch() *schema.Resource {
 			},
 			"commit": {
 				Type:     schema.TypeList,
-				MaxItems: 1,
 				Computed: true,
-				Optional: true,
+				MaxItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"id": {
@@ -113,13 +100,6 @@ func resourceGitlabBranch() *schema.Resource {
 							Computed: true,
 							Optional: true,
 						},
-						"parent_ids": {
-							Type:     schema.TypeSet,
-							Computed: true,
-							Optional: true,
-							Elem:     &schema.Schema{Type: schema.TypeString},
-							Set:      schema.HashString,
-						},
 					},
 				},
 			},
@@ -163,11 +143,12 @@ func resourceGitlabBranchRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("web_url", branch.WebURL)
 	d.Set("default", branch.Default)
 	d.Set("can_push", branch.CanPush)
-	d.Set("protected", branch.Protected)
 	d.Set("merged", branch.Merged)
-	d.Set("developer_can_merge", branch.DevelopersCanMerge)
-	d.Set("developer_can_push", branch.DevelopersCanPush)
-	d.Set("commit", flattenCommit(branch.Commit))
+	commit := flattenCommit(branch.Commit)
+	if err := d.Set("commit", commit); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -190,17 +171,11 @@ func flattenCommit(commit *gitlab.Commit) (values []map[string]interface{}) {
 
 	return []map[string]interface{}{
 		{
-			"id":              commit.ID,
-			"short_id":        commit.ShortID,
-			"title":           commit.Title,
-			"author_name":     commit.AuthorName,
-			"author_email":    commit.AuthorEmail,
-			"authored_date":   commit.AuthoredDate.String(),
-			"committed_date":  commit.CommittedDate.String(),
-			"committer_email": commit.CommitterEmail,
-			"commiter_name":   commit.CommitterName,
-			"message":         commit.Message,
-			"parent_ids":      commit.ParentIDs,
+			"id":          commit.ID,
+			"short_id":    commit.ShortID,
+			"title":       commit.Title,
+			"author_name": commit.AuthorName,
+			"message":     commit.Message,
 		},
 	}
 }

--- a/gitlab/resource_gitlab_branch.go
+++ b/gitlab/resource_gitlab_branch.go
@@ -1,0 +1,88 @@
+package gitlab 
+
+import (
+	// "errors"
+	// "fmt"
+	"log"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	gitlab "github.com/xanzy/go-gitlab"
+)
+
+func resourceGitlabBranch() *schema.Resource {
+	// removed guest TODO check acceptable access levels 
+	// ref force new false --- TODO resolve if incorrect
+	// acceptedAccessLevels := []string{ "reporter", "developer", "maintainer"}
+
+	return &schema.Resource{
+		Create: resourceGitlabBranchCreate,
+		Read:   resourceGitlabBranchRead,
+		Delete: resourceGitlabBranchDelete,
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"project": {
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
+			},
+			"ref": {
+				Type:         schema.TypeString,
+				ForceNew:     false,
+				Required:     true,
+			},
+		},
+	}
+}
+
+func resourceGitlabBranchCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	name := d.Get("name").(string)
+	project := d.Get("project").(string)
+	ref := d.Get("ref").(string)
+	branchOptions := &gitlab.CreateBranchOptions{
+		Branch: &name, Ref: &ref,
+	}
+
+	log.Printf("[DEBUG] create gitlab branch %s for project %s with ref %s", name, project, ref)
+	// requestOptions := &gitlab.RequestOptionFunc()
+	branch, resp, err := client.Branches.CreateBranch(project, branchOptions)
+	if err != nil {
+		log.Printf("[DEBUG] failed to create gitlab branch %v response %v", branch, resp)
+		return err
+	}
+	return nil
+}
+
+
+// type Branch struct {
+// 	Commit             *Commit `json:"commit"`
+// 	Name               string  `json:"name"`
+// 	Protected          bool    `json:"protected"`
+// 	Merged             bool    `json:"merged"`
+// 	Default            bool    `json:"default"`
+// 	CanPush            bool    `json:"can_push"`
+// 	DevelopersCanPush  bool    `json:"developers_can_push"`
+// 	DevelopersCanMerge bool    `json:"developers_can_merge"`
+// 	WebURL             string  `json:"web_url"`
+// }
+
+func resourceGitlabBranchRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	log.Printf("[DEBUG] read gitlab group %s", d.Id())
+	name := d.Get("name").(string)
+	project := d.Get("project").(string)
+	branch, resp, err := client.Branches.GetBranch( project, name )
+	if err != nil {
+		log.Printf("[DEBUG] failed to read gitlab branch %s response %v", branch, resp)
+	}
+	d.Set("name", branch.Name) 
+	return nil
+}
+
+func resourceGitlabBranchDelete(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}

--- a/gitlab/resource_gitlab_branch.go
+++ b/gitlab/resource_gitlab_branch.go
@@ -53,9 +53,8 @@ func resourceGitlabBranchCreate(d *schema.ResourceData, meta interface{}) error 
 	branch, resp, err := client.Branches.CreateBranch(project, branchOptions)
 	if err != nil {
 		log.Printf("[DEBUG] failed to create gitlab branch %v response %v", branch, resp)
-		return err
 	}
-	return resourceGitlabBranchRead(d, meta)
+	return err
 }
 
 // TODO investigate setting
@@ -73,15 +72,13 @@ func resourceGitlabBranchCreate(d *schema.ResourceData, meta interface{}) error 
 
 func resourceGitlabBranchRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gitlab.Client)
-	project, name, err := projectAndBranchFromID(d.Id())
-	log.Printf("[DEBUG] read gitlab branch %s", d.Id())
+	name := d.Get("name").(string)
+	project := d.Get("project").(string)
+	log.Printf("[DEBUG] read gitlab branch %s", name)
 	branch, resp, err := client.Branches.GetBranch(project, name)
 	if err != nil {
 		log.Printf("[DEBUG] failed to read gitlab branch %s response %v", branch, resp)
 	}
-	d.Set("name", branch.Name)
-	d.Set("ref", d.Get("ref").(string))
-	d.Set("project", project)
 	return err
 }
 

--- a/gitlab/resource_gitlab_branch.go
+++ b/gitlab/resource_gitlab_branch.go
@@ -88,7 +88,7 @@ func resourceGitlabBranchDelete(d *schema.ResourceData, meta interface{}) error 
 	client := meta.(*gitlab.Client)
 	project, name, err := projectAndBranchFromID(d.Id())
 	log.Printf("[DEBUG] delete gitlab branch %s", name)
-	_, err := client.Branches.DeleteBranch(project, name)
+	_, err = client.Branches.DeleteBranch(project, name)
 
 	return err
 }

--- a/gitlab/resource_gitlab_branch.go
+++ b/gitlab/resource_gitlab_branch.go
@@ -1,4 +1,4 @@
-package gitlab 
+package gitlab
 
 import (
 	// "errors"
@@ -10,7 +10,7 @@ import (
 )
 
 func resourceGitlabBranch() *schema.Resource {
-	// removed guest TODO check acceptable access levels 
+	// removed guest TODO check acceptable access levels
 	// ref force new false --- TODO resolve if incorrect
 	// acceptedAccessLevels := []string{ "reporter", "developer", "maintainer"}
 
@@ -30,9 +30,9 @@ func resourceGitlabBranch() *schema.Resource {
 				Required: true,
 			},
 			"ref": {
-				Type:         schema.TypeString,
-				ForceNew:     false,
-				Required:     true,
+				Type:     schema.TypeString,
+				ForceNew: true,
+				Required: true,
 			},
 		},
 	}
@@ -78,7 +78,7 @@ func resourceGitlabBranchRead(d *schema.ResourceData, meta interface{}) error {
 	if err != nil {
 		log.Printf("[DEBUG] failed to read gitlab branch %s response %v", branch, resp)
 	}
-	d.Set("name", branch.Name) 	
+	d.Set("name", branch.Name)
 	d.Set("ref", d.Get("ref").(string))
 	d.Set("project", project)
 	return err

--- a/gitlab/resource_gitlab_branch.go
+++ b/gitlab/resource_gitlab_branch.go
@@ -8,7 +8,6 @@ import (
 )
 
 func resourceGitlabBranch() *schema.Resource {
-	// TODO project -> project_name
 	return &schema.Resource{
 		Create: resourceGitlabBranchCreate,
 		Read:   resourceGitlabBranchRead,
@@ -27,7 +26,8 @@ func resourceGitlabBranch() *schema.Resource {
 			"ref": {
 				Type:     schema.TypeString,
 				ForceNew: true,
-				Required: true,
+				Optional: true,
+				Default:  "master",
 			},
 			"web_url": {
 				Type:     schema.TypeString,

--- a/gitlab/resource_gitlab_branch.go
+++ b/gitlab/resource_gitlab_branch.go
@@ -54,10 +54,10 @@ func resourceGitlabBranchCreate(d *schema.ResourceData, meta interface{}) error 
 		log.Printf("[DEBUG] failed to create gitlab branch %v response %v", branch, resp)
 		return err
 	}
-	return nil
+	return resourceGitlabBranchRead(d, meta)
 }
 
-
+// TODO investigate setting
 // type Branch struct {
 // 	Commit             *Commit `json:"commit"`
 // 	Name               string  `json:"name"`
@@ -72,17 +72,23 @@ func resourceGitlabBranchCreate(d *schema.ResourceData, meta interface{}) error 
 
 func resourceGitlabBranchRead(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gitlab.Client)
-	log.Printf("[DEBUG] read gitlab group %s", d.Id())
-	name := d.Get("name").(string)
-	project := d.Get("project").(string)
-	branch, resp, err := client.Branches.GetBranch( project, name )
+	project, name, err := projectAndBranchFromID(d.Id())
+	log.Printf("[DEBUG] read gitlab branch %s", d.Id())
+	branch, resp, err := client.Branches.GetBranch(project, name)
 	if err != nil {
 		log.Printf("[DEBUG] failed to read gitlab branch %s response %v", branch, resp)
 	}
-	d.Set("name", branch.Name) 
-	return nil
+	d.Set("name", branch.Name) 	
+	d.Set("ref", d.Get("ref").(string))
+	d.Set("project", project)
+	return err
 }
 
 func resourceGitlabBranchDelete(d *schema.ResourceData, meta interface{}) error {
-	return nil
+	client := meta.(*gitlab.Client)
+	project, name, err := projectAndBranchFromID(d.Id())
+	log.Printf("[DEBUG] delete gitlab branch %s", name)
+	_, err := client.Branches.DeleteBranch(project, name)
+
+	return err
 }

--- a/gitlab/resource_gitlab_branch_test.go
+++ b/gitlab/resource_gitlab_branch_test.go
@@ -63,7 +63,7 @@ func testAccCheckGitlabBranchAttributes(n string, branch *gitlab.Branch, want *t
 			return errors.New("No ID set for branch")
 		}
 		if branch.Commit.ID == "" {
-			return errors.New("Empty commit message")
+			return errors.New("Empty commit")
 		}
 		if branch.Name != want.Name {
 			return fmt.Errorf("got name %s; want %s", branch.Name, want.Name)

--- a/gitlab/resource_gitlab_branch_test.go
+++ b/gitlab/resource_gitlab_branch_test.go
@@ -27,12 +27,44 @@ func TestAccGitlabBranch_basic(t *testing.T) {
 					testAccCheckGitlabBranchExists("foo", "test", &branch, rInt),
 					testAccCheckGitlabBranchExists("foo2", "test", &branch2, rInt),
 					testAccCheckGitlabBranchAttributes("foo", "test", &branch, &testAccGitlabBranchExpectedAttributes{
-						Name: fmt.Sprintf("testbranch-%d", rInt),
+						Name:               fmt.Sprintf("testbranch-%d", rInt),
+						Protected:          false,
+						DevelopersCanMerge: false,
+						DevelopersCanPush:  false,
 					}),
 					testAccCheckGitlabBranchAttributes("foo2", "test", &branch2, &testAccGitlabBranchExpectedAttributes{
-						Name: fmt.Sprintf("testbranch2-%d", rInt),
+						Name:               fmt.Sprintf("testbranch2-%d", rInt),
+						Protected:          false,
+						DevelopersCanMerge: false,
+						DevelopersCanPush:  false,
 					}),
 					testAccCheckGitlabBranchRef("foo2", fooBranchName),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGitlabBranch_protected(t *testing.T) {
+	var branch gitlab.Branch
+	rInt := acctest.RandInt()
+	fooBranchName := fmt.Sprintf("testbranch-%d", rInt)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGitlabBranchDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGitlabBranchProtectedConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabBranchExists("foo", "test", &branch, rInt),
+					testAccCheckGitlabBranchAttributes("foo", "test", &branch, &testAccGitlabBranchExpectedAttributes{
+						Name:               fooBranchName,
+						Protected:          true,
+						DevelopersCanMerge: true,
+						DevelopersCanPush:  true,
+					}),
 				),
 			},
 		},
@@ -77,11 +109,14 @@ func testAccCheckGitlabBranchAttributes(n, p string, branch *gitlab.Branch, want
 		if branch.WebURL == "" {
 			return errors.New("got empty web url")
 		}
+		if branch.Protected != want.Protected {
+			return fmt.Errorf("protected %t; want %t", branch.CanPush, want.CanPush)
+		}
 		projectID := s.RootModule().Resources[fmt.Sprintf("gitlab_project.%s", p)].Primary.ID
 		if s.RootModule().Resources[fmt.Sprintf("gitlab_branch.%s", n)].Primary.ID != fmt.Sprintf("%s-%s", projectID, want.Name) {
 			return fmt.Errorf("Got ID: %s expected: %s-%s", s.RootModule().Resources[fmt.Sprintf("gitlab_branch.%s", n)].Primary.ID, projectID, want.Name)
 		}
-		if branch.Commit.ID == "" {
+		if branch.Commit == nil {
 			return errors.New("Empty commit")
 		}
 		if branch.Name != want.Name {
@@ -90,11 +125,11 @@ func testAccCheckGitlabBranchAttributes(n, p string, branch *gitlab.Branch, want
 		if !branch.CanPush {
 			return fmt.Errorf("can push %t; want %t", branch.CanPush, want.CanPush)
 		}
-		if branch.DevelopersCanPush {
-			return errors.New("Developers can push expected output to be false")
+		if branch.DevelopersCanPush != want.DevelopersCanPush {
+			return fmt.Errorf("Developers can push  %t; want %t", branch.DevelopersCanPush, want.DevelopersCanPush)
 		}
-		if branch.DevelopersCanMerge {
-			return errors.New("Developers can merge expected output to be false")
+		if branch.DevelopersCanMerge != want.DevelopersCanMerge {
+			return fmt.Errorf("Developers can merge  %t; want %t", branch.DevelopersCanMerge, want.DevelopersCanMerge)
 		}
 		if branch.Default {
 			return errors.New("Default branch set to true")
@@ -119,6 +154,31 @@ func testAccCheckGitlabBranchExists(n, p string, branch *gitlab.Branch, rInt int
 		*branch = *gotBranch
 		return err
 	}
+}
+
+func testAccGitlabBranchProtectedConfig(rInt int) string {
+	return fmt.Sprintf(`
+	resource "gitlab_project" "test" {
+		name = "foo-%d"
+		description = "Terraform acceptance tests"
+	  
+		# So that acceptance tests can be run in a gitlab organization
+		# with no billing
+		visibility_level = "public"
+	}
+
+	resource "gitlab_branch_protection" "foo" {
+		project = "${gitlab_branch.foo.project}"
+		branch = "${gitlab_branch.foo.name}"
+		push_access_level = "developer"
+		merge_access_level = "developer"
+	  }
+	resource "gitlab_branch" "foo" {
+		name = "testbranch-%d"
+		ref = "master"
+		project = gitlab_project.test.id
+	}
+`, rInt, rInt)
 }
 
 func testAccGitlabBranchConfig(rInt int) string {

--- a/gitlab/resource_gitlab_branch_test.go
+++ b/gitlab/resource_gitlab_branch_test.go
@@ -1,14 +1,13 @@
 package gitlab
 
 import (
+	"errors"
 	"fmt"
-	"log"
-	"testing"
-
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	gitlab "github.com/xanzy/go-gitlab"
+	"testing"
 )
 
 func TestAccGitlabBranch_basic(t *testing.T) {
@@ -20,11 +19,18 @@ func TestAccGitlabBranch_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGitlabBranchDestroy,
 		Steps: []resource.TestStep{
-			// Create a group
 			{
 				Config: testAccGitlabBranchConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabBranchExists("gitlab_branch.foo", &branch, rInt),
+					testAccCheckGitlabBranchAttributes(&branch, &testAccGitlabBranchExpectedAttributes{
+						Name:               fmt.Sprintf("testbranch-%d", rInt),
+						CanPush:            true,
+						DevelopersCanMerge: false,
+						DevelopersCanPush:  false,
+						Default:            false,
+						Merged:             false,
+					}),
 				),
 			},
 		},
@@ -32,27 +38,52 @@ func TestAccGitlabBranch_basic(t *testing.T) {
 }
 
 func testAccCheckGitlabBranchDestroy(s *terraform.State) error {
-	// conn := testAccProvider.Meta().(*gitlab.Client)
-
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "gitlab_branch" {
 			continue
 		}
-		// branch, resp, err := conn.Branches.GetBranch(rs.Primary.ID ,rs.Primary.Name)
-		// // if err == nil {
-		// // 	if group != nil && fmt.Sprintf("%d", group.ID) == rs.Primary.ID {
-		// // 		if group.MarkedForDeletionOn == nil {
-		// // 			return fmt.Errorf("Group still exists")
-		// // 		}
-		// // 	}
-		// // }
-		// if resp.StatusCode != 404 {
-		// 	return err
-		// }
-		// return nil
+		name := rs.Primary.Attributes["name"]
+		pid := s.RootModule().Resources["gitlab_project.test"].Primary.ID
+		conn := testAccProvider.Meta().(*gitlab.Client)
+		branch, resp, err := conn.Branches.GetBranch(pid, name)
+		if err == nil {
+			if branch != nil && fmt.Sprintf("%s", branch.Name) == name {
+				return fmt.Errorf("Branch still exists")
+			}
+		}
+		if resp.StatusCode != 404 {
+			return err
+		}
+		return nil
 	}
-	log.Println("destroy method")
 	return nil
+}
+
+func testAccCheckGitlabBranchAttributes(branch *gitlab.Branch, want *testAccGitlabBranchExpectedAttributes) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if branch.WebURL == "" {
+			return errors.New("got empty web url")
+		}
+		if branch.Name != want.Name {
+			return fmt.Errorf("got name %s; want %s", branch.Name, want.Name)
+		}
+		if branch.CanPush != want.CanPush {
+			return fmt.Errorf("can push %t; want %t", branch.CanPush, want.CanPush)
+		}
+		if branch.DevelopersCanPush != want.DevelopersCanPush {
+			return fmt.Errorf("Developers can push %t; want %t", branch.DevelopersCanPush, want.DevelopersCanPush)
+		}
+		if branch.DevelopersCanMerge != want.DevelopersCanMerge {
+			return fmt.Errorf("Developers can merge %t; want %t", branch.DevelopersCanMerge, want.DevelopersCanMerge)
+		}
+		if branch.Default != want.Default {
+			return fmt.Errorf("Default set %t; want %t", branch.CanPush, want.CanPush)
+		}
+		if branch.Merged != want.Merged {
+			return fmt.Errorf("Merged %t; want %t", branch.CanPush, want.CanPush)
+		}
+		return nil
+	}
 }
 
 func testAccCheckGitlabBranchExists(n string, branch *gitlab.Branch, rInt int) resource.TestCheckFunc {
@@ -65,7 +96,7 @@ func testAccCheckGitlabBranchExists(n string, branch *gitlab.Branch, rInt int) r
 		pid := s.RootModule().Resources["gitlab_project.test"].Primary.ID
 		conn := testAccProvider.Meta().(*gitlab.Client)
 		gotBranch, _, err := conn.Branches.GetBranch(pid, name)
-		branch = gotBranch
+		*branch = *gotBranch
 		return err
 	}
 }
@@ -86,4 +117,18 @@ func testAccGitlabBranchConfig(rInt int) string {
 		project = gitlab_project.test.id
 	}
   `, rInt, rInt)
+}
+
+type testAccGitlabBranchExpectedAttributes struct {
+	Name               string
+	WebURL             string
+	CanPush            bool
+	Default            bool
+	Merged             bool
+	Protected          bool
+	Ref                string
+	Project            string
+	DevelopersCanPush  bool
+	DevelopersCanMerge bool
+	Commit             *gitlab.Commit
 }

--- a/gitlab/resource_gitlab_branch_test.go
+++ b/gitlab/resource_gitlab_branch_test.go
@@ -1,0 +1,100 @@
+package gitlab
+
+import (
+	"fmt"
+	"log"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	gitlab "github.com/xanzy/go-gitlab"
+)
+
+
+func TestAccGitlabBranch_basic(t *testing.T) {
+	var branch gitlab.Branch
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGitlabBranchDestroy,
+		Steps: []resource.TestStep{
+			// Create a group
+			{
+				Config: testAccGitlabBranchConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabBranchExists("testbranch", &branch, rInt),
+				),
+			},
+		},
+	})
+}
+
+
+func testAccCheckGitlabBranchDestroy(s *terraform.State) error {
+	// conn := testAccProvider.Meta().(*gitlab.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "gitlab_branch" {
+			continue
+		}
+		// branch, resp, err := conn.Branches.GetBranch(rs.Primary.ID ,rs.Primary.Name)
+		// // if err == nil {
+		// // 	if group != nil && fmt.Sprintf("%d", group.ID) == rs.Primary.ID {
+		// // 		if group.MarkedForDeletionOn == nil {
+		// // 			return fmt.Errorf("Group still exists")
+		// // 		}
+		// // 	}
+		// // }
+		// if resp.StatusCode != 404 {
+		// 	return err
+		// }
+		// return nil
+	}
+	log.Println("destroy method")
+	return nil
+}
+
+func testAccCheckGitlabBranchExists(n string, branch *gitlab.Branch, rInt int) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[n]
+		log.Println("resource")
+		log.Printf("%+v")
+		if !ok {
+			return fmt.Errorf("Not Found: %s", n)
+		}
+
+		// branchID := rs.Primary.ID
+		// if groupID == "" {
+		// 	return fmt.Errorf("No group ID is set")
+		// }
+		conn := testAccProvider.Meta().(*gitlab.Client)
+
+		gotBranch, _, err := conn.Branches.GetBranch(fmt.Sprint("foo-%d", rInt) ,n)
+		if err != nil {
+			return err
+		}
+		*branch = *gotBranch
+		return nil
+	}
+}
+
+func testAccGitlabBranchConfig(rInt int) string {
+	return fmt.Sprintf(`
+	resource "gitlab_project" "foo" {
+		name = "foo-%d"
+		description = "Terraform acceptance tests"
+	  
+		# So that acceptance tests can be run in a gitlab organization
+		# with no billing
+		visibility_level = "public"
+	}
+	resource "gitlab_branch" "foo" {
+		name = "foo-name-%d"
+		ref = "master"
+		project = gitlab_project.foo.id
+	}
+  `, rInt, rInt)
+}

--- a/gitlab/resource_gitlab_branch_test.go
+++ b/gitlab/resource_gitlab_branch_test.go
@@ -11,7 +11,6 @@ import (
 	gitlab "github.com/xanzy/go-gitlab"
 )
 
-
 func TestAccGitlabBranch_basic(t *testing.T) {
 	var branch gitlab.Branch
 	rInt := acctest.RandInt()
@@ -31,7 +30,6 @@ func TestAccGitlabBranch_basic(t *testing.T) {
 		},
 	})
 }
-
 
 func testAccCheckGitlabBranchDestroy(s *terraform.State) error {
 	// conn := testAccProvider.Meta().(*gitlab.Client)
@@ -59,9 +57,9 @@ func testAccCheckGitlabBranchDestroy(s *terraform.State) error {
 
 func testAccCheckGitlabBranchExists(n string, branch *gitlab.Branch, rInt int) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		_, ok := s.RootModule().Resources[n]
+		rs, ok := s.RootModule().Resources[n]
 		log.Println("resource")
-		log.Printf("%+v")
+		log.Printf("%+v", rs)
 		if !ok {
 			return fmt.Errorf("Not Found: %s", n)
 		}
@@ -72,12 +70,9 @@ func testAccCheckGitlabBranchExists(n string, branch *gitlab.Branch, rInt int) r
 		// }
 		conn := testAccProvider.Meta().(*gitlab.Client)
 
-		gotBranch, _, err := conn.Branches.GetBranch(fmt.Sprint("foo-%d", rInt) ,n)
-		if err != nil {
-			return err
-		}
+		gotBranch, _, err := conn.Branches.GetBranch(fmt.Sprintf("foo-%d", rInt), n)
 		*branch = *gotBranch
-		return nil
+		return err
 	}
 }
 

--- a/gitlab/resource_gitlab_group.go
+++ b/gitlab/resource_gitlab_group.go
@@ -206,9 +206,8 @@ func retryGetGroup(attempts int, sleep time.Duration, client *gitlab.Client, par
 
 		if attempts--; attempts > 0 {
 			// Add some randomness to prevent creating a Thundering Herd
-			jitter := time.Duration(rand.Int63n(int64(sleep)))
+			jitter := time.Duration(rand.Int63n(int64(2)))
 			sleep = sleep + jitter/2
-
 			time.Sleep(sleep)
 			return retryGetGroup(attempts, sleep, client, parentID)
 		}
@@ -243,7 +242,7 @@ func readParentID(parentID string, meta interface{}) (*int, error) {
 	}
 	client := meta.(*gitlab.Client)
 
-	return retryGetGroup(25, 4*time.Second, client, parentID)
+	return retryGetGroup(25, 3*time.Second, client, parentID)
 }
 
 func resourceGitlabGroupRead(d *schema.ResourceData, meta interface{}) error {

--- a/gitlab/resource_gitlab_group.go
+++ b/gitlab/resource_gitlab_group.go
@@ -243,7 +243,7 @@ func readParentID(parentID string, meta interface{}) (*int, error) {
 	}
 	client := meta.(*gitlab.Client)
 	
-	return retryGetGroup(5, 10 * time.Second, client, parentID)
+	return retryGetGroup(25, 4 * time.Second, client, parentID)
 }
 
 func resourceGitlabGroupRead(d *schema.ResourceData, meta interface{}) error {

--- a/gitlab/resource_gitlab_group.go
+++ b/gitlab/resource_gitlab_group.go
@@ -185,8 +185,6 @@ func resourceGitlabGroupCreate(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return err
 		}
-		log.Println("[DEBUG] setting id")
-		log.Println(id)
 		options.ParentID = id
 	}
 
@@ -237,15 +235,11 @@ func readParentID(parentID string, meta interface{}) (*int, error) {
 	if parentID == "" {
 		return nil, nil
 	}
-	log.Println("[DEBUG] should see a debug here if parent id is not empty")
-	log.Println(parentID)
 	if id, err := strconv.Atoi(parentID); err == nil {
-		log.Println("[DEBUG] should see an int number")
 		// BUG(eddb7): If path is purely numeric it may appear as an ID in this block
 		return gitlab.Int(id), err
 	}
 	client := meta.(*gitlab.Client)
-	log.Printf("[DEBUG] URL PATH %s", parentID)
 	return retryGetGroup(25, 3*time.Second, client, parentID)
 }
 

--- a/gitlab/resource_gitlab_group.go
+++ b/gitlab/resource_gitlab_group.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -107,7 +108,7 @@ func resourceGitlabGroup() *schema.Resource {
 				Default:  48,
 			},
 			"parent_id": {
-				Type:     schema.TypeInt,
+				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
 				Default:  0,
@@ -174,7 +175,7 @@ func resourceGitlabGroupCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	if v, ok := d.GetOk("parent_id"); ok {
-		options.ParentID = gitlab.Int(v.(int))
+		options.ParentID = readParentID(v.(string), meta)
 	}
 
 	log.Printf("[DEBUG] create gitlab group %q", *options.Name)
@@ -187,6 +188,26 @@ func resourceGitlabGroupCreate(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(fmt.Sprintf("%d", group.ID))
 
 	return resourceGitlabGroupRead(d, meta)
+}
+
+func readParentID(parentID string, meta interface{}) *int {
+	if id, err := strconv.Atoi(parentID); err == nil {
+		return gitlab.Int(id)
+	}
+	client := meta.(*gitlab.Client)
+	group, resp, err := client.Groups.GetGroup(parentID)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			log.Printf("[DEBUG] gitlab group %s not found", parentID)
+			return nil
+		}
+		return nil
+	}
+	if group.MarkedForDeletionOn != nil {
+		log.Printf("[DEBUG] gitlab group %s is marked for deletion", parentID)
+		return nil
+	}
+	return gitlab.Int(group.ID)
 }
 
 func resourceGitlabGroupRead(d *schema.ResourceData, meta interface{}) error {

--- a/gitlab/resource_gitlab_group.go
+++ b/gitlab/resource_gitlab_group.go
@@ -113,7 +113,7 @@ func resourceGitlabGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				ForceNew: true,
-				Default:  0,
+				Default:  "",
 			},
 			"runners_token": {
 				Type:      schema.TypeString,
@@ -229,6 +229,9 @@ func getGroup(client *gitlab.Client, parentID string) (*int, error) {
 }
 
 func readParentID(parentID string, meta interface{}) (*int, error) {
+	if parentID == "" {
+		return nil, nil
+	}
 	if id, err := strconv.Atoi(parentID); err == nil {
 		return gitlab.Int(id), err
 	}

--- a/gitlab/resource_gitlab_group.go
+++ b/gitlab/resource_gitlab_group.go
@@ -200,10 +200,6 @@ func retryGetGroup(attempts int, sleep time.Duration, client *gitlab.Client, par
 	id, err := getGroup(client, parentID)
 	rand.Seed(time.Now().UnixNano())
 	if err != nil {
-		if s, ok := err.(stop); ok {
-			return nil, s.error
-		}
-
 		if attempts--; attempts > 0 {
 			// Add some randomness to prevent creating a Thundering Herd
 			jitter := time.Duration(rand.Int63n(int64(2)))
@@ -214,10 +210,6 @@ func retryGetGroup(attempts int, sleep time.Duration, client *gitlab.Client, par
 		return nil, err
 	}
 	return id, err
-}
-
-type stop struct {
-	error
 }
 
 func getGroup(client *gitlab.Client, parentID string) (*int, error) {

--- a/gitlab/resource_gitlab_group.go
+++ b/gitlab/resource_gitlab_group.go
@@ -2,9 +2,9 @@ package gitlab
 
 import (
 	"errors"
-	"math/rand"
 	"fmt"
 	"log"
+	"math/rand"
 	"net/http"
 	"strconv"
 	"strings"
@@ -197,7 +197,7 @@ func resourceGitlabGroupCreate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func retryGetGroup(attempts int, sleep time.Duration, client *gitlab.Client, parentID string) (*int, error) {
-	id, err := getGroup(client, parentID);
+	id, err := getGroup(client, parentID)
 	rand.Seed(time.Now().UnixNano())
 	if err != nil {
 		if s, ok := err.(stop); ok {
@@ -242,8 +242,8 @@ func readParentID(parentID string, meta interface{}) (*int, error) {
 		return gitlab.Int(id), err
 	}
 	client := meta.(*gitlab.Client)
-	
-	return retryGetGroup(25, 4 * time.Second, client, parentID)
+
+	return retryGetGroup(25, 4*time.Second, client, parentID)
 }
 
 func resourceGitlabGroupRead(d *schema.ResourceData, meta interface{}) error {

--- a/gitlab/resource_gitlab_group_test.go
+++ b/gitlab/resource_gitlab_group_test.go
@@ -1,6 +1,7 @@
 package gitlab
 
 import (
+	"errors"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
@@ -75,6 +76,49 @@ func TestAccGitlabGroup_basic(t *testing.T) {
 						SubGroupCreationLevel: "owner",      // default value
 						TwoFactorGracePeriod:  48,           // default value
 					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGitlabGroupRetryGetGroup(t *testing.T) {
+	var group gitlab.Group
+	var emptyGroup = gitlab.Group{
+		FullPath: "made/up/path",
+	}
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGitlabGroupDestroy,
+		Steps: []resource.TestStep{
+			// Create a group
+			{
+				Config: testAccGitlabGroupConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGetGitlabGroup(&emptyGroup, true),
+					testAccCheckGitlabGroupExists("gitlab_group.foo", &group),
+					testAccCheckGetGitlabGroup(&group, false),
+					testAccCheckGitlabGroupAttributes(&group, &testAccGitlabGroupExpectedAttributes{
+						Name:                  fmt.Sprintf("foo-name-%d", rInt),
+						Path:                  fmt.Sprintf("foo-path-%d", rInt),
+						Description:           "Terraform acceptance tests",
+						LFSEnabled:            true,
+						Visibility:            "public",     // default value
+						ProjectCreationLevel:  "maintainer", // default value
+						SubGroupCreationLevel: "owner",      // default value
+						TwoFactorGracePeriod:  48,           // default value
+					}),
+				),
+			},
+
+			// remove group
+			{
+				Config: testAccGitlabNoGroupConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGetGitlabGroup(&group, true),
 				),
 			},
 		},
@@ -205,6 +249,7 @@ func TestAccGitlabGroup_disappears(t *testing.T) {
 				Config: testAccGitlabGroupConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabGroupExists("gitlab_group.foo", &group),
+					testAccCheckGetGitlabGroup(&group, false),
 					testAccCheckGitlabGroupDisappears(&group),
 				),
 				ExpectNonEmptyPlan: true,
@@ -236,6 +281,30 @@ func testAccCheckGitlabGroupDisappears(group *gitlab.Group) resource.TestCheckFu
 			}
 		}
 		return fmt.Errorf("waited for more than 15 seconds for group to be asynchronously deleted")
+	}
+}
+
+func testAccCheckGetGitlabGroup(group *gitlab.Group, hasError bool) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		client := testAccProvider.Meta().(*gitlab.Client)
+		// get group with full path or ID
+		gid, err := getGroup(client, group.FullPath)
+		if hasError {
+			if err == nil {
+				return errors.New("Expected error but found none")
+			}
+			if gid != nil {
+				return fmt.Errorf("expected nil value for group go %d", gid)
+			}
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if gid == nil || *gid != group.ID {
+			return fmt.Errorf("Unexpected ID returned %d", gid)
+		}
+		return nil
 	}
 }
 
@@ -373,6 +442,19 @@ func testAccCheckGitlabGroupDestroy(s *terraform.State) error {
 		return nil
 	}
 	return nil
+}
+
+func testAccGitlabNoGroupConfig(rInt int) string {
+	return fmt.Sprintf(`
+resource "gitlab_project" "foo" {
+  name = "foo-name-%d"
+  description = "Terraform acceptance tests"
+
+  # So that acceptance tests can be run in a gitlab organization
+  # with no billing
+  visibility_level = "public"
+}
+  `, rInt)
 }
 
 func testAccGitlabGroupConfig(rInt int) string {


### PR DESCRIPTION
Hi I have been using this provider and required a way to automate and manage the creation and deletion of gitlab branches.
This allows the management of a `gitlab_branch` by adding it as a `resource` or `data` source block in terraform
The create, delete and read methods are using:  
 https://github.com/xanzy/go-gitlab/blob/master/branches.go#L188


The data structure for the resources is modelled on the response from 
https://docs.gitlab.com/ee/api/branches.html#get-single-repository-branch

The properties around  branch protection have been excluded for consistency, allowing this to work alongside the `gitlab_branch_protection` resources

It would be great to get some feedback and thoughts about wether this could potentially be integrated into the main package
