### PR TITLE
No need to protect branch at creation, there is a resource to handle that

### DIFF
--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -41,6 +41,7 @@ The following arguments are supported:
 * `tags` - (Optional) Tags (topics) of the project.
 
 * `default_branch` - (Optional) The default branch for the project.
+Default branch is not protected at project creation, to do so manage default branch with [`gitlab_branch_protection`](branch_protection.html) resource.
 
 * `import_url` - (Optional) Git URL to a repository to be imported.
 

--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -501,14 +501,6 @@ func resourceGitlabProjectCreate(d *schema.ResourceData, meta interface{}) error
 			return fmt.Errorf("Failed to set default branch to %q for project %q: %w", newDefaultBranch, d.Id(), err)
 		}
 
-		log.Printf("[DEBUG] protect new default branch %q for project %q", newDefaultBranch, d.Id())
-		_, _, err = client.ProtectedBranches.ProtectRepositoryBranches(project.ID, &gitlab.ProtectRepositoryBranchesOptions{
-			Name: gitlab.String(newDefaultBranch),
-		})
-		if err != nil {
-			return fmt.Errorf("Failed to protect default branch %q for project %q: %w", newDefaultBranch, d.Id(), err)
-		}
-
 		log.Printf("[DEBUG] unprotect old default branch %q for project %q", oldDefaultBranch, d.Id())
 		_, err = client.ProtectedBranches.UnprotectRepositoryBranches(project.ID, oldDefaultBranch)
 		if err != nil {


### PR DESCRIPTION
Hello,

I encountered issues with project creation and default branch protection. Let me detail my case.

**Issue**
When a repository is created the default branch is protected "implicilty" by the provider, but we can not manage the protection with resource gitlab_branch_protection because it ends with an error saying the branch is already protected.
So we are unable to define resource gitlab_branch_protection on the default branch to ensure it will stay protected over time.
I guess the current behavior aims to copy the GUI one, but it could be annoying with the terraform usage.

**Commit**
This commit will remove the "implicit" branch protection in the provider

**New behavior**
At creation time default branch will not be protected
Ensure the default branch is protected in terraform definition by using gitlab_branch_protection resource

This commit will change current behavior of project creation and an explicit definition of gitlab_branch_protection will be necessary after that.
Do you think this commit and the new behavior are right ?

Regards,
