### PR TITLE
support for can_push on gitlab_deploy_key and gitlab_deploy_key_enable

### DIFF
--- a/docs/resources/deploy_key.md
+++ b/docs/resources/deploy_key.md
@@ -31,7 +31,7 @@ resource "gitlab_deploy_key" "example" {
 
 ### Optional
 
-- **can_push** (Boolean) Allow this deploy key to be used to push changes to the project.  Defaults to `false`. **NOTE::** this cannot currently be managed.
+- **can_push** (Boolean) Allow this deploy key to be used to push changes to the project. Defaults to `false`.
 - **id** (String) The ID of this resource.
 
 ## Import

--- a/gitlab/resource_gitlab_deploy_key.go
+++ b/gitlab/resource_gitlab_deploy_key.go
@@ -46,7 +46,7 @@ func resourceGitlabDeployKey() *schema.Resource {
 				},
 			},
 			"can_push": {
-				Description: "Allow this deploy key to be used to push changes to the project.  Defaults to `false`. **NOTE::** this cannot currently be managed.",
+				Description: "Allow this deploy key to be used to push changes to the project. Defaults to `false`.",
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,

--- a/gitlab/resource_gitlab_deploy_key_enable.go
+++ b/gitlab/resource_gitlab_deploy_key_enable.go
@@ -53,7 +53,8 @@ func resourceGitlabDeployEnableKey() *schema.Resource {
 				Description: "Can deploy key push to the project’s repository.",
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Computed:    true,
+				Default:     false,
+				ForceNew:    true,
 			},
 		},
 	}
@@ -67,6 +68,14 @@ func resourceGitlabDeployKeyEnableCreate(ctx context.Context, d *schema.Resource
 	log.Printf("[DEBUG] enable gitlab deploy key %s/%d", project, key_id)
 
 	deployKey, _, err := client.DeployKeys.EnableDeployKey(project, key_id, gitlab.WithContext(ctx))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	options := &gitlab.UpdateDeployKeyOptions{
+		CanPush: gitlab.Bool(d.Get("can_push").(bool)),
+	}
+	_, _, err = client.DeployKeys.UpdateDeployKey(project, key_id, options)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/gitlab/resource_gitlab_deploy_key_enable_test.go
+++ b/gitlab/resource_gitlab_deploy_key_enable_test.go
@@ -24,14 +24,51 @@ func TestAccGitlabDeployKeyEnable_basic(t *testing.T) {
 		Providers:    testAccProviders,
 		CheckDestroy: testAccCheckGitlabDeployKeyEnableDestroy,
 		Steps: []resource.TestStep{
-			// Create a project and deployKey with default options
+			// Enable a deployKey on project with default options
 			{
 				Config: testAccGitlabDeployKeyEnableConfig(rInt, keyTitle, key),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabDeployKeyEnableExists("gitlab_deploy_key_enable.foo", &deployKey),
 					testAccCheckGitlabDeployKeyEnableAttributes(&deployKey, &testAccGitlabDeployKeyEnableExpectedAttributes{
-						Title: keyTitle,
-						Key:   key,
+						Title:   keyTitle,
+						Key:     key,
+						CanPush: false,
+					}),
+				),
+			},
+			// Define canPush to true
+			{
+				Config: testAccGitlabDeployKeyEnableConfigCanPush(rInt, keyTitle, key, true),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabDeployKeyEnableExists("gitlab_deploy_key_enable.foo", &deployKey),
+					testAccCheckGitlabDeployKeyEnableAttributes(&deployKey, &testAccGitlabDeployKeyEnableExpectedAttributes{
+						Title:   keyTitle,
+						Key:     key,
+						CanPush: true,
+					}),
+				),
+			},
+			// Define canPush to false
+			{
+				Config: testAccGitlabDeployKeyEnableConfigCanPush(rInt, keyTitle, key, false),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabDeployKeyEnableExists("gitlab_deploy_key_enable.foo", &deployKey),
+					testAccCheckGitlabDeployKeyEnableAttributes(&deployKey, &testAccGitlabDeployKeyEnableExpectedAttributes{
+						Title:   keyTitle,
+						Key:     key,
+						CanPush: false,
+					}),
+				),
+			},
+			// Get back to default options
+			{
+				Config: testAccGitlabDeployKeyEnableConfig(rInt, keyTitle, key),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabDeployKeyEnableExists("gitlab_deploy_key_enable.foo", &deployKey),
+					testAccCheckGitlabDeployKeyEnableAttributes(&deployKey, &testAccGitlabDeployKeyEnableExpectedAttributes{
+						Title:   keyTitle,
+						Key:     key,
+						CanPush: false,
 					}),
 				),
 			},
@@ -137,8 +174,8 @@ resource "gitlab_project" "foo" {
 
 resource "gitlab_deploy_key" "parent" {
   project = "${gitlab_project.parent.id}"
-	title = "%s"
-	key = "%s"
+  title = "%s"
+  key = "%s"
 }
 
 resource "gitlab_deploy_key_enable" "foo" {
@@ -146,4 +183,38 @@ resource "gitlab_deploy_key_enable" "foo" {
   key_id = "${gitlab_deploy_key.parent.id}"
 }
   `, rInt, rInt, keyTitle, key)
+}
+
+func testAccGitlabDeployKeyEnableConfigCanPush(rInt int, keyTitle string, key string, canPush bool) string {
+	return fmt.Sprintf(`
+resource "gitlab_project" "parent" {
+  name = "parent-%d"
+  description = "Terraform acceptance tests - Parent project"
+
+  # So that acceptance tests can be run in a gitlab organization
+  # with no billing
+  visibility_level = "public"
+}
+
+resource "gitlab_project" "foo" {
+  name = "foo-%d"
+  description = "Terraform acceptance tests - Test Project"
+
+  # So that acceptance tests can be run in a gitlab organization
+  # with no billing
+  visibility_level = "public"
+}
+
+resource "gitlab_deploy_key" "parent" {
+  project = "${gitlab_project.parent.id}"
+  title = "%s"
+  key = "%s"
+}
+
+resource "gitlab_deploy_key_enable" "foo" {
+  project = "${gitlab_project.foo.id}"
+  key_id = "${gitlab_deploy_key.parent.id}"
+  can_push = %t
+}
+  `, rInt, rInt, keyTitle, key, canPush)
 }

--- a/gitlab/resource_gitlab_deploy_key_test.go
+++ b/gitlab/resource_gitlab_deploy_key_test.go
@@ -37,8 +37,9 @@ func TestAccGitlabDeployKey_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabDeployKeyExists("gitlab_deploy_key.foo", &deployKey),
 					testAccCheckGitlabDeployKeyAttributes(&deployKey, &testAccGitlabDeployKeyExpectedAttributes{
-						Title: fmt.Sprintf("modifiedDeployKey-%d", rInt),
-						Key:   "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC6pSke2kb7YBjo65xDKegbOQsAtnMupRcFxXji7L1iXivGwORq0qpC2xzbhez5jk1WgPckEaNv2/Bz0uEW6oSIXw1KT1VN2WzEUfQCbpNyZPtn4iV3nyl6VQW/Nd1SrxiFJtH1H4vu+eCo4McMXTjuBBD06fiJNrHaSw734LjQgqtXWJuVym9qS5MqraZB7wDwTQwSM6kslL7KTgmo3ONsTLdb2zZhv6CS+dcFKinQo7/ttTmeMuXGbPOVuNfT/bePVIN1MF1TislHa2L2dZdGeoynNJT4fVPjA2Xl6eHWh4ySbvnfPznASsjBhP0n/QKprYJ/5fQShdBYBcuQiIMd richardc@tamborine.example.2",
+						Title:   fmt.Sprintf("modifiedDeployKey-%d", rInt),
+						Key:     "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC6pSke2kb7YBjo65xDKegbOQsAtnMupRcFxXji7L1iXivGwORq0qpC2xzbhez5jk1WgPckEaNv2/Bz0uEW6oSIXw1KT1VN2WzEUfQCbpNyZPtn4iV3nyl6VQW/Nd1SrxiFJtH1H4vu+eCo4McMXTjuBBD06fiJNrHaSw734LjQgqtXWJuVym9qS5MqraZB7wDwTQwSM6kslL7KTgmo3ONsTLdb2zZhv6CS+dcFKinQo7/ttTmeMuXGbPOVuNfT/bePVIN1MF1TislHa2L2dZdGeoynNJT4fVPjA2Xl6eHWh4ySbvnfPznASsjBhP0n/QKprYJ/5fQShdBYBcuQiIMd richardc@tamborine.example.2",
+						CanPush: true,
 					}),
 				),
 			},
@@ -224,6 +225,7 @@ resource "gitlab_deploy_key" "foo" {
   project = "${gitlab_project.foo.id}"
   title = "modifiedDeployKey-%d"
   key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC6pSke2kb7YBjo65xDKegbOQsAtnMupRcFxXji7L1iXivGwORq0qpC2xzbhez5jk1WgPckEaNv2/Bz0uEW6oSIXw1KT1VN2WzEUfQCbpNyZPtn4iV3nyl6VQW/Nd1SrxiFJtH1H4vu+eCo4McMXTjuBBD06fiJNrHaSw734LjQgqtXWJuVym9qS5MqraZB7wDwTQwSM6kslL7KTgmo3ONsTLdb2zZhv6CS+dcFKinQo7/ttTmeMuXGbPOVuNfT/bePVIN1MF1TislHa2L2dZdGeoynNJT4fVPjA2Xl6eHWh4ySbvnfPznASsjBhP0n/QKprYJ/5fQShdBYBcuQiIMd richardc@tamborine.example.2"
+  can_push = true
 }
   `, rInt, rInt)
 }


### PR DESCRIPTION
Hi!

Here's some changes to have `can_push` implemented on `gitlab_deploy_key_enable`.
Moreover, `can_push` actually works for `gitlab_deploy_key` so the documentation is updated.

Fix #294
Fix #577