### PR TITLE
Check for protected branch before trying to delete protection

### DIFF
--- a/gitlab/resource_gitlab_project.go
+++ b/gitlab/resource_gitlab_project.go
@@ -524,10 +524,19 @@ func resourceGitlabProjectCreate(d *schema.ResourceData, meta interface{}) error
 			return fmt.Errorf("Failed to protect default branch %q for project %q: %w", newDefaultBranch, d.Id(), err)
 		}
 
-		log.Printf("[DEBUG] unprotect old default branch %q for project %q", oldDefaultBranch, d.Id())
-		_, err = client.ProtectedBranches.UnprotectRepositoryBranches(project.ID, oldDefaultBranch)
-		if err != nil {
-			return fmt.Errorf("Failed to unprotect undesired default branch %q for project %q: %w", oldDefaultBranch, d.Id(), err)
+		log.Printf("[DEBUG] check for protection on old default branch %q for project %q", oldDefaultBranch, d.Id())
+		branch, resp, err := client.ProtectedBranches.GetProtectedBranch(project.ID, oldDefaultBranch)
+		if err != nil && resp.StatusCode != http.StatusNotFound {
+			return fmt.Errorf("Failed to check for protected default branch %q for project %q: %w", oldDefaultBranch, d.Id(), err)
+		}
+		if branch == nil {
+			log.Printf("[DEBUG] Default protected branch %q for project %q does not exist", oldDefaultBranch, d.Id())
+		} else {
+			log.Printf("[DEBUG] unprotect old default branch %q for project %q", oldDefaultBranch, d.Id())
+			_, err = client.ProtectedBranches.UnprotectRepositoryBranches(project.ID, oldDefaultBranch)
+			if err != nil {
+				return fmt.Errorf("Failed to unprotect undesired default branch %q for project %q: %w", oldDefaultBranch, d.Id(), err)
+			}
 		}
 
 		log.Printf("[DEBUG] delete old default branch %q for project %q", oldDefaultBranch, d.Id())


### PR DESCRIPTION
In `resourceGitlabProjectCreate` if `default_branch` is set on the resource, the provider tries to delete branch protection on the old default branch even if it does not exist. If the branch isn't protected this returns a 404 and the provider fails.

This PR adds a check first so that if the old default branch is not protected, the provider can proceed to delete the old default branch, and the resource can be created.

fixes #759