### PR TITLE
Add environment scope to gitlab_group_variable

### DIFF
--- a/docs/resources/group_variable.md
+++ b/docs/resources/group_variable.md
@@ -8,11 +8,12 @@ documentation](https://docs.gitlab.com/ce/ci/variables/README.html#variables).
 
 ```hcl
 resource "gitlab_group_variable" "example" {
-   group     = "12345"
-   key       = "group_variable_key"
-   value     = "group_variable_value"
-   protected = false
-   masked    = false
+   group             = "12345"
+   key               = "group_variable_key"
+   value             = "group_variable_value"
+   protected         = false
+   masked            = false
+   environment_scope = "*"
 }
 ```
 
@@ -32,10 +33,12 @@ The following arguments are supported:
 
 * `masked` - (Optional, boolean) If set to `true`, the value of the variable will be hidden in job logs. The value must meet the [masking requirements](https://docs.gitlab.com/ee/ci/variables/#masked-variables). Defaults to `false`.
 
+* `environment_scope` - (Optional, string) The environment scope of the variable. Defaults to all environment (`*`). Note that in Community Editions of Gitlab, values other than `*` will cause inconsistent plans. See https://docs.gitlab.com/ee/ci/variables/#add-a-cicd-variable-to-a-group
+
 ## Import
 
-GitLab group variables can be imported using an id made up of `groupid:variablename`, e.g.
+GitLab group variables can be imported using an id made up of `groupid:variablename:scope`, e.g.
 
 ```
-$ terraform import gitlab_group_variable.example 12345:group_variable_key
+$ terraform import gitlab_group_variable.example 12345:group_variable_key:*
 ```


### PR DESCRIPTION
Add support for `environment_scope` to group level variables

Fixes #610
Supersedes #611