### PR TITLE
golangci-lint: exclude ResourceData.Set

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  errcheck:
+    exclude: errcheck_excludes.txt

--- a/errcheck_excludes.txt
+++ b/errcheck_excludes.txt
@@ -1,0 +1,1 @@
+(*github.com/hashicorp/terraform-plugin-sdk/helper/schema.ResourceData).Set


### PR DESCRIPTION
The common case when using this method is to ignore the error return. This is because the Terraform test framework checks these errors for primitive types for us.

See https://www.terraform.io/docs/extend/best-practices/detecting-drift.html#error-checking-aggregate-types