### PR TITLE
Update number of possible access level values

### DIFF
--- a/docs/data-sources/group_membership.md
+++ b/docs/data-sources/group_membership.md
@@ -43,6 +43,6 @@ The following attributes are exported:
   * `state` - Whether the user is active or blocked.
   * `avatar_url` - The avatar URL of the user.
   * `web_url` - User's website URL.
-  * `access_level` - One of five levels of access to the group.
+  * `access_level` - One of six levels of access to the group.
   * `expires_at` - Expiration date for the group membership.
 

--- a/docs/resources/branch_protection.md
+++ b/docs/resources/branch_protection.md
@@ -21,8 +21,8 @@ The following arguments are supported:
 
 * `branch` - (Required) Name of the branch.
 
-* `push_access_level` - (Required) One of five levels of access to the project.
+* `push_access_level` - (Required) One of six levels of access to the project.
 
-* `merge_access_level` - (Required) One of five levels of access to the project.
+* `merge_access_level` - (Required) One of six levels of access to the project.
 
 * `code_owner_approval_required` (Optional) Bool, defaults to false. Can be set to true to require code owner approval before merging.

--- a/docs/resources/group_share_group.md
+++ b/docs/resources/group_share_group.md
@@ -21,7 +21,7 @@ The following arguments are supported:
 
 * `share_group_id` - (Required) The id of an additional group which will be shared with the main group.
 
-* `group_access` - (Required) One of five levels of access to the group.
+* `group_access` - (Required) One of six levels of access to the group.
 
 * `expires_at` - (Optional) Share expiration date. Format: `YYYY-MM-DD`
 

--- a/docs/resources/project_membership.md
+++ b/docs/resources/project_membership.md
@@ -20,7 +20,7 @@ The following arguments are supported:
 
 * `user_id` - (Required) The id of the user.
 
-* `access_level` - (Required) One of five levels of access to the project.
+* `access_level` - (Required) One of six levels of access to the project.
 
 ## Import
 

--- a/docs/resources/project_share_group.md
+++ b/docs/resources/project_share_group.md
@@ -20,7 +20,7 @@ The following arguments are supported:
 
 * `group_id` - (Required) The id of the group.
 
-* `access_level` - (Required) One of five levels of access to the project.
+* `access_level` - (Required) One of six levels of access to the project.
 
 ## Import
 

--- a/docs/resources/tag_protection.md
+++ b/docs/resources/tag_protection.md
@@ -20,4 +20,4 @@ The following arguments are supported:
 
 * `tag` - (Required) Name of the tag or wildcard.
 
-* `create_access_level` - (Required) One of five levels of access to the project.
+* `create_access_level` - (Required) One of six levels of access to the project.


### PR DESCRIPTION

https://github.com/gitlabhq/terraform-provider-gitlab/blob/620964c9a7f6705e54d915e6071424b8b8b2164d/gitlab/util.go#L205-L215

util.go indicates that there are six (seven, if you include the deprecated one)
possible values. It would be nice to have these valid values enumerated in
the documents, but that is for another day.
