### PR TITLE
Allow to create deploy token with all possible scopes.

### DIFF
--- a/gitlab/resource_gitlab_deploy_token.go
+++ b/gitlab/resource_gitlab_deploy_token.go
@@ -55,8 +55,16 @@ func resourceGitlabDeployToken() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: validation.StringInSlice([]string{"read_registry", "read_repository"}, false),
+					Type: schema.TypeString,
+					ValidateFunc: validation.StringInSlice(
+						[]string{
+							"read_registry",
+							"read_repository",
+							"read_package_registry",
+							"write_repository",
+							"write_registry",
+							"write_package_registry",
+						}, false),
 				},
 			},
 
@@ -169,12 +177,19 @@ func resourceGitlabDeployTokenRead(d *schema.ResourceData, meta interface{}) err
 			}
 
 			for _, scope := range token.Scopes {
-				if scope == "read_repository" {
+				switch scope {
+				case "read_repository":
 					d.Set("scopes.read_repository", true)
-				}
-
-				if scope == "read_registry" {
+				case "read_registry":
 					d.Set("scopes.read_registry", true)
+				case "read_package_registry":
+					d.Set("scopes.read_package_registry", true)
+				case "write_repository":
+					d.Set("scopes.write_repository", true)
+				case "write_registry":
+					d.Set("scopes.write_registry", true)
+				case "write_package_registry":
+					d.Set("scopes.write_package_registry", true)
 				}
 			}
 		}

--- a/gitlab/resource_gitlab_deploy_token_test.go
+++ b/gitlab/resource_gitlab_deploy_token_test.go
@@ -161,6 +161,10 @@ resource "gitlab_deploy_token" "foo" {
   scopes = [
 	"read_registry",
 	"read_repository",
+	"read_package_registry",
+	"write_repository",
+	"write_registry",
+	"write_package_registry",
   ]
 }
   `, rInt, rInt)


### PR DESCRIPTION
Resolves: https://github.com/gitlabhq/terraform-provider-gitlab/issues/704

Add all existing scopes to provider: https://docs.gitlab.com/ee/api/deploy_tokens.html#create-a-project-deploy-token