### PR TITLE
Missing documentation for gitlab_instance_variable

### DIFF
--- a/docs/resources/instance_variable.md
+++ b/docs/resources/instance_variable.md
@@ -1,11 +1,3 @@
----
-layout: "gitlab"
-page_title: "GitLab: gitlab_instance_variable"
-sidebar_current: "docs-gitlab-resource-instance-variable"
-description: |-
-  Creates and manages CI/CD variables for GitLab instances
----
-
 # gitlab\_instance\_variable
 
 This resource allows you to create and manage CI/CD variables for your GitLab instance.


### PR DESCRIPTION
Looking on https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs gitlab_instance_variable is missing.
This patch should fix that situation by renaming the file and formatting the file to match the other documentations.