### PR TITLE
Annotate golangci-lint failing checks

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,6 +1,6 @@
 name: golangci-lint
 
-on: push
+on: [push,pull_request]
 
 jobs:
   golangci:

--- a/gitlab/data_source_gitlab_group_test.go
+++ b/gitlab/data_source_gitlab_group_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAccDataSourceGitlabGroup_basic(t *testing.T) {
-	rString := fmt.Sprintf("%s", acctest.RandString(5))
+	rString := fmt.Sprintf("%s", acctest.RandString(5)) // nolint // TODO: Resolve this golangci-lint issue: S1025: the argument is already a string, there's no need to use fmt.Sprintf (gosimple)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/gitlab/data_source_gitlab_projects.go
+++ b/gitlab/data_source_gitlab_projects.go
@@ -102,7 +102,7 @@ func flattenGitlabBasicUser(user *gitlab.User) (values []map[string]interface{})
 }
 
 func flattenProjects(projects []*gitlab.Project) (values []map[string]interface{}) {
-	if projects != nil {
+	if projects != nil { // nolint // TODO: Resolve this golangci-lint issue: S1031: unnecessary nil check around range (gosimple)
 		for _, project := range projects {
 			v := map[string]interface{}{
 				"id":                                    project.ID,

--- a/gitlab/data_source_gitlab_projects_test.go
+++ b/gitlab/data_source_gitlab_projects_test.go
@@ -137,7 +137,7 @@ func testAccDataSourceGitlabProjects(src string, n string) resource.TestCheckFun
 
 		var errorMessageExpected strings.Builder
 		for _, attr := range testAttributes {
-			errorMessageExpected.WriteString(fmt.Sprintf("%s=%v, ", attr, projectResource[fmt.Sprintf("%s", attr)]))
+			errorMessageExpected.WriteString(fmt.Sprintf("%s=%v, ", attr, projectResource[fmt.Sprintf("%s", attr)])) // nolint // TODO: Resolve this golangci-lint issue: S1025: the argument is already a string, there's no need to use fmt.Sprintf (gosimple)
 		}
 
 		var errorMessageGot strings.Builder

--- a/gitlab/data_source_gitlab_user_test.go
+++ b/gitlab/data_source_gitlab_user_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAccDataSourceGitlabUser_basic(t *testing.T) {
-	rString := fmt.Sprintf("%s", acctest.RandString(5))
+	rString := fmt.Sprintf("%s", acctest.RandString(5)) // nolint // TODO: Resolve this golangci-lint issue: S1025: the argument is already a string, there's no need to use fmt.Sprintf (gosimple)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },

--- a/gitlab/helper_test.go
+++ b/gitlab/helper_test.go
@@ -14,9 +14,9 @@ import (
 func testAccCompareGitLabAttribute(attr string, expected, received *schema.ResourceData) error {
 	e := expected.Get(attr)
 	r := received.Get(attr)
-	switch e.(type) {
+	switch e.(type) { // nolint // TODO: Resolve this golangci-lint issue: S1034: assigning the result of this type assertion to a variable (switch e := e.(type)) could eliminate type assertions in switch cases (gosimple)
 	case *schema.Set:
-		if !e.(*schema.Set).Equal(r) {
+		if !e.(*schema.Set).Equal(r) { // nolint // TODO: Resolve this golangci-lint issue: S1034(related information): could eliminate this type assertion (gosimple)
 			return fmt.Errorf(`attribute set %s expected "%+v" received "%+v"`, attr, e, r)
 		}
 	default:

--- a/gitlab/provider.go
+++ b/gitlab/provider.go
@@ -142,7 +142,7 @@ func providerConfigure(p *schema.Provider, d *schema.ResourceData) (interface{},
 
 	// NOTE: httpclient.TerraformUserAgent is deprecated and removed in Terraform SDK v2
 	// After upgrading the SDK to v2 replace with p.UserAgent("terraform-provider-gitlab")
-	client.UserAgent = httpclient.TerraformUserAgent(p.TerraformVersion) + " terraform-provider-gitlab"
+	client.UserAgent = httpclient.TerraformUserAgent(p.TerraformVersion) + " terraform-provider-gitlab" // nolint // TODO: Resolve this golangci-lint issue: SA1019: httpclient.TerraformUserAgent is deprecated: This will be removed in v2 without replacement. If you need its functionality, you can copy it or reference the v1 package. (staticcheck)
 
 	return client, err
 }

--- a/gitlab/resource_gitlab_deploy_key_enable.go
+++ b/gitlab/resource_gitlab_deploy_key_enable.go
@@ -52,7 +52,7 @@ func resourceGitlabDeployEnableKey() *schema.Resource {
 func resourceGitlabDeployKeyEnableCreate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(*gitlab.Client)
 	project := d.Get("project").(string)
-	key_id, err := strconv.Atoi(d.Get("key_id").(string))
+	key_id, err := strconv.Atoi(d.Get("key_id").(string)) // nolint // TODO: Resolve this golangci-lint issue: ineffectual assignment to err (ineffassign)
 
 	log.Printf("[DEBUG] enable gitlab deploy key %s/%d", project, key_id)
 

--- a/gitlab/resource_gitlab_deploy_key_test.go
+++ b/gitlab/resource_gitlab_deploy_key_test.go
@@ -153,7 +153,7 @@ func testAccCheckGitlabDeployKeyDestroy(s *terraform.State) error {
 		if rs.Type != "gitlab_project" {
 			continue
 		}
-		deployKeyID, err := strconv.Atoi(rs.Primary.ID)
+		deployKeyID, err := strconv.Atoi(rs.Primary.ID) // nolint // TODO: Resolve this golangci-lint issue: ineffectual assignment to err (ineffassign)
 		project := rs.Primary.Attributes["project"]
 
 		gotDeployKey, resp, err := conn.DeployKeys.GetDeployKey(project, deployKeyID)

--- a/gitlab/resource_gitlab_group_ldap_link.go
+++ b/gitlab/resource_gitlab_group_ldap_link.go
@@ -71,7 +71,7 @@ func resourceGitlabGroupLdapLinkCreate(d *schema.ResourceData, meta interface{})
 	}
 
 	if force {
-		resourceGitlabGroupLdapLinkDelete(d, meta)
+		resourceGitlabGroupLdapLinkDelete(d, meta) // nolint // TODO: Resolve this golangci-lint issue: Error return value is not checked (errcheck)
 	}
 
 	log.Printf("[DEBUG] Create GitLab group LdapLink %s", d.Id())
@@ -95,9 +95,9 @@ func resourceGitlabGroupLdapLinkRead(d *schema.ResourceData, meta interface{}) e
 	if err != nil {
 		// The read/GET API wasn't implemented in GitLab until version 12.8 (March 2020, well after the add and delete APIs).
 		// If we 404, assume GitLab is at an older version and take things on faith.
-		switch err.(type) {
+		switch err.(type) { // nolint // TODO: Resolve this golangci-lint issue: S1034: assigning the result of this type assertion to a variable (switch err := err.(type)) could eliminate type assertions in switch cases (gosimple)
 		case *gitlab.ErrorResponse:
-			if err.(*gitlab.ErrorResponse).Response.StatusCode == 404 {
+			if err.(*gitlab.ErrorResponse).Response.StatusCode == 404 { // nolint // TODO: Resolve this golangci-lint issue: S1034(related information): could eliminate this type assertion (gosimple)
 				log.Printf("[WARNING] This GitLab instance doesn't have the GET API for group_ldap_sync.  Please upgrade to 12.8 or later for best results.")
 			} else {
 				return err
@@ -124,7 +124,7 @@ func resourceGitlabGroupLdapLinkRead(d *schema.ResourceData, meta interface{}) e
 
 		if !found {
 			d.SetId("")
-			return errors.New(fmt.Sprintf("LdapLink %s does not exist.", d.Id()))
+			return errors.New(fmt.Sprintf("LdapLink %s does not exist.", d.Id())) // nolint // TODO: Resolve this golangci-lint issue: S1028: should use fmt.Errorf(...) instead of errors.New(fmt.Sprintf(...)) (gosimple)
 		}
 	}
 
@@ -140,10 +140,10 @@ func resourceGitlabGroupLdapLinkDelete(d *schema.ResourceData, meta interface{})
 	log.Printf("[DEBUG] Delete GitLab group LdapLink %s", d.Id())
 	_, err := client.Groups.DeleteGroupLDAPLinkForProvider(groupId, ldap_provider, cn)
 	if err != nil {
-		switch err.(type) {
+		switch err.(type) { // nolint // TODO: Resolve this golangci-lint issue: S1034: assigning the result of this type assertion to a variable (switch err := err.(type)) could eliminate type assertions in switch cases (gosimple)
 		case *gitlab.ErrorResponse:
 			// Ignore LDAP links that don't exist
-			if strings.Contains(string(err.(*gitlab.ErrorResponse).Message), "Linked LDAP group not found") {
+			if strings.Contains(string(err.(*gitlab.ErrorResponse).Message), "Linked LDAP group not found") { // nolint // TODO: Resolve this golangci-lint issue: S1034(related information): could eliminate this type assertion (gosimple)
 				log.Printf("[WARNING] %s", err)
 			} else {
 				return err

--- a/gitlab/resource_gitlab_group_ldap_link_test.go
+++ b/gitlab/resource_gitlab_group_ldap_link_test.go
@@ -37,7 +37,7 @@ func TestAccGitlabGroupLdapLink_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabGroupLdapLinkExists("gitlab_group_ldap_link.foo", &ldapLink),
 					testAccCheckGitlabGroupLdapLinkAttributes(&ldapLink, &testAccGitlabGroupLdapLinkExpectedAttributes{
-						accessLevel: fmt.Sprintf("developer"),
+						accessLevel: fmt.Sprintf("developer"), // nolint // TODO: Resolve this golangci-lint issue: S1039: unnecessary use of fmt.Sprintf (gosimple)
 					})),
 			},
 
@@ -48,7 +48,7 @@ func TestAccGitlabGroupLdapLink_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabGroupLdapLinkExists("gitlab_group_ldap_link.foo", &ldapLink),
 					testAccCheckGitlabGroupLdapLinkAttributes(&ldapLink, &testAccGitlabGroupLdapLinkExpectedAttributes{
-						accessLevel: fmt.Sprintf("maintainer"),
+						accessLevel: fmt.Sprintf("maintainer"), // nolint // TODO: Resolve this golangci-lint issue: S1039: unnecessary use of fmt.Sprintf (gosimple)
 					})),
 			},
 
@@ -59,7 +59,7 @@ func TestAccGitlabGroupLdapLink_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabGroupLdapLinkExists("gitlab_group_ldap_link.bar", &ldapLink),
 					testAccCheckGitlabGroupLdapLinkAttributes(&ldapLink, &testAccGitlabGroupLdapLinkExpectedAttributes{
-						accessLevel: fmt.Sprintf("developer"),
+						accessLevel: fmt.Sprintf("developer"), // nolint // TODO: Resolve this golangci-lint issue: S1039: unnecessary use of fmt.Sprintf (gosimple)
 					})),
 			},
 		},
@@ -160,9 +160,9 @@ func testAccGetGitlabGroupLdapLink(ldapLink *gitlab.LDAPGroupLink, resourceState
 	if err != nil {
 		// The read/GET API wasn't implemented in GitLab until version 12.8 (March 2020, well after the add and delete APIs).
 		// If we 404, assume GitLab is at an older version and take things on faith.
-		switch err.(type) {
+		switch err.(type) { // nolint // TODO: Resolve this golangci-lint issue: S1034: assigning the result of this type assertion to a variable (switch err := err.(type)) could eliminate type assertions in switch cases (gosimple)
 		case *gitlab.ErrorResponse:
-			if err.(*gitlab.ErrorResponse).Response.StatusCode == 404 {
+			if err.(*gitlab.ErrorResponse).Response.StatusCode == 404 { // nolint // TODO: Resolve this golangci-lint issue: S1034(related information): could eliminate this type assertion (gosimple)
 				// Do nothing
 			} else {
 				return err
@@ -186,7 +186,7 @@ func testAccGetGitlabGroupLdapLink(ldapLink *gitlab.LDAPGroupLink, resourceState
 		}
 
 		if !found {
-			return errors.New(fmt.Sprintf("LdapLink %s does not exist.", desiredLdapLinkId))
+			return errors.New(fmt.Sprintf("LdapLink %s does not exist.", desiredLdapLinkId)) // nolint // TODO: Resolve this golangci-lint issue: S1028: should use fmt.Errorf(...) instead of errors.New(fmt.Sprintf(...)) (gosimple)
 		}
 	} else {
 		*ldapLink = desiredLdapLink

--- a/gitlab/resource_gitlab_group_membership_test.go
+++ b/gitlab/resource_gitlab_group_membership_test.go
@@ -24,7 +24,7 @@ func TestAccGitlabGroupMembership_basic(t *testing.T) {
 			{
 				Config: testAccGitlabGroupMembershipConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(testAccCheckGitlabGroupMembershipExists("gitlab_group_membership.foo", &groupMember), testAccCheckGitlabGroupMembershipAttributes(&groupMember, &testAccGitlabGroupMembershipExpectedAttributes{
-					accessLevel: fmt.Sprintf("developer"),
+					accessLevel: fmt.Sprintf("developer"), // nolint // TODO: Resolve this golangci-lint issue: S1039: unnecessary use of fmt.Sprintf (gosimple)
 				})),
 			},
 
@@ -32,8 +32,8 @@ func TestAccGitlabGroupMembership_basic(t *testing.T) {
 			{
 				Config: testAccGitlabGroupMembershipUpdateConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(testAccCheckGitlabGroupMembershipExists("gitlab_group_membership.foo", &groupMember), testAccCheckGitlabGroupMembershipAttributes(&groupMember, &testAccGitlabGroupMembershipExpectedAttributes{
-					accessLevel: fmt.Sprintf("guest"),
-					expiresAt:   fmt.Sprintf("2099-01-01"),
+					accessLevel: fmt.Sprintf("guest"),      // nolint // TODO: Resolve this golangci-lint issue: S1039: unnecessary use of fmt.Sprintf (gosimple)
+					expiresAt:   fmt.Sprintf("2099-01-01"), // nolint // TODO: Resolve this golangci-lint issue: S1039: unnecessary use of fmt.Sprintf (gosimple)
 				})),
 			},
 
@@ -41,7 +41,7 @@ func TestAccGitlabGroupMembership_basic(t *testing.T) {
 			{
 				Config: testAccGitlabGroupMembershipConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(testAccCheckGitlabGroupMembershipExists("gitlab_group_membership.foo", &groupMember), testAccCheckGitlabGroupMembershipAttributes(&groupMember, &testAccGitlabGroupMembershipExpectedAttributes{
-					accessLevel: fmt.Sprintf("developer"),
+					accessLevel: fmt.Sprintf("developer"), // nolint // TODO: Resolve this golangci-lint issue: S1039: unnecessary use of fmt.Sprintf (gosimple)
 				})),
 			},
 		},
@@ -108,7 +108,7 @@ func testAccCheckGitlabGroupMembershipDestroy(s *terraform.State) error {
 		userIdString := rs.Primary.Attributes["user_id"]
 
 		// GetGroupMember needs int type for userIdString
-		userId, err := strconv.Atoi(userIdString)
+		userId, err := strconv.Atoi(userIdString) // nolint // TODO: Resolve this golangci-lint issue: ineffectual assignment to err (ineffassign)
 		groupMember, resp, err := conn.GroupMembers.GetGroupMember(groupId, userId)
 		if err != nil {
 			if groupMember != nil && fmt.Sprintf("%d", groupMember.AccessLevel) == rs.Primary.Attributes["accessLevel"] {

--- a/gitlab/resource_gitlab_group_variable_test.go
+++ b/gitlab/resource_gitlab_group_variable_test.go
@@ -122,7 +122,7 @@ func testAccCheckGitlabGroupVariableDestroy(s *terraform.State) error {
 		}
 
 		_, resp, err := conn.Groups.GetGroup(rs.Primary.ID)
-		if err == nil {
+		if err == nil { // nolint // TODO: Resolve this golangci-lint issue: SA9003: empty branch (staticcheck)
 			//if gotRepo != nil && fmt.Sprintf("%d", gotRepo.ID) == rs.Primary.ID {
 			//	if gotRepo.MarkedForDeletionAt == nil {
 			//		return fmt.Errorf("Repository still exists")

--- a/gitlab/resource_gitlab_pipeline_schedule.go
+++ b/gitlab/resource_gitlab_pipeline_schedule.go
@@ -117,7 +117,7 @@ func resourceGitlabPipelineScheduleRead(d *schema.ResourceData, meta interface{}
 		opt.Page = resp.NextPage
 	}
 	if !found {
-		return errors.New(fmt.Sprintf("PipelineSchedule %d no longer exists in gitlab", pipelineScheduleID))
+		return errors.New(fmt.Sprintf("PipelineSchedule %d no longer exists in gitlab", pipelineScheduleID)) // nolint // TODO: Resolve this golangci-lint issue: S1028: should use fmt.Errorf(...) instead of errors.New(fmt.Sprintf(...)) (gosimple)
 	}
 
 	return nil

--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -476,7 +476,7 @@ func resourceGitlabProjectCreate(d *schema.ResourceData, meta interface{}) error
 
 	// Some project settings can't be set in the Project Create API and have to
 	// set in a second call after project creation.
-	resourceGitlabProjectUpdate(d, meta)
+	resourceGitlabProjectUpdate(d, meta) // nolint // TODO: Resolve this golangci-lint issue: Error return value is not checked (errcheck)
 
 	return resourceGitlabProjectRead(d, meta)
 }

--- a/gitlab/resource_gitlab_project_membership_test.go
+++ b/gitlab/resource_gitlab_project_membership_test.go
@@ -24,7 +24,7 @@ func TestAccGitlabProjectMembership_basic(t *testing.T) {
 			{
 				Config: testAccGitlabProjectMembershipConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(testAccCheckGitlabProjectMembershipExists("gitlab_project_membership.foo", &membership), testAccCheckGitlabProjectMembershipAttributes(&membership, &testAccGitlabProjectMembershipExpectedAttributes{
-					access_level: fmt.Sprintf("developer"),
+					access_level: fmt.Sprintf("developer"), // nolint // TODO: Resolve this golangci-lint issue: S1039: unnecessary use of fmt.Sprintf (gosimple)
 				})),
 			},
 
@@ -32,7 +32,7 @@ func TestAccGitlabProjectMembership_basic(t *testing.T) {
 			{
 				Config: testAccGitlabProjectMembershipUpdateConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(testAccCheckGitlabProjectMembershipExists("gitlab_project_membership.foo", &membership), testAccCheckGitlabProjectMembershipAttributes(&membership, &testAccGitlabProjectMembershipExpectedAttributes{
-					access_level: fmt.Sprintf("guest"),
+					access_level: fmt.Sprintf("guest"), // nolint // TODO: Resolve this golangci-lint issue: S1039: unnecessary use of fmt.Sprintf (gosimple)
 				})),
 			},
 
@@ -40,7 +40,7 @@ func TestAccGitlabProjectMembership_basic(t *testing.T) {
 			{
 				Config: testAccGitlabProjectMembershipConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(testAccCheckGitlabProjectMembershipExists("gitlab_project_membership.foo", &membership), testAccCheckGitlabProjectMembershipAttributes(&membership, &testAccGitlabProjectMembershipExpectedAttributes{
-					access_level: fmt.Sprintf("developer"),
+					access_level: fmt.Sprintf("developer"), // nolint // TODO: Resolve this golangci-lint issue: S1039: unnecessary use of fmt.Sprintf (gosimple)
 				})),
 			},
 		},
@@ -106,7 +106,7 @@ func testAccCheckGitlabProjectMembershipDestroy(s *terraform.State) error {
 		userID := rs.Primary.Attributes["user_id"]
 
 		// GetProjectMember needs int type for userID
-		userIDI, err := strconv.Atoi(userID)
+		userIDI, err := strconv.Atoi(userID) // nolint // TODO: Resolve this golangci-lint issue: ineffectual assignment to err (ineffassign)
 		gotMembership, resp, err := conn.ProjectMembers.GetProjectMember(projectID, userIDI)
 		if err != nil {
 			if gotMembership != nil && fmt.Sprintf("%d", gotMembership.AccessLevel) == rs.Primary.Attributes["access_level"] {

--- a/gitlab/resource_gitlab_project_test.go
+++ b/gitlab/resource_gitlab_project_test.go
@@ -506,7 +506,7 @@ func TestAccGitlabProject_importURL(t *testing.T) {
 		t.Fatalf("failed to create base project: %v", err)
 	}
 
-	defer client.Projects.DeleteProject(baseProject.ID)
+	defer client.Projects.DeleteProject(baseProject.ID) // nolint // TODO: Resolve this golangci-lint issue: Error return value of `client.Projects.DeleteProject` is not checked (errcheck)
 
 	// Add a file to the base project, for later verifying the import.
 	_, _, err = client.RepositoryFiles.CreateFile(baseProject.ID, "foo.txt", &gitlab.CreateFileOptions{
@@ -591,7 +591,7 @@ func TestAccGitlabProject_importURLMirrored(t *testing.T) {
 		t.Fatalf("failed to create base project: %v", err)
 	}
 
-	defer client.Projects.DeleteProject(baseProject.ID)
+	defer client.Projects.DeleteProject(baseProject.ID) // nolint // TODO: Resolve this golangci-lint issue: Error return value of `client.Projects.DeleteProject` is not checked (errcheck)
 
 	// Add a file to the base project, for later verifying the import.
 	_, _, err = client.RepositoryFiles.CreateFile(baseProject.ID, "foo.txt", &gitlab.CreateFileOptions{


### PR DESCRIPTION
chore: run golangci-lint for pull requests and annotate failing checks so we can fix them individually, similarly to the tfproviderlint checks annotated in #653