### PR TITLE
Test refactor - testAccGitlabProjectContext and resource_gitlab_project_mirror_test.go

### DIFF
--- a/gitlab/resource_gitlab_project_variable_test.go
+++ b/gitlab/resource_gitlab_project_variable_test.go
@@ -6,50 +6,10 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/xanzy/go-gitlab"
 )
-
-// testAccGitlabProjectContext encapsulates a GitLab client and test project to be used during an
-// acceptance test.
-type testAccGitlabProjectContext struct {
-	t       *testing.T
-	client  *gitlab.Client
-	project *gitlab.Project
-}
-
-// finish deletes the test project. Call this when the test is finished, usually in a defer.
-func (c testAccGitlabProjectContext) finish() {
-	if _, err := c.client.Projects.DeleteProject(c.project.ID); err != nil {
-		c.t.Fatalf("could not delete test project: %v", err)
-	}
-}
-
-// testAccGitlabProjectStart initializes the GitLab client and creates a test project. Remember to
-// call testAccGitlabProjectContext.finish() when finished with the testAccGitlabProjectContext.
-func testAccGitlabProjectStart(t *testing.T) testAccGitlabProjectContext {
-	testAccCheck(t)
-
-	client := testAccNewClient(t)
-
-	project, _, err := client.Projects.CreateProject(&gitlab.CreateProjectOptions{
-		Name:        gitlab.String(acctest.RandomWithPrefix("acctest")),
-		Description: gitlab.String("Terraform acceptance tests"),
-		// So that acceptance tests can be run in a gitlab organization with no billing
-		Visibility: gitlab.Visibility(gitlab.PublicVisibility),
-	})
-	if err != nil {
-		t.Fatalf("could not create test project: %v", err)
-	}
-
-	return testAccGitlabProjectContext{
-		t:       t,
-		client:  client,
-		project: project,
-	}
-}
 
 func testAccCheckGitlabProjectVariableExists(client *gitlab.Client, name string) resource.TestCheckFunc {
 	var (
@@ -110,7 +70,6 @@ func testAccGitlabProjectVariableCheckAllVariablesDestroyed(ctx testAccGitlabPro
 
 func TestAccGitlabProjectVariable_basic(t *testing.T) {
 	ctx := testAccGitlabProjectStart(t)
-	defer ctx.finish()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -213,7 +172,6 @@ EOF
 
 func TestAccGitlabProjectVariable_scoped(t *testing.T) {
 	ctx := testAccGitlabProjectStart(t)
-	defer ctx.finish()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },


### PR DESCRIPTION
Supersedes #538 (Cherry picked just the test refactor)

Relates to #205 (fixed for gitlab_project_mirror resource)
Relates to #434 (fixed for gitlab_project_mirror resource)

Move testAccGitlabProjectContext to helper_test.go and use it in resource_gitlab_project_mirror_test.go

This is a step toward having correct "destroy" tests for the provider.