### PR TITLE
Added missing scopes to deploy token

### DIFF
--- a/gitlab/resource_gitlab_deploy_token.go
+++ b/gitlab/resource_gitlab_deploy_token.go
@@ -61,7 +61,6 @@ func resourceGitlabDeployToken() *schema.Resource {
 							"read_registry",
 							"read_repository",
 							"read_package_registry",
-							"write_repository",
 							"write_registry",
 							"write_package_registry",
 						}, false),
@@ -184,8 +183,6 @@ func resourceGitlabDeployTokenRead(d *schema.ResourceData, meta interface{}) err
 					d.Set("scopes.read_registry", true)
 				case "read_package_registry":
 					d.Set("scopes.read_package_registry", true)
-				case "write_repository":
-					d.Set("scopes.write_repository", true)
 				case "write_registry":
 					d.Set("scopes.write_registry", true)
 				case "write_package_registry":

--- a/gitlab/resource_gitlab_deploy_token.go
+++ b/gitlab/resource_gitlab_deploy_token.go
@@ -55,8 +55,16 @@ func resourceGitlabDeployToken() *schema.Resource {
 				Required: true,
 				ForceNew: true,
 				Elem: &schema.Schema{
-					Type:         schema.TypeString,
-					ValidateFunc: validation.StringInSlice([]string{"read_registry", "read_repository"}, false),
+					Type: schema.TypeString,
+					ValidateFunc: validation.StringInSlice(
+						[]string{
+							"read_registry",
+							"read_repository",
+							"read_package_registry",
+							"write_repository",
+							"write_registry",
+							"write_package_registry",
+						}, false),
 				},
 			},
 
@@ -169,12 +177,19 @@ func resourceGitlabDeployTokenRead(d *schema.ResourceData, meta interface{}) err
 			}
 
 			for _, scope := range token.Scopes {
-				if scope == "read_repository" {
+				switch scope {
+				case "read_repository":
 					d.Set("scopes.read_repository", true)
-				}
-
-				if scope == "read_registry" {
+				case "read_registry":
 					d.Set("scopes.read_registry", true)
+				case "read_package_registry":
+					d.Set("scopes.read_package_registry", true)
+				case "write_repository":
+					d.Set("scopes.write_repository", true)
+				case "write_registry":
+					d.Set("scopes.write_registry", true)
+				case "write_package_registry":
+					d.Set("scopes.write_package_registry", true)
 				}
 			}
 		}

--- a/gitlab/resource_gitlab_deploy_token_test.go
+++ b/gitlab/resource_gitlab_deploy_token_test.go
@@ -162,7 +162,6 @@ resource "gitlab_deploy_token" "foo" {
 	"read_registry",
 	"read_repository",
 	"read_package_registry",
-	"write_repository",
 	"write_registry",
 	"write_package_registry",
   ]

--- a/gitlab/resource_gitlab_deploy_token_test.go
+++ b/gitlab/resource_gitlab_deploy_token_test.go
@@ -161,6 +161,10 @@ resource "gitlab_deploy_token" "foo" {
   scopes = [
 	"read_registry",
 	"read_repository",
+	"read_package_registry",
+	"write_repository",
+	"write_registry",
+	"write_package_registry",
   ]
 }
   `, rInt, rInt)


### PR DESCRIPTION
This Pull Request is the same as Allow to create deploy token with all possible scopes. #695 
The only difference is, that i removed write_repository, because it is not allowed