### PR TITLE
New computed branch_protection_id attribute for gitlab_branch_protection

### DIFF
--- a/docs/resources/branch_protection.md
+++ b/docs/resources/branch_protection.md
@@ -56,6 +56,8 @@ An `allowed_to_push` or `allowed_to_merge` block supports the following argument
 
 The following attributes are exported:
 
+* `branch_protection_id` - The ID of the branch protection (not the branch name).
+
 * The `allowed_to_push` and `allowed_to_merge` blocks export the `access_level_description` field, which contains a textual description of the access level, user or group allowed to perform the relevant action.
 
 ## Import

--- a/docs/resources/project_approval_rule.md
+++ b/docs/resources/project_approval_rule.md
@@ -4,33 +4,37 @@ This resource allows you to create and manage multiple approval rules for your G
 projects. For further information on approval rules, consult the [gitlab
 documentation](https://docs.gitlab.com/ee/api/merge_request_approvals.html#project-level-mr-approvals).
 
--> This feature requires a GitLab Starter account or above.
+-> This feature requires GitLab Premium.
 
 ## Example Usage
 
 ```hcl
 resource "gitlab_project_approval_rule" "example-one" {
   project            = 5
-  name               = "Example Rule 1"
+  name               = "Example Rule"
   approvals_required = 3
   user_ids           = [50, 500]
   group_ids          = [51]
 }
+```
 
+### With Protected Branch IDs
+
+```hcl
 resource "gitlab_branch_protection" "example" {
   project            = 5
-  branch             = "main"
-  push_access_level  = "developer"
+  branch             = "release/*"
+  push_access_level  = "maintainer"
   merge_access_level = "developer"
 }
 
-resource "gitlab_project_approval_rule" "example-two" {
+resource "gitlab_project_approval_rule" "example" {
   project              = 5
-  name                 = "Example Rule 2"
-  approvals_required   = 1
-  user_ids             = []
-  group_ids            = [52]
-  protected_branch_ids = [gitlab_branch_protection.example.id]
+  name                 = "Example Rule"
+  approvals_required   = 3
+  user_ids             = [50, 500]
+  group_ids            = [51]
+  protected_branch_ids = [gitlab_branch_protection.example.branch_protection_id]
 }
 ```
 
@@ -48,7 +52,7 @@ The following arguments are supported:
 
 * `group_ids` - (Optional) A list of group IDs whose members can approve of the merge request.
 
-* `protected_branch_ids` - (Optional) A list of protected branch IDs for which the rule applies.
+* `protected_branch_ids` - (Optional) A list of protected branch IDs (not branch names) for which the rule applies.
 
 ## Import
 

--- a/gitlab/resource_gitlab_branch_protection.go
+++ b/gitlab/resource_gitlab_branch_protection.go
@@ -76,6 +76,10 @@ func resourceGitlabBranchProtection() *schema.Resource {
 				Optional: true,
 				Default:  false,
 			},
+			"branch_protection_id": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -171,6 +175,8 @@ func resourceGitlabBranchProtectionRead(d *schema.ResourceData, meta interface{}
 	if err := d.Set("code_owner_approval_required", pb.CodeOwnerApprovalRequired); err != nil {
 		return fmt.Errorf("error setting code_owner_approval_required: %v", err)
 	}
+
+	d.Set("branch_protection_id", pb.ID)
 
 	d.SetId(buildTwoPartID(&project, &pb.Name))
 

--- a/gitlab/resource_gitlab_branch_protection_test.go
+++ b/gitlab/resource_gitlab_branch_protection_test.go
@@ -28,6 +28,7 @@ func TestAccGitlabBranchProtection_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
+					testAccCheckGitlabBranchProtectionComputedAttributes("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
 						Name:             fmt.Sprintf("BranchProtect-%d", rInt),
 						PushAccessLevel:  accessLevel[gitlab.DeveloperPermissions],
@@ -289,6 +290,12 @@ func testAccCheckGitlabBranchProtectionExists(n string, pb *gitlab.ProtectedBran
 			}
 		}
 		return fmt.Errorf("Protected Branch does not exist")
+	}
+}
+
+func testAccCheckGitlabBranchProtectionComputedAttributes(n string, pb *gitlab.ProtectedBranch) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		return resource.TestCheckResourceAttr(n, "branch_protection_id", strconv.Itoa(pb.ID))(s)
 	}
 }
 


### PR DESCRIPTION
Related to #659, this makes the `protected_branch_ids` argument of `gitlab_project_approval_rule` more useful by adding a computed `branch_protection_id` attribute to `gitlab_branch_protection`. It also fixes incorrect documentation.