### PR TITLE
Use context-aware CRUD functions and use it in gitlab API calls

### DIFF
--- a/gitlab/resource_gitlab_deploy_key_enable.go
+++ b/gitlab/resource_gitlab_deploy_key_enable.go
@@ -1,22 +1,24 @@
 package gitlab
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"strconv"
 	"strings"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	gitlab "github.com/xanzy/go-gitlab"
 )
 
 func resourceGitlabDeployEnableKey() *schema.Resource {
 	return &schema.Resource{
-		Create: resourceGitlabDeployKeyEnableCreate,
-		Read:   resourceGitlabDeployKeyEnableRead,
-		Delete: resourceGitlabDeployKeyEnableDelete,
+		CreateContext: resourceGitlabDeployKeyEnableCreate,
+		ReadContext:   resourceGitlabDeployKeyEnableRead,
+		DeleteContext: resourceGitlabDeployKeyEnableDelete,
 		Importer: &schema.ResourceImporter{
-			State: resourceGitlabDeployKeyEnableStateImporter,
+			StateContext: resourceGitlabDeployKeyEnableStateImporter,
 		},
 
 		Schema: map[string]*schema.Schema{
@@ -49,40 +51,40 @@ func resourceGitlabDeployEnableKey() *schema.Resource {
 	}
 }
 
-func resourceGitlabDeployKeyEnableCreate(d *schema.ResourceData, meta interface{}) error {
+func resourceGitlabDeployKeyEnableCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gitlab.Client)
 	project := d.Get("project").(string)
 	key_id, err := strconv.Atoi(d.Get("key_id").(string)) // nolint // TODO: Resolve this golangci-lint issue: ineffectual assignment to err (ineffassign)
 
 	log.Printf("[DEBUG] enable gitlab deploy key %s/%d", project, key_id)
 
-	deployKey, _, err := client.DeployKeys.EnableDeployKey(project, key_id)
+	deployKey, _, err := client.DeployKeys.EnableDeployKey(project, key_id, gitlab.WithContext(ctx))
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.SetId(fmt.Sprintf("%s:%d", project, deployKey.ID))
 
-	return resourceGitlabDeployKeyEnableRead(d, meta)
+	return resourceGitlabDeployKeyEnableRead(ctx, d, meta)
 }
 
-func resourceGitlabDeployKeyEnableRead(d *schema.ResourceData, meta interface{}) error {
+func resourceGitlabDeployKeyEnableRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gitlab.Client)
 	project := d.Get("project").(string)
 	deployKeyID, err := strconv.Atoi(d.Get("key_id").(string))
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	log.Printf("[DEBUG] read gitlab deploy key %s/%d", project, deployKeyID)
 
-	deployKey, _, err := client.DeployKeys.GetDeployKey(project, deployKeyID)
+	deployKey, _, err := client.DeployKeys.GetDeployKey(project, deployKeyID, gitlab.WithContext(ctx))
 	if err != nil {
 		if is404(err) {
 			log.Printf("[DEBUG] gitlab deploy key not found %s/%d", project, deployKeyID)
 			d.SetId("")
 			return nil
 		}
-		return err
+		return diag.FromErr(err)
 	}
 
 	d.Set("title", deployKey.Title)
@@ -93,25 +95,30 @@ func resourceGitlabDeployKeyEnableRead(d *schema.ResourceData, meta interface{})
 	return nil
 }
 
-func resourceGitlabDeployKeyEnableDelete(d *schema.ResourceData, meta interface{}) error {
+func resourceGitlabDeployKeyEnableDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gitlab.Client)
 	project := d.Get("project").(string)
 	deployKeyID, err := strconv.Atoi(d.Get("key_id").(string))
 	if err != nil {
-		return err
+		return diag.FromErr(err)
 	}
 	log.Printf("[DEBUG] Delete gitlab deploy key %s/%d", project, deployKeyID)
 
-	response, err := client.DeployKeys.DeleteDeployKey(project, deployKeyID)
+	response, err := client.DeployKeys.DeleteDeployKey(project, deployKeyID, gitlab.WithContext(ctx))
+
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
 	// HTTP 2XX is success including 204 with no body
 	if response != nil && response.StatusCode/100 == 2 {
 		return nil
 	}
-	return err
+
+	return nil
 }
 
-func resourceGitlabDeployKeyEnableStateImporter(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+func resourceGitlabDeployKeyEnableStateImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
 	s := strings.Split(d.Id(), ":")
 	if len(s) != 2 {
 		d.SetId("")

--- a/gitlab/resource_gitlab_project_level_mr_approvals.go
+++ b/gitlab/resource_gitlab_project_level_mr_approvals.go
@@ -84,7 +84,7 @@ func resourceGitlabProjectLevelMRApprovalsRead(ctx context.Context, d *schema.Re
 			d.SetId("")
 			return nil
 		}
-		return diag.Errorf("couldn't read approval configuration: %w", err)
+		return diag.Errorf("couldn't read approval configuration: %v", err)
 	}
 
 	d.Set("project_id", projectId)

--- a/gitlab/resource_gitlab_project_variable_test.go
+++ b/gitlab/resource_gitlab_project_variable_test.go
@@ -1,6 +1,7 @@
 package gitlab
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -66,7 +67,7 @@ func testAccCheckGitlabProjectVariableExists(client *gitlab.Client, name string)
 		func(state *terraform.State) error {
 			attributes := state.RootModule().Resources[name].Primary.Attributes
 
-			got, err := getProjectVariable(client, attributes["project"], attributes["key"], attributes["environment_scope"])
+			got, err := getProjectVariable(context.Background(), client, attributes["project"], attributes["key"], attributes["environment_scope"])
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This is a follow up of #725 which uses the context-aware CRUD functions for resources and data sources.
It also uses this contexts for the GitLab API calls.

See https://www.terraform.io/plugin/sdkv2/guides/v2-upgrade-guide#more-support-for-context-context

I've created separate commits for each resource / data source for better traceability of such a massive change set.