### PR TITLE
Add CustomCIPath to resource `gitlab_project`

### DIFF
--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -107,6 +107,8 @@ consult the [gitlab documentation](https://docs.gitlab.com/ee/user/project/repos
 
 * `build_coverage_regex` - (Optional) Test coverage parsing for the project.
 
+* `ci_config_path` - (Optional) Custom Path to CI config file.
+
 ## Attributes Reference
 
 The following additional attributes are exported:

--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -277,6 +277,10 @@ var resourceGitLabProjectSchema = map[string]*schema.Schema{
 		Type:     schema.TypeString,
 		Optional: true,
 	},
+	"ci_config_path": {
+		Type:     schema.TypeString,
+		Optional: true,
+	},
 }
 
 func resourceGitlabProject() *schema.Resource {
@@ -330,7 +334,7 @@ func resourceGitlabProjectSetToState(d *schema.ResourceData, project *gitlab.Pro
 	d.Set("mirror_overwrites_diverged_branches", project.MirrorOverwritesDivergedBranches)
 	d.Set("only_mirror_protected_branches", project.OnlyMirrorProtectedBranches)
 	d.Set("build_coverage_regex", project.BuildCoverageRegex)
-
+	d.Set("ci_config_path", project.CIConfigPath)
 	return nil
 }
 
@@ -358,6 +362,7 @@ func resourceGitlabProjectCreate(d *schema.ResourceData, meta interface{}) error
 		Mirror:                                    gitlab.Bool(d.Get("mirror").(bool)),
 		MirrorTriggerBuilds:                       gitlab.Bool(d.Get("mirror_trigger_builds").(bool)),
 		BuildCoverageRegex:                        gitlab.String(d.Get("build_coverage_regex").(string)),
+		CIConfigPath:                              gitlab.String(d.Get("ci_config_path").(string)),
 	}
 
 	if v, ok := d.GetOk("path"); ok {
@@ -406,6 +411,10 @@ func resourceGitlabProjectCreate(d *schema.ResourceData, meta interface{}) error
 
 	if v, ok := d.GetOk("pages_access_level"); ok {
 		options.PagesAccessLevel = stringToAccessControlValue(v.(string))
+	}
+
+	if v, ok := d.GetOk("ci_config_path"); ok {
+		options.CIConfigPath = gitlab.String(v.(string))
 	}
 
 	log.Printf("[DEBUG] create gitlab project %q", *options.Name)
@@ -685,6 +694,10 @@ func resourceGitlabProjectUpdate(d *schema.ResourceData, meta interface{}) error
 
 	if d.HasChange("build_coverage_regex") {
 		options.BuildCoverageRegex = gitlab.String(d.Get("build_coverage_regex").(string))
+	}
+
+	if d.HasChange("ci_config_path") {
+		options.CIConfigPath = gitlab.String(d.Get("ci_config_path").(string))
 	}
 
 	if *options != (gitlab.EditProjectOptions{}) {

--- a/gitlab/resource_gitlab_project_test.go
+++ b/gitlab/resource_gitlab_project_test.go
@@ -48,6 +48,7 @@ func TestAccGitlabProject_basic(t *testing.T) {
 		PackagesEnabled:    true,
 		PagesAccessLevel:   gitlab.PublicAccessControl,
 		BuildCoverageRegex: "foo",
+		CIConfigPath:       ".gitlab-ci.yml@mynamespace/myproject",
 	}
 
 	defaultsMainBranch = defaults
@@ -362,6 +363,7 @@ func TestAccGitlabProject_willError(t *testing.T) {
 		PackagesEnabled:    true,
 		PagesAccessLevel:   gitlab.PublicAccessControl,
 		BuildCoverageRegex: "foo",
+		CIConfigPath:       ".gitlab-ci.yml@mynamespace/myproject",
 	}
 	willError := defaults
 	willError.TagList = []string{"notatag"}
@@ -575,36 +577,6 @@ resource "gitlab_project" "foo" {
 					testAccCheckGitlabProjectDefaultBranch(&project, &testAccGitlabProjectExpectedAttributes{
 						DefaultBranch: "foo",
 					}),
-				),
-			},
-		},
-	})
-}
-
-func TestAccGitlabProject_initializeWithCustomCIPath(t *testing.T) {
-	var project gitlab.Project
-	rInt := acctest.RandInt()
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckGitlabProjectDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: fmt.Sprintf(`
-resource "gitlab_project" "foo" {
-  name        = "foo-%d"
-  description = "Terraform acceptance tests with custom CI Path"
-
-  # So that acceptance tests can be run in a gitlab organization
-  # with no billing
-  visibility_level = "public"
-
-  ci_config_path = ".gitlab-ci.yml@mynamespace/myproject"
-}`, rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabProjectExists("gitlab_project.foo", &project),
-					resource.TestCheckResourceAttr("gitlab_project.foo", "ci_config_path", ".gitlab-ci.yml@mynamespace/myproject"),
 				),
 			},
 		},
@@ -1027,6 +999,7 @@ resource "gitlab_project" "foo" {
   only_allow_merge_if_all_discussions_are_resolved = true
   pages_access_level = "public"
   build_coverage_regex = "foo"
+  ci_config_path = ".gitlab-ci.yml@mynamespace/myproject"
 }
 	`, rInt, rInt, defaultBranchStatement)
 }

--- a/gitlab/resource_gitlab_project_test.go
+++ b/gitlab/resource_gitlab_project_test.go
@@ -581,6 +581,36 @@ resource "gitlab_project" "foo" {
 	})
 }
 
+func TestAccGitlabProject_initializeWithCustomCIPath(t *testing.T) {
+	var project gitlab.Project
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGitlabProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+resource "gitlab_project" "foo" {
+  name        = "foo-%d"
+  description = "Terraform acceptance tests with custom CI Path"
+
+  # So that acceptance tests can be run in a gitlab organization
+  # with no billing
+  visibility_level = "public"
+
+  ci_config_path = ".gitlab-ci.yml@mynamespace/myproject"
+}`, rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabProjectExists("gitlab_project.foo", &project),
+					resource.TestCheckResourceAttr("gitlab_project.foo", "ci_config_path", ".gitlab-ci.yml@mynamespace/myproject"),
+				),
+			},
+		},
+	})
+}
+
 type testAccGitlabProjectMirroredExpectedAttributes struct {
 	Mirror                           bool
 	MirrorTriggerBuilds              bool


### PR DESCRIPTION
This Merge Request aims to add a very simple change to the GitLab resource Project resource so that the CustomCIPath can be passed as a parameter to the Terraform resource

 - Amend documentation to reflect the change
 - Add a standalone acceptance test


