### PR TITLE
Do not recreate project mirror on every run.

### DIFF
--- a/docs/resources/project_mirror.md
+++ b/docs/resources/project_mirror.md
@@ -25,6 +25,10 @@ The following arguments are supported:
 
 * `url` - (Required) The URL of the remote repository to be mirrored.
 
+~> Due to limitations of the GitLab API, the provider cannot update the
+username and passwords that are present in the URL. To change the username or
+the password, we recommend you to [replace](https://www.terraform.io/docs/cli/commands/plan.html#replace-address) the resources.
+
 * `enabled` - Determines if the mirror is enabled.
 
 * `only_protected_branches` - Determines if only protected branches are mirrored.

--- a/gitlab/resource_gitlab_project_mirror.go
+++ b/gitlab/resource_gitlab_project_mirror.go
@@ -2,6 +2,7 @@ package gitlab
 
 import (
 	"log"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -34,6 +35,23 @@ func resourceGitlabProjectMirror() *schema.Resource {
 				ForceNew:  true,
 				Required:  true,
 				Sensitive: true, // Username and password must be provided in the URL for https.
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					oldURL, err := url.Parse(old)
+					if err != nil {
+						return old == new
+					}
+					newURL, err := url.Parse(new)
+					if err != nil {
+						return old == new
+					}
+					if oldURL.User != nil {
+						oldURL.User = url.UserPassword("redacted", "redacted")
+					}
+					if newURL.User != nil {
+						newURL.User = url.UserPassword("redacted", "redacted")
+					}
+					return oldURL.String() == newURL.String()
+				},
 			},
 			"enabled": {
 				Type:     schema.TypeBool,
@@ -141,21 +159,32 @@ func resourceGitlabProjectMirrorRead(d *schema.ResourceData, meta interface{}) e
 	}
 	log.Printf("[DEBUG] read gitlab project mirror %s id %v", projectID, mirrorID)
 
-	mirrors, _, err := client.ProjectMirrors.ListProjectMirror(projectID, nil)
-
-	if err != nil {
-		return err
-	}
-
 	var mirror *gitlab.ProjectMirror
 	found := false
 
-	for _, m := range mirrors {
-		log.Printf("[DEBUG] project mirror found %v", m.ID)
-		if m.ID == integerMirrorID {
-			mirror = m
-			found = true
+	opts := &gitlab.ListProjectMirrorOptions{
+		Page:    1,
+		PerPage: 20,
+	}
+
+	for {
+		mirrors, response, err := client.ProjectMirrors.ListProjectMirror(projectID, opts)
+		if err != nil {
+			return err
 		}
+
+		for _, m := range mirrors {
+			log.Printf("[DEBUG] project mirror found %v", m.ID)
+			if m.ID == integerMirrorID {
+				mirror = m
+				found = true
+				break
+			}
+		}
+		if response.CurrentPage >= response.TotalPages {
+			break
+		}
+		opts.Page++
 	}
 
 	if !found {

--- a/gitlab/resource_gitlab_project_mirror_test.go
+++ b/gitlab/resource_gitlab_project_mirror_test.go
@@ -65,6 +65,39 @@ func TestAccGitlabProjectMirror_basic(t *testing.T) {
 	})
 }
 
+func TestAccGitlabProjectMirror_withPassword(t *testing.T) {
+	//var mirror gitlab.ProjectMirror
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGitlabProjectMirrorDestroy,
+		Steps: []resource.TestStep{
+			// Create a project and mirror with a username / password.
+			{
+				Config: testAccGitlabProjectMirrorConfigWithPassword(rInt),
+			},
+		},
+	})
+}
+
+func TestAccGitlabProjectMirror_withCount(t *testing.T) {
+	//var mirror gitlab.ProjectMirror
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGitlabProjectMirrorDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGitlabProjectMirrorConfigWithCount(rInt),
+			},
+		},
+	})
+}
+
 // lintignore: AT002 // TODO: Resolve this tfproviderlint issue
 func TestAccGitlabProjectMirror_import(t *testing.T) {
 	rInt := acctest.RandInt()
@@ -186,6 +219,43 @@ resource "gitlab_project_mirror" "foo" {
   url = "https://example.com/hook-%d"
 }
 	`, rInt, rInt)
+}
+
+func testAccGitlabProjectMirrorConfigWithCount(rInt int) string {
+	return fmt.Sprintf(`
+resource "gitlab_project" "foo" {
+  name = "foo-%d"
+  description = "Terraform acceptance tests"
+
+  # So that acceptance tests can be run in a gitlab organization
+  # with no billing
+  visibility_level = "public"
+}
+
+resource "gitlab_project_mirror" "foo" {
+  project = "${gitlab_project.foo.id}"
+  url = "https://foo:%d@example.com/mirror-%d"
+  count = 40
+}
+	`, rInt, rInt, rInt)
+}
+
+func testAccGitlabProjectMirrorConfigWithPassword(rInt int) string {
+	return fmt.Sprintf(`
+resource "gitlab_project" "foo" {
+  name = "foo-%d"
+  description = "Terraform acceptance tests"
+
+  # So that acceptance tests can be run in a gitlab organization
+  # with no billing
+  visibility_level = "public"
+}
+
+resource "gitlab_project_mirror" "foo" {
+  project = "${gitlab_project.foo.id}"
+  url = "https://foo:%d@example.com/mirror-%d"
+}
+	`, rInt, rInt, rInt)
 }
 
 func testAccGitlabProjectMirrorUpdateConfig(rInt int) string {


### PR DESCRIPTION
GitLab does not return username and password from the mirrors.
Therefore, let's ignore it in the provider.

Fix #504 

Signed-off-by: Julien Pivotto <roidelapluie@inuits.eu>