### PR TITLE
Support group level CI/CD variable environment scope

### DIFF
--- a/docs/resources/group_variable.md
+++ b/docs/resources/group_variable.md
@@ -8,11 +8,12 @@ documentation](https://docs.gitlab.com/ce/ci/variables/README.html#variables).
 
 ```hcl
 resource "gitlab_group_variable" "example" {
-   group     = "12345"
-   key       = "group_variable_key"
-   value     = "group_variable_value"
-   protected = false
-   masked    = false
+   group             = "12345"
+   key               = "group_variable_key"
+   value             = "group_variable_value"
+   protected         = false
+   masked            = false
+   environment_scope = "example"
 }
 ```
 
@@ -31,6 +32,8 @@ The following arguments are supported:
 * `protected` - (Optional, boolean) If set to `true`, the variable will be passed only to pipelines running on protected branches and tags. Defaults to `false`.
 
 * `masked` - (Optional, boolean) If set to `true`, the value of the variable will be hidden in job logs. The value must meet the [masking requirements](https://docs.gitlab.com/ee/ci/variables/#masked-variables). Defaults to `false`.
+
+* `environment_scope` - (Optional, string)  Set to limit the environment scope of a CI/CD variable by defining which environments it can be available for.
 
 ## Import
 

--- a/docs/resources/group_variable.md
+++ b/docs/resources/group_variable.md
@@ -1,4 +1,4 @@
-# gitlab\_group\_variable
+# gitlab_group_variable
 
 This resource allows you to create and manage CI/CD variables for your GitLab groups.
 For further information on variables, consult the [gitlab
@@ -21,19 +21,19 @@ resource "gitlab_group_variable" "example" {
 
 The following arguments are supported:
 
-* `group` - (Required, string) The name or id of the group to add the hook to.
+- `group` - (Required, string) The name or id of the group to add the hook to.
 
-* `key` - (Required, string) The name of the variable.
+- `key` - (Required, string) The name of the variable.
 
-* `value` - (Required, string) The value of the variable.
+- `value` - (Required, string) The value of the variable.
 
-* `variable_type` - (Optional, string)  The type of a variable. Available types are: env_var (default) and file.
+- `variable_type` - (Optional, string) The type of a variable. Available types are: env_var (default) and file.
 
-* `protected` - (Optional, boolean) If set to `true`, the variable will be passed only to pipelines running on protected branches and tags. Defaults to `false`.
+- `protected` - (Optional, boolean) If set to `true`, the variable will be passed only to pipelines running on protected branches and tags. Defaults to `false`.
 
-* `masked` - (Optional, boolean) If set to `true`, the value of the variable will be hidden in job logs. The value must meet the [masking requirements](https://docs.gitlab.com/ee/ci/variables/#masked-variables). Defaults to `false`.
+- `masked` - (Optional, boolean) If set to `true`, the value of the variable will be hidden in job logs. The value must meet the [masking requirements](https://docs.gitlab.com/ee/ci/variables/#masked-variables). Defaults to `false`.
 
-* `environment_scope` - (Optional, string)  Set to limit the environment scope of a CI/CD variable by defining which environments it can be available for.
+- `environment_scope` - (Optional, string) Set to limit the environment scope of a CI/CD variable by defining which environments it can be available for. Only available with Premium license and above, from [GitLab 13.11](https://docs.gitlab.com/ee/ci/environments/index.html#scoping-environments-with-specs).
 
 ## Import
 

--- a/gitlab/resource_gitlab_group_ldap_link.go
+++ b/gitlab/resource_gitlab_group_ldap_link.go
@@ -66,7 +66,7 @@ func resourceGitlabGroupLdapLinkCreate(d *schema.ResourceData, meta interface{})
 
 	options := &gitlab.AddGroupLDAPLinkOptions{
 		CN:          &cn,
-		GroupAccess: &group_access,
+		GroupAccess: gitlab.AccessLevel(gitlab.AccessLevelValue(group_access)),
 		Provider:    &ldap_provider,
 	}
 

--- a/gitlab/resource_gitlab_group_variable.go
+++ b/gitlab/resource_gitlab_group_variable.go
@@ -50,6 +50,11 @@ func resourceGitlabGroupVariable() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"environment_scope": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Default:  "*",
+			},
 		},
 	}
 }
@@ -63,13 +68,15 @@ func resourceGitlabGroupVariableCreate(d *schema.ResourceData, meta interface{})
 	variableType := stringToVariableType(d.Get("variable_type").(string))
 	protected := d.Get("protected").(bool)
 	masked := d.Get("masked").(bool)
+	environmentScope := d.Get("environment_scope").(string)
 
 	options := gitlab.CreateGroupVariableOptions{
-		Key:          &key,
-		Value:        &value,
-		VariableType: variableType,
-		Protected:    &protected,
-		Masked:       &masked,
+		Key:              &key,
+		Value:            &value,
+		VariableType:     variableType,
+		Protected:        &protected,
+		Masked:           &masked,
+		EnvironmentScope: &environmentScope,
 	}
 	log.Printf("[DEBUG] create gitlab group variable %s/%s", group, key)
 
@@ -104,6 +111,7 @@ func resourceGitlabGroupVariableRead(d *schema.ResourceData, meta interface{}) e
 	d.Set("group", group)
 	d.Set("protected", v.Protected)
 	d.Set("masked", v.Masked)
+	d.Set("environment_scope", v.EnvironmentScope)
 	return nil
 }
 
@@ -116,12 +124,14 @@ func resourceGitlabGroupVariableUpdate(d *schema.ResourceData, meta interface{})
 	variableType := stringToVariableType(d.Get("variable_type").(string))
 	protected := d.Get("protected").(bool)
 	masked := d.Get("masked").(bool)
+	environmentScope := d.Get("environment_scope").(string)
 
 	options := &gitlab.UpdateGroupVariableOptions{
-		Value:        &value,
-		Protected:    &protected,
-		VariableType: variableType,
-		Masked:       &masked,
+		Value:            &value,
+		Protected:        &protected,
+		VariableType:     variableType,
+		Masked:           &masked,
+		EnvironmentScope: &environmentScope,
 	}
 	log.Printf("[DEBUG] update gitlab group variable %s/%s", group, key)
 

--- a/gitlab/resource_gitlab_group_variable_test.go
+++ b/gitlab/resource_gitlab_group_variable_test.go
@@ -30,9 +30,10 @@ func TestAccGitlabGroupVariable_basic(t *testing.T) {
 					}),
 				),
 			},
-			// Update the group variable to toggle all the values to their inverse
+			// Update the group variable to toggle all the values to their inverse - check environment_scope if license allows it
 			{
-				Config: testAccGitlabGroupVariableUpdateConfig(rString),
+				Config:   testAccGitlabGroupVariableUpdateConfig(rString),
+				SkipFunc: isRunningInCE,
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabGroupVariableExists("gitlab_group_variable.foo", &groupVariable),
 					testAccCheckGitlabGroupVariableAttributes(&groupVariable, &testAccGitlabGroupVariableExpectedAttributes{
@@ -40,6 +41,19 @@ func TestAccGitlabGroupVariable_basic(t *testing.T) {
 						Value:            fmt.Sprintf("value-inverse-%s", rString),
 						Protected:        true,
 						EnvironmentScope: fmt.Sprintf("foo%s", rString),
+					}),
+				),
+			},
+			// Update the group variable to toggle all the values to their inverse - skip check of environment_scope as it is only available in Premium
+			{
+				Config:   testAccGitlabGroupVariableUpdateConfig(rString),
+				SkipFunc: isRunningInEE,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabGroupVariableExists("gitlab_group_variable.foo", &groupVariable),
+					testAccCheckGitlabGroupVariableAttributes(&groupVariable, &testAccGitlabGroupVariableExpectedAttributes{
+						Key:       fmt.Sprintf("key_%s", rString),
+						Value:     fmt.Sprintf("value-inverse-%s", rString),
+						Protected: true,
 					}),
 				),
 			},

--- a/gitlab/resource_gitlab_group_variable_test.go
+++ b/gitlab/resource_gitlab_group_variable_test.go
@@ -36,9 +36,10 @@ func TestAccGitlabGroupVariable_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabGroupVariableExists("gitlab_group_variable.foo", &groupVariable),
 					testAccCheckGitlabGroupVariableAttributes(&groupVariable, &testAccGitlabGroupVariableExpectedAttributes{
-						Key:       fmt.Sprintf("key_%s", rString),
-						Value:     fmt.Sprintf("value-inverse-%s", rString),
-						Protected: true,
+						Key:              fmt.Sprintf("key_%s", rString),
+						Value:            fmt.Sprintf("value-inverse-%s", rString),
+						Protected:        true,
+						EnvironmentScope: fmt.Sprintf("foo%s", rString),
 					}),
 				),
 			},
@@ -48,9 +49,10 @@ func TestAccGitlabGroupVariable_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabGroupVariableExists("gitlab_group_variable.foo", &groupVariable),
 					testAccCheckGitlabGroupVariableAttributes(&groupVariable, &testAccGitlabGroupVariableExpectedAttributes{
-						Key:       fmt.Sprintf("key_%s", rString),
-						Value:     fmt.Sprintf("value-%s", rString),
-						Protected: false,
+						Key:              fmt.Sprintf("key_%s", rString),
+						Value:            fmt.Sprintf("value-%s", rString),
+						Protected:        false,
+						EnvironmentScope: "",
 					}),
 				),
 			},
@@ -85,10 +87,11 @@ func testAccCheckGitlabGroupVariableExists(n string, groupVariable *gitlab.Group
 }
 
 type testAccGitlabGroupVariableExpectedAttributes struct {
-	Key       string
-	Value     string
-	Protected bool
-	Masked    bool
+	Key              string
+	Value            string
+	Protected        bool
+	Masked           bool
+	EnvironmentScope string
 }
 
 func testAccCheckGitlabGroupVariableAttributes(variable *gitlab.GroupVariable, want *testAccGitlabGroupVariableExpectedAttributes) resource.TestCheckFunc {
@@ -107,6 +110,10 @@ func testAccCheckGitlabGroupVariableAttributes(variable *gitlab.GroupVariable, w
 
 		if variable.Masked != want.Masked {
 			return fmt.Errorf("got masked %t; want %t", variable.Masked, want.Masked)
+		}
+
+		if variable.EnvironmentScope != want.EnvironmentScope {
+			return fmt.Errorf("got environment_scope %s; environment_scope %s", variable.EnvironmentScope, want.EnvironmentScope)
 		}
 
 		return nil
@@ -167,6 +174,7 @@ resource "gitlab_group_variable" "foo" {
   value = "value-inverse-%s"
   protected = true
   masked = false
+  environment_scope = "foo%s"
 }
-	`, rString, rString, rString, rString)
+	`, rString, rString, rString, rString, rString)
 }


### PR DESCRIPTION
Depends on https://github.com/xanzy/go-gitlab/pull/1138. Will remove replace directive from go.mod once released in go-gitlab.

Fixes #610.

The unrelated changes to calls to the `client.Users.GetUser` method are due to a breaking change in the upstream library.