### PR TITLE
Support running the provider using an OAuth token

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,6 +1,6 @@
 TEST?=./gitlab
 SERVICE?=gitlab-ce
-GITLAB_TOKEN?=ACCTEST
+GITLAB_TOKEN?=ACCTEST1234567890123
 GITLAB_BASE_URL?=http://127.0.0.1:8080/api/v4
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ $ make testacc GITLAB_TOKEN=example123 GITLAB_BASE_URL=https://example.com/api/v
   Then run the desired Go test as you would normally from your IDE, but configure your run configuration to set these environment variables:
 
   ```
-  GITLAB_TOKEN=ACCTEST
+  GITLAB_TOKEN=ACCTEST1234567890123
   GITLAB_BASE_URL=http://127.0.0.1:8080/api/v4
   TF_ACC=1
   ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,8 +57,8 @@ resource "gitlab_project" "sample_group_project" {
 
 The following arguments are supported in the `provider` block:
 
-* `token` - (Optional) This is the GitLab personal access token. It must be provided, but
-  it can also be sourced from the `GITLAB_TOKEN` environment variable.
+* `token` - (Required) The OAuth2 token or project/personal access token used to connect to GitLab.
+  It must be provided, but it can also be sourced from the `GITLAB_TOKEN` environment variable.
 
 * `base_url` - (Optional) This is the target GitLab base API endpoint. Providing a value is a
   requirement when working with GitLab CE or GitLab Enterprise e.g. `https://my.gitlab.server/api/v4/`.

--- a/gitlab/config.go
+++ b/gitlab/config.go
@@ -67,7 +67,9 @@ func (c *Config) Client() (*gitlab.Client, error) {
 		opts = append(opts, gitlab.WithBaseURL(c.BaseURL))
 	}
 
-	client, err := gitlab.NewClient(c.Token, opts...)
+	// The OAuth method is also compatible with project/personal access tokens because they are all usable as Bearer tokens.
+	// https://docs.gitlab.com/ee/api
+	client, err := gitlab.NewOAuthClient(c.Token, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/gitlab/provider.go
+++ b/gitlab/provider.go
@@ -112,7 +112,7 @@ var descriptions map[string]string
 
 func init() {
 	descriptions = map[string]string{
-		"token": "The OAuth token used to connect to GitLab.",
+		"token": "The OAuth2 token or project/personal access token used to connect to GitLab.",
 
 		"base_url": "The GitLab Base API URL",
 

--- a/scripts/await-healthy.sh
+++ b/scripts/await-healthy.sh
@@ -11,5 +11,5 @@ echo
 echo 'GitLab is healthy'
 
 # Print the version, since it is useful debugging information.
-curl --silent --show-error --header 'PRIVATE-TOKEN: ACCTEST' http://127.0.0.1:8080/api/v4/version
+curl --silent --show-error --header 'Authorization: Bearer ACCTEST1234567890123' http://127.0.0.1:8080/api/v4/version
 echo

--- a/scripts/healthcheck-and-setup.sh
+++ b/scripts/healthcheck-and-setup.sh
@@ -24,7 +24,7 @@ test -f $done || {
     printf 'user_id: 1, '
     printf 'scopes: [:api, :read_user], '
     printf 'name: :terraform);'
-    printf "terraform_token.set_token('ACCTEST');"
+    printf "terraform_token.set_token('ACCTEST1234567890123');"
     printf 'terraform_token.save!;'
   ) | gitlab-rails console
 


### PR DESCRIPTION
Supersedes #678
Closes #60 

Thanks to @wuperry563 for the initial PR which this builds on.

As discussed in that PR, GitLab supports the same auth header for both PAT and OAuth. I've tested this change using a real PAT and it still works.