### PR TITLE
Add printing_merge_request_link_enabled attribute to projects

### DIFF
--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -43,6 +43,7 @@ data "gitlab_project" "example" {
 - **namespace_id** (Number) The namespace (group or user) of the project. Defaults to your user.
 - **path** (String) The path of the repository.
 - **pipelines_enabled** (Boolean) Enable pipelines for the project.
+- **printing_merge_request_link_enabled** (Boolean) Show link to create/view merge request when pushing from the command line
 - **push_rules** (List of Object) Push rules for the project. (see [below for nested schema](#nestedatt--push_rules))
 - **remove_source_branch_after_merge** (Boolean) Enable `Delete source branch` option by default for all new merge requests
 - **request_access_enabled** (Boolean) Allow users to request member access.

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -73,6 +73,7 @@ resource "gitlab_project" "example-two" {
 - **pages_access_level** (String) Enable pages access control
 - **path** (String) The path of the repository.
 - **pipelines_enabled** (Boolean) Enable pipelines for the project.
+- **printing_merge_request_link_enabled** (Boolean) Show link to create/view merge request when pushing from the command line
 - **push_rules** (Block List, Max: 1) Push rules for the project. (see [below for nested schema](#nestedblock--push_rules))
 - **remove_source_branch_after_merge** (Boolean) Enable `Delete source branch` option by default for all new merge requests.
 - **request_access_enabled** (Boolean) Allow users to request member access.

--- a/examples/gitlab-managed-state/main.tf
+++ b/examples/gitlab-managed-state/main.tf
@@ -41,6 +41,7 @@ resource "gitlab_project" "api" {
   only_allow_merge_if_all_discussions_are_resolved = true
   only_allow_merge_if_pipeline_succeeds            = true
   remove_source_branch_after_merge                 = true
+  printing_merge_request_link_enabled              = true
 
   container_registry_enabled = false
   lfs_enabled                = false

--- a/internal/provider/data_source_gitlab_project.go
+++ b/internal/provider/data_source_gitlab_project.go
@@ -134,6 +134,11 @@ var _ = registerDataSource("gitlab_project", func() *schema.Resource {
 				Type:        schema.TypeBool,
 				Computed:    true,
 			},
+			"printing_merge_request_link_enabled": {
+				Description: "Show link to create/view merge request when pushing from the command line",
+				Type:        schema.TypeBool,
+				Computed:    true,
+			},
 			// lintignore: S031 // TODO: Resolve this tfproviderlint issue
 			"push_rules": {
 				Description: "Push rules for the project.",

--- a/internal/provider/resource_gitlab_project.go
+++ b/internal/provider/resource_gitlab_project.go
@@ -204,6 +204,12 @@ var resourceGitLabProjectSchema = map[string]*schema.Schema{
 		Type:        schema.TypeBool,
 		Optional:    true,
 	},
+	"printing_merge_request_link_enabled": {
+		Description: "Show link to create/view merge request when pushing from the command line",
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Default:     true,
+	},
 	"packages_enabled": {
 		Description: "Enable packages repository for the project.",
 		Type:        schema.TypeBool,
@@ -419,6 +425,7 @@ func resourceGitlabProjectSetToState(d *schema.ResourceData, project *gitlab.Pro
 	d.Set("archived", project.Archived)
 	d.Set("squash_option", project.SquashOption)
 	d.Set("remove_source_branch_after_merge", project.RemoveSourceBranchAfterMerge)
+	d.Set("printing_merge_request_link_enabled", project.PrintingMergeRequestLinkEnabled)
 	d.Set("packages_enabled", project.PackagesEnabled)
 	d.Set("pages_access_level", string(project.PagesAccessLevel))
 	d.Set("mirror", project.Mirror)
@@ -456,6 +463,7 @@ func resourceGitlabProjectCreate(ctx context.Context, d *schema.ResourceData, me
 		SquashOption:                              stringToSquashOptionValue(d.Get("squash_option").(string)),
 		RemoveSourceBranchAfterMerge:              gitlab.Bool(d.Get("remove_source_branch_after_merge").(bool)),
 		PackagesEnabled:                           gitlab.Bool(d.Get("packages_enabled").(bool)),
+		PrintingMergeRequestLinkEnabled:           gitlab.Bool(d.Get("printing_merge_request_link_enabled").(bool)),
 		Mirror:                                    gitlab.Bool(d.Get("mirror").(bool)),
 		MirrorTriggerBuilds:                       gitlab.Bool(d.Get("mirror_trigger_builds").(bool)),
 		BuildCoverageRegex:                        gitlab.String(d.Get("build_coverage_regex").(string)),
@@ -788,6 +796,10 @@ func resourceGitlabProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 
 	if d.HasChange("remove_source_branch_after_merge") {
 		options.RemoveSourceBranchAfterMerge = gitlab.Bool(d.Get("remove_source_branch_after_merge").(bool))
+	}
+
+	if d.HasChange("printing_merge_request_link_enabled") {
+		options.PrintingMergeRequestLinkEnabled = gitlab.Bool(d.Get("printing_merge_request_link_enabled").(bool))
 	}
 
 	if d.HasChange("packages_enabled") {

--- a/internal/provider/resource_gitlab_project_test.go
+++ b/internal/provider/resource_gitlab_project_test.go
@@ -44,16 +44,17 @@ func TestAccGitlabProject_basic(t *testing.T) {
 		MergeMethod:                      gitlab.FastForwardMerge,
 		OnlyAllowMergeIfPipelineSucceeds: true,
 		OnlyAllowMergeIfAllDiscussionsAreResolved: true,
-		SquashOption:                gitlab.SquashOptionDefaultOff,
-		AllowMergeOnSkippedPipeline: false,
-		Archived:                    false, // needless, but let's make this explicit
-		PackagesEnabled:             true,
-		PagesAccessLevel:            gitlab.PublicAccessControl,
-		BuildCoverageRegex:          "foo",
-		IssuesTemplate:              "",
-		MergeRequestsTemplate:       "",
-		CIConfigPath:                ".gitlab-ci.yml@mynamespace/myproject",
-		CIForwardDeploymentEnabled:  true,
+		SquashOption:                    gitlab.SquashOptionDefaultOff,
+		AllowMergeOnSkippedPipeline:     false,
+		Archived:                        false, // needless, but let's make this explicit
+		PackagesEnabled:                 true,
+		PrintingMergeRequestLinkEnabled: true,
+		PagesAccessLevel:                gitlab.PublicAccessControl,
+		BuildCoverageRegex:              "foo",
+		IssuesTemplate:                  "",
+		MergeRequestsTemplate:           "",
+		CIConfigPath:                    ".gitlab-ci.yml@mynamespace/myproject",
+		CIForwardDeploymentEnabled:      true,
 	}
 
 	defaultsMainBranch = defaults
@@ -91,6 +92,7 @@ func TestAccGitlabProject_basic(t *testing.T) {
 						SharedRunnersEnabled:             false,
 						Visibility:                       gitlab.PublicVisibility,
 						MergeMethod:                      gitlab.FastForwardMerge,
+						PrintingMergeRequestLinkEnabled:  true,
 						OnlyAllowMergeIfPipelineSucceeds: true,
 						OnlyAllowMergeIfAllDiscussionsAreResolved: true,
 						SquashOption:                gitlab.SquashOptionDefaultOn,
@@ -482,6 +484,7 @@ func TestAccGitlabProject_willError(t *testing.T) {
 		SharedRunnersEnabled:             true,
 		Visibility:                       gitlab.PublicVisibility,
 		MergeMethod:                      gitlab.FastForwardMerge,
+		PrintingMergeRequestLinkEnabled:  true,
 		OnlyAllowMergeIfPipelineSucceeds: true,
 		OnlyAllowMergeIfAllDiscussionsAreResolved: true,
 		SquashOption:               gitlab.SquashOptionDefaultOff,
@@ -589,11 +592,12 @@ func TestAccGitlabProject_transfer(t *testing.T) {
 		MergeMethod:                      gitlab.NoFastForwardMerge,
 		OnlyAllowMergeIfPipelineSucceeds: false,
 		OnlyAllowMergeIfAllDiscussionsAreResolved: false,
-		SquashOption:               gitlab.SquashOptionDefaultOff,
-		PackagesEnabled:            true,
-		PagesAccessLevel:           gitlab.PrivateAccessControl,
-		BuildCoverageRegex:         "foo",
-		CIForwardDeploymentEnabled: true,
+		SquashOption:                    gitlab.SquashOptionDefaultOff,
+		PackagesEnabled:                 true,
+		PrintingMergeRequestLinkEnabled: true,
+		PagesAccessLevel:                gitlab.PrivateAccessControl,
+		BuildCoverageRegex:              "foo",
+		CIForwardDeploymentEnabled:      true,
 	}
 
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
As mentioned on #782, the field is available on GitLab but still not
possible to use on terraform

Reference:
- https://github.com/gitlabhq/terraform-provider-gitlab/issues/782