### PR TITLE
Support `early_auth_check` flag in provider config. Closes #777

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -74,3 +74,8 @@ The following arguments are supported in the `provider` block:
 * `client_cert` - (Optional) File path to client certificate when GitLab instance is behind company proxy. File  must contain PEM encoded data.
 
 * `client_key` - (Optional) File path to client key when GitLab instance is behind company proxy. File must contain PEM encoded data. Required when `client_cert` is set.
+
+* `early_auth_check` - (Optional) (experimental) By default the provider does a dummy request to get the current user in order
+  to verify that the provider configuration is correct and the GitLab API is reachable.
+  Turn it off, to skip this check. This may be useful if the GitLab instance does not yet exist and is created within the same terraform module.
+  This is an experimental feature and may change in the future. Please make sure to always keep backups of your state.

--- a/gitlab/config.go
+++ b/gitlab/config.go
@@ -12,12 +12,13 @@ import (
 
 // Config is per-provider, specifies where to connect to gitlab
 type Config struct {
-	Token      string
-	BaseURL    string
-	Insecure   bool
-	CACertFile string
-	ClientCert string
-	ClientKey  string
+	Token         string
+	BaseURL       string
+	Insecure      bool
+	CACertFile    string
+	ClientCert    string
+	ClientKey     string
+	EarlyAuthFail bool
 }
 
 // Client returns a *gitlab.Client to interact with the configured gitlab instance
@@ -75,7 +76,9 @@ func (c *Config) Client() (*gitlab.Client, error) {
 	}
 
 	// Test the credentials by checking we can get information about the authenticated user.
-	_, _, err = client.Users.CurrentUser()
+	if c.EarlyAuthFail {
+		_, _, err = client.Users.CurrentUser()
+	}
 
 	return client, err
 }

--- a/gitlab/provider.go
+++ b/gitlab/provider.go
@@ -49,6 +49,12 @@ func Provider() *schema.Provider {
 				Default:     "",
 				Description: descriptions["client_key"],
 			},
+			"early_auth_check": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: descriptions["early_auth_check"],
+			},
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
@@ -124,17 +130,20 @@ func init() {
 		"client_cert": "File path to client certificate when GitLab instance is behind company proxy. File  must contain PEM encoded data.",
 
 		"client_key": "File path to client key when GitLab instance is behind company proxy. File must contain PEM encoded data.",
+
+		"early_auth_check": "Try to authenticate with the `CurrentUser` endpoint during the provider initialization. (experimental, see docs)",
 	}
 }
 
 func providerConfigure(ctx context.Context, p *schema.Provider, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 	config := Config{
-		Token:      d.Get("token").(string),
-		BaseURL:    d.Get("base_url").(string),
-		CACertFile: d.Get("cacert_file").(string),
-		Insecure:   d.Get("insecure").(bool),
-		ClientCert: d.Get("client_cert").(string),
-		ClientKey:  d.Get("client_key").(string),
+		Token:         d.Get("token").(string),
+		BaseURL:       d.Get("base_url").(string),
+		CACertFile:    d.Get("cacert_file").(string),
+		Insecure:      d.Get("insecure").(bool),
+		ClientCert:    d.Get("client_cert").(string),
+		ClientKey:     d.Get("client_key").(string),
+		EarlyAuthFail: d.Get("early_auth_check").(bool),
 	}
 
 	client, err := config.Client()


### PR DESCRIPTION
This change adds a new `early_auth_check` flag to the provider configuration.
It defaults to `true` which causes the provider to perform a dummy request to the GitLab API to verify the
configuration. If that is not desired it can be set to `false` which avoids this call.
This can be in useful if the GitLab instance is created within the same terraform module as this provider
is being used.