### PR TITLE
Add require_password_to_approve option for MRs

### DIFF
--- a/docs/resources/project_level_mr_approvals.md
+++ b/docs/resources/project_level_mr_approvals.md
@@ -26,7 +26,6 @@ resource "gitlab_project_level_mr_approvals" "foo" {
   disable_overriding_approvers_per_merge_request = false
   merge_requests_author_approval                 = false
   merge_requests_disable_committers_approval     = true
-  require_password_to_approve                    = true
 }
 ```
 
@@ -42,10 +41,9 @@ resource "gitlab_project_level_mr_approvals" "foo" {
 - **disable_overriding_approvers_per_merge_request** (Boolean) By default, users are able to edit the approval rules in merge requests. If set to true,
 - **id** (String) The ID of this resource.
 - **merge_requests_author_approval** (Boolean) Set to `true` if you want to allow merge request authors to self-approve merge requests. Authors
-- **merge_requests_disable_committers_approval** (Boolean) Set to `true` if you want to prevent approval of merge requests by merge request committers. Default is `false`.
+- **merge_requests_disable_committers_approval** (Boolean) Set to `true` if you want to prevent approval of merge requests by merge request committers.
+- **require_password_to_approve** (Boolean) Set to `true` if you want to require authentication when approving a merge request.
 - **reset_approvals_on_push** (Boolean) Set to `true` if you want to remove all approvals in a merge request when new commits are pushed to its source branch. Default is `true`.
-
-* `require_password_to_approve` - (Optional) Set to `true` if you want to require authentification when approving a merge request. Default is `false`.
 
 ## Import
 

--- a/docs/resources/project_level_mr_approvals.md
+++ b/docs/resources/project_level_mr_approvals.md
@@ -26,6 +26,7 @@ resource "gitlab_project_level_mr_approvals" "foo" {
   disable_overriding_approvers_per_merge_request = false
   merge_requests_author_approval                 = false
   merge_requests_disable_committers_approval     = true
+  require_password_to_approve                    = true
 }
 ```
 
@@ -43,6 +44,8 @@ resource "gitlab_project_level_mr_approvals" "foo" {
 - **merge_requests_author_approval** (Boolean) Set to `true` if you want to allow merge request authors to self-approve merge requests. Authors
 - **merge_requests_disable_committers_approval** (Boolean) Set to `true` if you want to prevent approval of merge requests by merge request committers. Default is `false`.
 - **reset_approvals_on_push** (Boolean) Set to `true` if you want to remove all approvals in a merge request when new commits are pushed to its source branch. Default is `true`.
+
+* `require_password_to_approve` - (Optional) Set to `true` if you want to require authentification when approving a merge request. Default is `false`.
 
 ## Import
 

--- a/internal/provider/resource_gitlab_project_level_mr_approvals.go
+++ b/internal/provider/resource_gitlab_project_level_mr_approvals.go
@@ -49,6 +49,10 @@ var _ = registerResource("gitlab_project_level_mr_approvals", func() *schema.Res
 				Type:        schema.TypeBool,
 				Optional:    true,
 			},
+			"require_password_to_approve": {
+				Type:     schema.TypeBool,
+				Optional: true,
+			},
 		},
 	}
 })
@@ -63,6 +67,7 @@ func resourceGitlabProjectLevelMRApprovalsCreate(ctx context.Context, d *schema.
 		DisableOverridingApproversPerMergeRequest: gitlab.Bool(d.Get("disable_overriding_approvers_per_merge_request").(bool)),
 		MergeRequestsAuthorApproval:               gitlab.Bool(d.Get("merge_requests_author_approval").(bool)),
 		MergeRequestsDisableCommittersApproval:    gitlab.Bool(d.Get("merge_requests_disable_committers_approval").(bool)),
+		RequirePasswordToApprove:                  gitlab.Bool(d.Get("require_password_to_approve").(bool)),
 	}
 
 	log.Printf("[DEBUG] Creating new MR approval configuration for project %d:", projectId)
@@ -100,6 +105,7 @@ func resourceGitlabProjectLevelMRApprovalsRead(ctx context.Context, d *schema.Re
 	d.Set("disable_overriding_approvers_per_merge_request", approvalConfig.DisableOverridingApproversPerMergeRequest)
 	d.Set("merge_requests_author_approval", approvalConfig.MergeRequestsAuthorApproval)
 	d.Set("merge_requests_disable_committers_approval", approvalConfig.MergeRequestsDisableCommittersApproval)
+	d.Set("require_password_to_approve", approvalConfig.RequirePasswordToApprove)
 
 	return nil
 }
@@ -123,6 +129,9 @@ func resourceGitlabProjectLevelMRApprovalsUpdate(ctx context.Context, d *schema.
 	if d.HasChange("merge_requests_disable_committers_approval") {
 		options.MergeRequestsDisableCommittersApproval = gitlab.Bool(d.Get("merge_requests_disable_committers_approval").(bool))
 	}
+	if d.HasChange("require_password_to_approve") {
+		options.RequirePasswordToApprove = gitlab.Bool(d.Get("require_password_to_approve").(bool))
+	}
 
 	if _, _, err := client.Projects.ChangeApprovalConfiguration(d.Id(), options, gitlab.WithContext(ctx)); err != nil {
 		return diag.Errorf("couldn't update approval configuration: %v", err)
@@ -140,6 +149,7 @@ func resourceGitlabProjectLevelMRApprovalsDelete(ctx context.Context, d *schema.
 		DisableOverridingApproversPerMergeRequest: gitlab.Bool(false),
 		MergeRequestsAuthorApproval:               gitlab.Bool(false),
 		MergeRequestsDisableCommittersApproval:    gitlab.Bool(false),
+		RequirePasswordToApprove:                  gitlab.Bool(false),
 	}
 
 	log.Printf("[DEBUG] Resetting approval configuration for project %s:", projectId)

--- a/internal/provider/resource_gitlab_project_level_mr_approvals.go
+++ b/internal/provider/resource_gitlab_project_level_mr_approvals.go
@@ -45,13 +45,14 @@ var _ = registerResource("gitlab_project_level_mr_approvals", func() *schema.Res
 				Optional:    true,
 			},
 			"merge_requests_disable_committers_approval": {
-				Description: "Set to `true` if you want to prevent approval of merge requests by merge request committers. Default is `false`.",
+				Description: "Set to `true` if you want to prevent approval of merge requests by merge request committers.",
 				Type:        schema.TypeBool,
 				Optional:    true,
 			},
 			"require_password_to_approve": {
-				Type:     schema.TypeBool,
-				Optional: true,
+				Description: "Set to `true` if you want to require authentication when approving a merge request.",
+				Type:        schema.TypeBool,
+				Optional:    true,
 			},
 		},
 	}

--- a/internal/provider/resource_gitlab_project_level_mr_approvals_test.go
+++ b/internal/provider/resource_gitlab_project_level_mr_approvals_test.go
@@ -30,6 +30,7 @@ func TestAccGitlabProjectLevelMRApprovals_basic(t *testing.T) {
 						disableOverridingApproversPerMergeRequest: true,
 						mergeRequestsAuthorApproval:               true,
 						mergeRequestsDisableCommittersApproval:    true,
+						requirePasswordToApprove:                  true,
 					}),
 				),
 			},
@@ -43,6 +44,7 @@ func TestAccGitlabProjectLevelMRApprovals_basic(t *testing.T) {
 						disableOverridingApproversPerMergeRequest: false,
 						mergeRequestsAuthorApproval:               false,
 						mergeRequestsDisableCommittersApproval:    false,
+						requirePasswordToApprove:                  false,
 					}),
 				),
 			},
@@ -56,6 +58,7 @@ func TestAccGitlabProjectLevelMRApprovals_basic(t *testing.T) {
 						disableOverridingApproversPerMergeRequest: true,
 						mergeRequestsAuthorApproval:               true,
 						mergeRequestsDisableCommittersApproval:    true,
+						requirePasswordToApprove:                  true,
 					}),
 				),
 			},
@@ -92,6 +95,7 @@ type testAccGitlabProjectLevelMRApprovalsExpectedAttributes struct {
 	disableOverridingApproversPerMergeRequest bool
 	mergeRequestsAuthorApproval               bool
 	mergeRequestsDisableCommittersApproval    bool
+	requirePasswordToApprove                  bool
 }
 
 func testAccCheckGitlabProjectLevelMRApprovalsAttributes(projectApprovals *gitlab.ProjectApprovals, want *testAccGitlabProjectLevelMRApprovalsExpectedAttributes) resource.TestCheckFunc {
@@ -107,6 +111,9 @@ func testAccCheckGitlabProjectLevelMRApprovalsAttributes(projectApprovals *gitla
 		}
 		if projectApprovals.MergeRequestsDisableCommittersApproval != want.mergeRequestsDisableCommittersApproval {
 			return fmt.Errorf("got merge_requests_disable_committers_approval %t; want %t", projectApprovals.MergeRequestsDisableCommittersApproval, want.mergeRequestsDisableCommittersApproval)
+		}
+		if projectApprovals.RequirePasswordToApprove != want.requirePasswordToApprove {
+			return fmt.Errorf("got require_password_to_approve %t; want %t", projectApprovals.RequirePasswordToApprove, want.requirePasswordToApprove)
 		}
 		return nil
 	}
@@ -170,6 +177,7 @@ resource "gitlab_project_level_mr_approvals" "foo" {
 	disable_overriding_approvers_per_merge_request = true
 	merge_requests_author_approval                 = true
 	merge_requests_disable_committers_approval     = true
+	require_password_to_approve                    = true
 }
 	`, rInt)
 }
@@ -188,6 +196,7 @@ resource "gitlab_project_level_mr_approvals" "foo" {
 	disable_overriding_approvers_per_merge_request = false
 	merge_requests_author_approval                 = false
 	merge_requests_disable_committers_approval     = false
+	require_password_to_approve                    = false
 }
 	`, rInt)
 }


### PR DESCRIPTION
## Description

Adds `require_password_to_approve` argument to `gitlab_project_level_mr_approvals` resource.

Follow-up for xanzy/go-gitlab#1116

## PR Checklist

<!-- For a smooth review process, please run through this checklist before submitting a PR. -->

- [x] Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
- [x] Docs are updated with any new resources or attributes, including how to import the resource.
- [x] New resources should have at minimum a basic test with three steps: N/A
    - Create the resource
    - Update the attributes
    - Import the resource
- [x] No new `//lintignore` comments that came from copied code. Linter rules are meant to be enforced on new code.