### PR TITLE
Update go-gitlab to v0.50.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ website/node_modules
 *.test
 *.iml
 .envrc
+.tool-versions
 
 website/vendor
 

--- a/gitlab/resource_gitlab_project_mirror.go
+++ b/gitlab/resource_gitlab_project_mirror.go
@@ -139,9 +139,12 @@ func resourceGitlabProjectMirrorRead(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		return err
 	}
+
+	options := &gitlab.ListProjectMirrorOptions{}
+
 	log.Printf("[DEBUG] read gitlab project mirror %s id %v", projectID, mirrorID)
 
-	mirrors, _, err := client.ProjectMirrors.ListProjectMirror(projectID)
+	mirrors, _, err := client.ProjectMirrors.ListProjectMirror(projectID, options)
 
 	if err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,5 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.7.0
 	github.com/hashicorp/terraform-plugin-sdk v1.16.0
 	github.com/mitchellh/hashstructure v1.0.0
-	github.com/xanzy/go-gitlab v0.50.0
+	github.com/xanzy/go-gitlab v0.50.1
 )

--- a/go.sum
+++ b/go.sum
@@ -299,6 +299,8 @@ github.com/vmihailenco/msgpack v4.0.1+incompatible h1:RMF1enSPeKTlXrXdOcqjFUElyw
 github.com/vmihailenco/msgpack v4.0.1+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/xanzy/go-gitlab v0.50.0 h1:t7IoYTrnLSbdEZN7d8X/5zcr+ZM4TZQ2mXa8MqWlAZQ=
 github.com/xanzy/go-gitlab v0.50.0/go.mod h1:Q+hQhV508bDPoBijv7YjK/Lvlb4PhVhJdKqXVQrUoAE=
+github.com/xanzy/go-gitlab v0.50.1 h1:eH1G0/ZV1j81rhGrtbcePjbM5Ern7mPA4Xjt+yE+2PQ=
+github.com/xanzy/go-gitlab v0.50.1/go.mod h1:Q+hQhV508bDPoBijv7YjK/Lvlb4PhVhJdKqXVQrUoAE=
 github.com/xanzy/ssh-agent v0.2.1 h1:TCbipTQL2JiiCprBWx9frJ2eJlCYT00NmctrHxVAr70=
 github.com/xanzy/ssh-agent v0.2.1/go.mod h1:mLlQY/MoOhWBj+gOGMQkOeiEvkx+8pJSI+0Bx9h2kr4=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
This fixes the issue #640 encountered when attempting to bump go-gitlab to v0.50.1 and completes the version bump.