### PR TITLE
Implement `archive_on_destroy` attribute for projects. Closes #761

### DIFF
--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -44,6 +44,7 @@ resource "gitlab_project" "example-two" {
 
 - **allow_merge_on_skipped_pipeline** (Boolean) Set to true if you want to treat skipped pipelines as if they finished with success.
 - **approvals_before_merge** (Number) Number of merge request approvals required for merging. Default is 0.
+- **archive_on_destroy** (Boolean) Set to `true` to archive the project instead of deleting on destroy. If set to `true` it will entire omit the `DELETE` operation.
 - **archived** (Boolean) Whether the project is in read-only mode (archived). Repositories can be archived/unarchived by toggling this parameter.
 - **build_coverage_regex** (String) Test coverage parsing for the project.
 - **ci_config_path** (String) Custom Path to CI config file.

--- a/gitlab/resource_gitlab_project_test.go
+++ b/gitlab/resource_gitlab_project_test.go
@@ -1210,6 +1210,10 @@ resource "gitlab_project" "foo" {
   path = "foo.%d"
   description = "Terraform acceptance tests"
   initialize_with_readme = true
+
+  # So that acceptance tests can be run in a gitlab organization
+  # with no billing
+  visibility_level = "public"
 }
 	`, rInt, rInt)
 }
@@ -1221,6 +1225,10 @@ resource "gitlab_project" "foo" {
   path = "foo.%d"
   description = "Terraform acceptance tests"
   initialize_with_readme = false
+
+  # So that acceptance tests can be run in a gitlab organization
+  # with no billing
+  visibility_level = "public"
 }
 	`, rInt, rInt)
 }
@@ -1318,6 +1326,10 @@ resource "gitlab_project" "template-name" {
   description = "Terraform acceptance tests"
   template_name = "rails"
   default_branch = "master"
+
+  # So that acceptance tests can be run in a gitlab organization
+  # with no billing
+  visibility_level = "public"
 }
 	`, rInt, rInt)
 }
@@ -1337,6 +1349,10 @@ resource "gitlab_project" "template-name-custom" {
   template_name = "myrails"
   use_custom_template = true
   default_branch = "master"
+
+  # So that acceptance tests can be run in a gitlab organization
+  # with no billing
+  visibility_level = "public"
 }
 	`, rInt, rInt)
 }
@@ -1350,6 +1366,10 @@ resource "gitlab_project" "template-id" {
   template_project_id = 999
   use_custom_template = true
   default_branch = "master"
+
+  # So that acceptance tests can be run in a gitlab organization
+  # with no billing
+  visibility_level = "public"
 }
 	`, rInt, rInt)
 }
@@ -1364,6 +1384,10 @@ resource "gitlab_project" "template-mutual-exclusive" {
   template_project_id = 999
   use_custom_template = true
   default_branch = "master"
+
+  # So that acceptance tests can be run in a gitlab organization
+  # with no billing
+  visibility_level = "public"
 }
 	`, rInt, rInt)
 }
@@ -1376,6 +1400,10 @@ resource "gitlab_project" "foo" {
   description = "Terraform acceptance tests"
   issues_template = "foo"
   merge_requests_template = "bar"
+
+  # So that acceptance tests can be run in a gitlab organization
+  # with no billing
+  visibility_level = "public"
 }
 	`, rInt, rInt)
 }
@@ -1388,6 +1416,10 @@ resource "gitlab_project" "foo" {
   description = "Terraform acceptance tests"
   archive_on_destroy = true
   archived = false
+
+  # So that acceptance tests can be run in a gitlab organization
+  # with no billing
+  visibility_level = "public"
 }
 	`, rInt, rInt)
 }


### PR DESCRIPTION
This change implements an `archive_on_destroy` attribute on the
`gitlab_project` resource. It defaults to `false`, if set to `true`, on
a destroy it will *archive* the project instead of deleting it.

This is especially useful in organizations where repositories need to
be kept for regulatory purposes and can't be deleted.

PS: the diff is a mess: I've basically just `if'ed` the `DeleteProject` case depending on the `archive_on_destroy` attribute and called `ArchiveProject` in the new branch :)