### PR TITLE
fix(group_ldap_link): add missing terraform import feature for group LDAP link

### DIFF
--- a/docs/resources/group_ldap_link.md
+++ b/docs/resources/group_ldap_link.md
@@ -37,4 +37,8 @@ resource "gitlab_group_ldap_link" "test" {
 - **group_access** (String) Minimum access level for members of the LDAP group. Valid values are: `no one`, `minimal`, `guest`, `reporter`, `developer`, `maintainer`, `owner`, `master`
 - **id** (String) The ID of this resource.
 
+GitLab group ldap links can be imported using an id made up of `group_id:ldap_provider:cn`, e.g.
 
+```shell
+terraform import gitlab_group_ldap_link.test "12345:ldapmain:testuser"
+```

--- a/docs/resources/group_ldap_link.md
+++ b/docs/resources/group_ldap_link.md
@@ -37,8 +37,11 @@ resource "gitlab_group_ldap_link" "test" {
 - **group_access** (String) Minimum access level for members of the LDAP group. Valid values are: `no one`, `minimal`, `guest`, `reporter`, `developer`, `maintainer`, `owner`, `master`
 - **id** (String) The ID of this resource.
 
-GitLab group ldap links can be imported using an id made up of `group_id:ldap_provider:cn`, e.g.
+## Import
+
+Import is supported using the following syntax:
 
 ```shell
+# GitLab group ldap links can be imported using an id made up of `group_id:ldap_provider:cn`, e.g.
 terraform import gitlab_group_ldap_link.test "12345:ldapmain:testuser"
 ```

--- a/examples/resources/gitlab_group_ldap_link/import.sh
+++ b/examples/resources/gitlab_group_ldap_link/import.sh
@@ -1,0 +1,2 @@
+# GitLab group ldap links can be imported using an id made up of `group_id:ldap_provider:cn`, e.g.
+terraform import gitlab_group_ldap_link.test "12345:ldapmain:testuser"

--- a/internal/provider/resource_gitlab_group_ldap_link.go
+++ b/internal/provider/resource_gitlab_group_ldap_link.go
@@ -21,7 +21,7 @@ var _ = registerResource("gitlab_group_ldap_link", func() *schema.Resource {
 		ReadContext:   resourceGitlabGroupLdapLinkRead,
 		DeleteContext: resourceGitlabGroupLdapLinkDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceGitlabGroupLdapLinkImporter,
+			StateContext: resourceGitlabGroupLdapLinkImporter,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -184,10 +184,10 @@ func resourceGitlabGroupLdapLinkDelete(ctx context.Context, d *schema.ResourceDa
 	return nil
 }
 
-func resourceGitlabGroupLdapLinkImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, diag.Diagnostics) {
+func resourceGitlabGroupLdapLinkImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	parts := strings.SplitN(d.Id(), ":", 3)
 	if len(parts) != 3 {
-		return nil, diag.FromErr(fmt.Errorf("invalid ldap link import id (should be <group id>:<ldap provider>:<ladp cn>): %s", d.Id()))
+		return nil, fmt.Errorf("invalid ldap link import id (should be <group id>:<ldap provider>:<ladp cn>): %s", d.Id())
 	}
 
 	groupId, ldapProvider, ldapCN := parts[0], parts[1], parts[2]
@@ -196,5 +196,8 @@ func resourceGitlabGroupLdapLinkImporter(ctx context.Context, d *schema.Resource
 	d.Set("force", false)
 
 	diag := resourceGitlabGroupLdapLinkRead(ctx, d, meta)
-	return []*schema.ResourceData{d}, diag
+	if diag.HasError() {
+		return nil, fmt.Errorf("%s", diag[0].Summary)
+	}
+	return []*schema.ResourceData{d}, nil
 }


### PR DESCRIPTION
**Why**

There is a bug that [the doc](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/group_ldap_link#import) says we can use `terraform import`, but actually the function is not implemented

**Code Changes**

* Added the missing import function and acceptance test case
* ~Fixed a bug to set `access_level` instead of `group_access`, because `access_level` is the one defined in schema~
   * ~Assigned the correct string value to `group_access`, before is an int type~, already fixed in the latest main branch
* Set `force=false` as default when importing, because we can not get any value from the Gitlab API
* Updated the doc about import part

**Design Changes**

* Added `group_id` in the import id string to change it from `ldap_provider:cn` to  `group_id:ldap_provider:cn`, because we need the `group_id` to identify the group

**Tests**

* built local provider, and tested
* added acceptance test

**Close**

* #448