### PR TITLE
Workflow: Read Go version from .go-version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,22 @@ on:
     tags:
       - 'v*'
 jobs:
+  go-version:
+    runs-on: ubuntu-latest
+    outputs:
+      go-version: ${{ steps.go-version.outputs.go-version }}
+    steps:
+      - uses: actions/checkout@v2
+      - id: go-version
+        run: echo "::set-output name=go-version::$(cat .go-version)"
+
   goreleaser:
     runs-on: ubuntu-latest
+    needs: [go-version]
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: ${{ needs.go-version.outputs.go-version }}
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,8 +2,18 @@ name: test
 on: [push,pull_request]
 
 jobs:
+  go-version:
+    runs-on: ubuntu-latest
+    outputs:
+      go-version: ${{ steps.go-version.outputs.go-version }}
+    steps:
+      - uses: actions/checkout@v2
+      - id: go-version
+        run: echo "::set-output name=go-version::$(cat .go-version)"
+
   lint:
     runs-on: ubuntu-latest
+    needs: [go-version]
     strategy:
       fail-fast: false
       matrix:
@@ -15,7 +25,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: ${{ needs.go-version.outputs.go-version }}
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
         with:
@@ -27,15 +37,15 @@ jobs:
 
   unit-test:
     runs-on: ${{ matrix.os }}
+    needs: [go-version]
     strategy:
       fail-fast: false
       matrix:
-        go: [1.16]
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: ${{ matrix.go }}
+          go-version: ${{ needs.go-version.outputs.go-version }}
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
         with:
@@ -45,10 +55,11 @@ jobs:
 
   generate-check:
     runs-on: ubuntu-latest
+    needs: [go-version]
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: ${{ needs.go-version.outputs.go-version }}
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
         with:
@@ -64,10 +75,11 @@ jobs:
   acceptance-ce:
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    needs: [go-version]
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: ${{ needs.go-version.outputs.go-version }}
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
         with:
@@ -79,11 +91,12 @@ jobs:
   acceptance-ee:
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    needs: [go-version]
     if: github.event_name == 'push' && github.repository_owner == 'gitlabhq'
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: ${{ needs.go-version.outputs.go-version }}
       - uses: actions/checkout@v2
       - uses: actions/cache@v2
         with:


### PR DESCRIPTION
## Description

<!-- Which issue/s does this PR close? Is there any more context you can give the reviewer? -->

I had to find out what our .go-version file is for, since it isn't referenced anywhere. 😆

I assume it comes from Terraform, and [in their CI workflow](https://github.com/hashicorp/terraform/blob/main/.github/workflows/build.yml) they use it to set the Go version to build with. This PR aligns with that strategy.

## PR Checklist

<!-- For a smooth review process, please run through this checklist before submitting a PR. -->

- [x] Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
- [x] [Examples](/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
- [x] New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
- [x] No new `//lintignore` comments that came from copied code. Linter rules are meant to be enforced on new code.
