### PR TITLE
Aligns the *Access Level* situation in this providers with the upstream API. Closes #794

### DIFF
--- a/docs/resources/branch_protection.md
+++ b/docs/resources/branch_protection.md
@@ -58,9 +58,9 @@ resource "gitlab_branch_protection" "main" {
 ### Required
 
 - **branch** (String) Name of the branch.
-- **merge_access_level** (String) Access levels allowed to merge. Valid values are: `no one`, `developer`, `maintainer`, `admin`.
+- **merge_access_level** (String) Access levels allowed to merge. Valid values are: `no one`, `developer`, `maintainer`.
 - **project** (String) The id of the project.
-- **push_access_level** (String) Access levels allowed to push. Valid values are: `no one`, `developer`, `maintainer`, `admin`.
+- **push_access_level** (String) Access levels allowed to push. Valid values are: `no one`, `developer`, `maintainer`.
 
 ### Optional
 

--- a/docs/resources/group_ldap_link.md
+++ b/docs/resources/group_ldap_link.md
@@ -16,7 +16,7 @@ This resource allows you to add an LDAP link to an existing GitLab group.
 resource "gitlab_group_ldap_link" "test" {
   group_id      = "12345"
   cn            = "testuser"
-  access_level  = "developer"
+  group_access  = "developer"
   ldap_provider = "ldapmain"
 }
 ```
@@ -26,14 +26,15 @@ resource "gitlab_group_ldap_link" "test" {
 
 ### Required
 
-- **access_level** (String) Acceptable values are: guest, minimal, reporter, developer, maintainer, owner.
 - **cn** (String) The CN of the LDAP group to link with.
 - **group_id** (String) The id of the GitLab group.
 - **ldap_provider** (String) The name of the LDAP provider as stored in the GitLab database.
 
 ### Optional
 
+- **access_level** (String, Deprecated) Minimum access level for members of the LDAP group. Valid values are: `no one`, `minimal`, `guest`, `reporter`, `developer`, `maintainer`, `owner`, `master`
 - **force** (Boolean) If true, then delete and replace an existing LDAP link if one exists.
+- **group_access** (String) Minimum access level for members of the LDAP group. Valid values are: `no one`, `minimal`, `guest`, `reporter`, `developer`, `maintainer`, `owner`, `master`
 - **id** (String) The ID of this resource.
 
 ## Import

--- a/docs/resources/group_membership.md
+++ b/docs/resources/group_membership.md
@@ -26,7 +26,7 @@ resource "gitlab_group_membership" "test" {
 
 ### Required
 
-- **access_level** (String) Acceptable values are: guest, minimal, reporter, developer, maintainer, owner.
+- **access_level** (String) Access level for the member. Valid values are: `no one`, `minimal`, `guest`, `reporter`, `developer`, `maintainer`, `owner`, `master`.
 - **group_id** (String) The id of the group.
 - **user_id** (Number) The id of the user.
 

--- a/docs/resources/group_share_group.md
+++ b/docs/resources/group_share_group.md
@@ -26,7 +26,7 @@ resource "gitlab_group_share_group" "test" {
 
 ### Required
 
-- **group_access** (String) One of five levels of access to the group.
+- **group_access** (String) The access level to grant the group. Valid values are: `no one`, `minimal`, `guest`, `reporter`, `developer`, `maintainer`, `owner`, `master`
 - **group_id** (String) The id of the main group.
 - **share_group_id** (Number) The id of an additional group which will be shared with the main group.
 

--- a/docs/resources/project_membership.md
+++ b/docs/resources/project_membership.md
@@ -31,7 +31,7 @@ resource "gitlab_project_membership" "example" {
 
 ### Required
 
-- **access_level** (String) One of five levels of access to the project.
+- **access_level** (String) The access level for the member. Valid values are: `no one`, `minimal`, `guest`, `reporter`, `developer`, `maintainer`, `master`
 - **project_id** (String) The id of the project.
 - **user_id** (Number) The id of the user.
 

--- a/docs/resources/project_share_group.md
+++ b/docs/resources/project_share_group.md
@@ -16,7 +16,7 @@ This resource allows you to share a project with a group
 resource "gitlab_project_share_group" "test" {
   project_id   = "12345"
   group_id     = 1337
-  access_level = "guest"
+  group_access = "guest"
 }
 ```
 
@@ -25,12 +25,13 @@ resource "gitlab_project_share_group" "test" {
 
 ### Required
 
-- **access_level** (String) One of five levels of access to the project.
 - **group_id** (Number) The id of the group.
 - **project_id** (String) The id of the project.
 
 ### Optional
 
+- **access_level** (String, Deprecated) The access level to grant the group for the project. Valid values are: `no one`, `minimal`, `guest`, `reporter`, `developer`, `maintainer`, `master`
+- **group_access** (String) The access level to grant the group for the project. Valid values are: `no one`, `minimal`, `guest`, `reporter`, `developer`, `maintainer`, `master`
 - **id** (String) The ID of this resource.
 
 ## Import

--- a/docs/resources/tag_protection.md
+++ b/docs/resources/tag_protection.md
@@ -25,7 +25,7 @@ resource "gitlab_tag_protection" "TagProtect" {
 
 ### Required
 
-- **create_access_level** (String) One of five levels of access to the project.
+- **create_access_level** (String) Access levels which are allowed to create. Valid values are: `no one`, `developer`, `maintainer`.
 - **project** (String) The id of the project.
 - **tag** (String) Name of the tag or wildcard.
 

--- a/examples/resources/gitlab_group_ldap_link/resource.tf
+++ b/examples/resources/gitlab_group_ldap_link/resource.tf
@@ -1,6 +1,6 @@
 resource "gitlab_group_ldap_link" "test" {
   group_id      = "12345"
   cn            = "testuser"
-  access_level  = "developer"
+  group_access  = "developer"
   ldap_provider = "ldapmain"
 }

--- a/examples/resources/gitlab_project_share_group/resource.tf
+++ b/examples/resources/gitlab_project_share_group/resource.tf
@@ -1,5 +1,5 @@
 resource "gitlab_project_share_group" "test" {
   project_id   = "12345"
   group_id     = 1337
-  access_level = "guest"
+  group_access = "guest"
 }

--- a/gitlab/access_level_helpers.go
+++ b/gitlab/access_level_helpers.go
@@ -1,0 +1,73 @@
+package gitlab
+
+import (
+	"github.com/xanzy/go-gitlab"
+)
+
+// NOTE:
+// The access level story in the GitLab API is a bit tricky.
+// There are different resources using the same access level names
+// with an identical mapping to int ids. As also defined in the
+// `gitlab.AccessLevelValue` types. However, different endpoints
+// allow all of them or just a subset. There is also endpoints
+// defining an additional `admin` access level, which is nowhere
+// documented and probably not used at all - this provider ignores it.
+// Point being, be careful when using them in a resource or data source
+// and consult the upstream API docs to verify what's possible and keep
+// your fingers crossed it's correct :)
+
+// see the source of truth for `accessLevelNameToValue` and `accessLevelValueToName`
+// here: https://docs.gitlab.com/ee/api/members.html#valid-access-levels
+var validGroupAccessLevelNames = []string{
+	"no one",
+	"minimal",
+	"guest",
+	"reporter",
+	"developer",
+	"maintainer",
+	"owner",
+
+	// Deprecated and should be removed in v4 of this provider
+	"master",
+}
+var validProjectAccessLevelNames = []string{
+	"no one",
+	"minimal",
+	"guest",
+	"reporter",
+	"developer",
+	"maintainer",
+
+	// Deprecated and should be removed in v4 of this provider
+	"master",
+}
+
+// NOTE(TF): the documentation here https://docs.gitlab.com/ee/api/protected_branches.html
+//           mentions an `60 => Admin access` level, but it actually seems to not exist.
+//           Ignoring here that I've every read about this ...
+var validProtectedBranchTagAccessLevelNames = []string{
+	"no one", "developer", "maintainer",
+}
+
+var accessLevelNameToValue = map[string]gitlab.AccessLevelValue{
+	"no one":     gitlab.NoPermissions,
+	"minimal":    gitlab.MinimalAccessPermissions,
+	"guest":      gitlab.GuestPermissions,
+	"reporter":   gitlab.ReporterPermissions,
+	"developer":  gitlab.DeveloperPermissions,
+	"maintainer": gitlab.MaintainerPermissions,
+	"owner":      gitlab.OwnerPermission,
+
+	// Deprecated and should be removed in v4 of this provider
+	"master": gitlab.MaintainerPermissions,
+}
+
+var accessLevelValueToName = map[gitlab.AccessLevelValue]string{
+	gitlab.NoPermissions:            "no one",
+	gitlab.MinimalAccessPermissions: "minimal",
+	gitlab.GuestPermissions:         "guest",
+	gitlab.ReporterPermissions:      "reporter",
+	gitlab.DeveloperPermissions:     "developer",
+	gitlab.MaintainerPermissions:    "maintainer",
+	gitlab.OwnerPermissions:         "owner",
+}

--- a/gitlab/data_source_gitlab_group_membership.go
+++ b/gitlab/data_source_gitlab_group_membership.go
@@ -13,10 +13,6 @@ import (
 )
 
 func dataSourceGitlabGroupMembership() *schema.Resource {
-	acceptedAccessLevels := make([]string, 0, len(accessLevelID))
-	for k := range accessLevelID {
-		acceptedAccessLevels = append(acceptedAccessLevels, k)
-	}
 	return &schema.Resource{
 		Description: "Provide details about a list of group members in the gitlab provider. The results include id, username, name and more about the requested members.\n\n" +
 			"> **Note**: exactly one of group_id or full_path must be provided.",
@@ -46,7 +42,7 @@ func dataSourceGitlabGroupMembership() *schema.Resource {
 				Type:             schema.TypeString,
 				Computed:         true,
 				Optional:         true,
-				ValidateDiagFunc: validateValueFunc(acceptedAccessLevels),
+				ValidateDiagFunc: validateValueFunc(validGroupAccessLevelNames),
 			},
 			"members": {
 				Description: "The list of group members.",
@@ -160,7 +156,7 @@ func flattenGitlabMembers(d *schema.ResourceData, members []*gitlab.GroupMember)
 
 	var filterAccessLevel gitlab.AccessLevelValue = gitlab.NoPermissions
 	if data, ok := d.GetOk("access_level"); ok {
-		filterAccessLevel = accessLevelID[data.(string)]
+		filterAccessLevel = accessLevelNameToValue[data.(string)]
 	}
 
 	for _, member := range members {
@@ -175,7 +171,7 @@ func flattenGitlabMembers(d *schema.ResourceData, members []*gitlab.GroupMember)
 			"state":        member.State,
 			"avatar_url":   member.AvatarURL,
 			"web_url":      member.WebURL,
-			"access_level": accessLevel[gitlab.AccessLevelValue(member.AccessLevel)],
+			"access_level": accessLevelValueToName[gitlab.AccessLevelValue(member.AccessLevel)],
 		}
 
 		if member.ExpiresAt != nil {

--- a/gitlab/data_source_gitlab_group_membership.go
+++ b/gitlab/data_source_gitlab_group_membership.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/xanzy/go-gitlab"
 )
 
@@ -42,7 +43,7 @@ func dataSourceGitlabGroupMembership() *schema.Resource {
 				Type:             schema.TypeString,
 				Computed:         true,
 				Optional:         true,
-				ValidateDiagFunc: validateValueFunc(validGroupAccessLevelNames),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(validGroupAccessLevelNames, false)),
 			},
 			"members": {
 				Description: "The list of group members.",

--- a/gitlab/data_source_gitlab_project_protected_branch.go
+++ b/gitlab/data_source_gitlab_project_protected_branch.go
@@ -58,7 +58,7 @@ func dataSourceGitlabProjectProtectedBranchSchemaAccessLevels() *schema.Schema {
 		Elem: &schema.Resource{
 			Schema: map[string]*schema.Schema{
 				"access_level": {
-					Description: "The access level allowed to perform the respective action (shows as 40 - \"maintainer\" if `user_id` or `group_id` are present).",
+					Description: fmt.Sprintf("The access level allowed to perform the respective action (shows as 40 - \"maintainer\" if `user_id` or `group_id` are present). Valid values are: %s", renderValueListForDocs(validProtectedBranchTagAccessLevelNames)),
 					Type:        schema.TypeString,
 					Computed:    true,
 				},
@@ -68,14 +68,16 @@ func dataSourceGitlabProjectProtectedBranchSchemaAccessLevels() *schema.Schema {
 					Computed:    true,
 				},
 				"user_id": {
-					Description: "If present, indicates that the user is allowed to perform the respective action.",
+					Description: "If present, indicates that the user is allowed to perform the respective action. (only GitLab Premium or higher)",
 					Type:        schema.TypeInt,
 					Computed:    true,
+					Optional:    true,
 				},
 				"group_id": {
-					Description: "If present, indicates that the group is allowed to perform the respective action.",
+					Description: "If present, indicates that the group is allowed to perform the respective action. (only GitLab Premium or higher)",
 					Type:        schema.TypeInt,
 					Computed:    true,
+					Optional:    true,
 				},
 			},
 		},
@@ -135,7 +137,7 @@ func convertBranchAccessDescriptionsToStateBranchAccessDescriptions(descriptions
 
 func convertBranchAccessDescriptionToStateBranchAccessDescription(description *gitlab.BranchAccessDescription) stateBranchAccessDescription {
 	stateDescription := stateBranchAccessDescription{
-		AccessLevel:            accessLevel[description.AccessLevel],
+		AccessLevel:            accessLevelValueToName[description.AccessLevel],
 		AccessLevelDescription: description.AccessLevelDescription,
 	}
 	if description.UserID != 0 {

--- a/gitlab/resource_gitlab_branch_protection.go
+++ b/gitlab/resource_gitlab_branch_protection.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	gitlab "github.com/xanzy/go-gitlab"
 )
 
@@ -66,14 +67,14 @@ func resourceGitlabBranchProtection() *schema.Resource {
 			"merge_access_level": {
 				Description:      fmt.Sprintf("Access levels allowed to merge. Valid values are: %s.", renderValueListForDocs(validProtectedBranchTagAccessLevelNames)),
 				Type:             schema.TypeString,
-				ValidateDiagFunc: validateValueFunc(validProtectedBranchTagAccessLevelNames),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(validProtectedBranchTagAccessLevelNames, false)),
 				Required:         true,
 				ForceNew:         true,
 			},
 			"push_access_level": {
 				Description:      fmt.Sprintf("Access levels allowed to push. Valid values are: %s.", renderValueListForDocs(validProtectedBranchTagAccessLevelNames)),
 				Type:             schema.TypeString,
-				ValidateDiagFunc: validateValueFunc(validProtectedBranchTagAccessLevelNames),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(validProtectedBranchTagAccessLevelNames, false)),
 				Required:         true,
 				ForceNew:         true,
 			},

--- a/gitlab/resource_gitlab_branch_protection_test.go
+++ b/gitlab/resource_gitlab_branch_protection_test.go
@@ -31,8 +31,8 @@ func TestAccGitlabBranchProtection_basic(t *testing.T) {
 					testAccCheckGitlabBranchProtectionComputedAttributes("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
 						Name:             fmt.Sprintf("BranchProtect-%d", rInt),
-						PushAccessLevel:  accessLevel[gitlab.DeveloperPermissions],
-						MergeAccessLevel: accessLevel[gitlab.DeveloperPermissions],
+						PushAccessLevel:  accessLevelValueToName[gitlab.DeveloperPermissions],
+						MergeAccessLevel: accessLevelValueToName[gitlab.DeveloperPermissions],
 					}),
 				),
 			},
@@ -44,8 +44,8 @@ func TestAccGitlabBranchProtection_basic(t *testing.T) {
 					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
 						Name:             fmt.Sprintf("BranchProtect-%d", rInt),
-						PushAccessLevel:  accessLevel[gitlab.MasterPermissions],
-						MergeAccessLevel: accessLevel[gitlab.MasterPermissions],
+						PushAccessLevel:  accessLevelValueToName[gitlab.MasterPermissions],
+						MergeAccessLevel: accessLevelValueToName[gitlab.MasterPermissions],
 					}),
 				),
 			},
@@ -57,8 +57,8 @@ func TestAccGitlabBranchProtection_basic(t *testing.T) {
 					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
 						Name:             fmt.Sprintf("BranchProtect-%d", rInt),
-						PushAccessLevel:  accessLevel[gitlab.DeveloperPermissions],
-						MergeAccessLevel: accessLevel[gitlab.DeveloperPermissions],
+						PushAccessLevel:  accessLevelValueToName[gitlab.DeveloperPermissions],
+						MergeAccessLevel: accessLevelValueToName[gitlab.DeveloperPermissions],
 					}),
 				),
 			},
@@ -71,8 +71,8 @@ func TestAccGitlabBranchProtection_basic(t *testing.T) {
 					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
 						Name:                      fmt.Sprintf("BranchProtect-%d", rInt),
-						PushAccessLevel:           accessLevel[gitlab.DeveloperPermissions],
-						MergeAccessLevel:          accessLevel[gitlab.DeveloperPermissions],
+						PushAccessLevel:           accessLevelValueToName[gitlab.DeveloperPermissions],
+						MergeAccessLevel:          accessLevelValueToName[gitlab.DeveloperPermissions],
 						CodeOwnerApprovalRequired: true,
 					}),
 				),
@@ -87,8 +87,8 @@ func TestAccGitlabBranchProtection_basic(t *testing.T) {
 					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
 						Name:             fmt.Sprintf("BranchProtect-%d", rInt),
-						PushAccessLevel:  accessLevel[gitlab.DeveloperPermissions],
-						MergeAccessLevel: accessLevel[gitlab.DeveloperPermissions],
+						PushAccessLevel:  accessLevelValueToName[gitlab.DeveloperPermissions],
+						MergeAccessLevel: accessLevelValueToName[gitlab.DeveloperPermissions],
 					}),
 				),
 			},
@@ -100,8 +100,8 @@ func TestAccGitlabBranchProtection_basic(t *testing.T) {
 					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
 						Name:             fmt.Sprintf("BranchProtect-%d", rInt),
-						PushAccessLevel:  accessLevel[gitlab.DeveloperPermissions],
-						MergeAccessLevel: accessLevel[gitlab.DeveloperPermissions],
+						PushAccessLevel:  accessLevelValueToName[gitlab.DeveloperPermissions],
+						MergeAccessLevel: accessLevelValueToName[gitlab.DeveloperPermissions],
 					}),
 				),
 			},
@@ -127,8 +127,8 @@ func TestAccGitlabBranchProtection_createWithCodeOwnerApproval(t *testing.T) {
 					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
 						Name:             fmt.Sprintf("BranchProtect-%d", rInt),
-						PushAccessLevel:  accessLevel[gitlab.DeveloperPermissions],
-						MergeAccessLevel: accessLevel[gitlab.DeveloperPermissions],
+						PushAccessLevel:  accessLevelValueToName[gitlab.DeveloperPermissions],
+						MergeAccessLevel: accessLevelValueToName[gitlab.DeveloperPermissions],
 					}),
 				),
 			},
@@ -141,8 +141,8 @@ func TestAccGitlabBranchProtection_createWithCodeOwnerApproval(t *testing.T) {
 					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
 						Name:                      fmt.Sprintf("BranchProtect-%d", rInt),
-						PushAccessLevel:           accessLevel[gitlab.DeveloperPermissions],
-						MergeAccessLevel:          accessLevel[gitlab.DeveloperPermissions],
+						PushAccessLevel:           accessLevelValueToName[gitlab.DeveloperPermissions],
+						MergeAccessLevel:          accessLevelValueToName[gitlab.DeveloperPermissions],
 						CodeOwnerApprovalRequired: true,
 					}),
 				),
@@ -157,8 +157,8 @@ func TestAccGitlabBranchProtection_createWithCodeOwnerApproval(t *testing.T) {
 					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
 						Name:                      fmt.Sprintf("BranchProtect-%d", rInt),
-						PushAccessLevel:           accessLevel[gitlab.DeveloperPermissions],
-						MergeAccessLevel:          accessLevel[gitlab.DeveloperPermissions],
+						PushAccessLevel:           accessLevelValueToName[gitlab.DeveloperPermissions],
+						MergeAccessLevel:          accessLevelValueToName[gitlab.DeveloperPermissions],
 						CodeOwnerApprovalRequired: true,
 					}),
 				),
@@ -171,8 +171,8 @@ func TestAccGitlabBranchProtection_createWithCodeOwnerApproval(t *testing.T) {
 					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
 						Name:             fmt.Sprintf("BranchProtect-%d", rInt),
-						PushAccessLevel:  accessLevel[gitlab.DeveloperPermissions],
-						MergeAccessLevel: accessLevel[gitlab.DeveloperPermissions],
+						PushAccessLevel:  accessLevelValueToName[gitlab.DeveloperPermissions],
+						MergeAccessLevel: accessLevelValueToName[gitlab.DeveloperPermissions],
 					}),
 				),
 			},
@@ -198,8 +198,8 @@ func TestAccGitlabBranchProtection_createWithMultipleAccessLevels(t *testing.T) 
 					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
 						Name:                 fmt.Sprintf("BranchProtect-%d", rInt),
-						PushAccessLevel:      accessLevel[gitlab.MaintainerPermissions],
-						MergeAccessLevel:     accessLevel[gitlab.MaintainerPermissions],
+						PushAccessLevel:      accessLevelValueToName[gitlab.MaintainerPermissions],
+						MergeAccessLevel:     accessLevelValueToName[gitlab.MaintainerPermissions],
 						UsersAllowedToPush:   []string{fmt.Sprintf("listest2%d", rInt)},
 						UsersAllowedToMerge:  []string{fmt.Sprintf("listest%d", rInt), fmt.Sprintf("listest2%d", rInt)},
 						GroupsAllowedToPush:  []string{fmt.Sprintf("test-%d", rInt), fmt.Sprintf("test2-%d", rInt)},
@@ -216,8 +216,8 @@ func TestAccGitlabBranchProtection_createWithMultipleAccessLevels(t *testing.T) 
 					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
 						Name:                 fmt.Sprintf("BranchProtect-%d", rInt),
-						PushAccessLevel:      accessLevel[gitlab.DeveloperPermissions],
-						MergeAccessLevel:     accessLevel[gitlab.DeveloperPermissions],
+						PushAccessLevel:      accessLevelValueToName[gitlab.DeveloperPermissions],
+						MergeAccessLevel:     accessLevelValueToName[gitlab.DeveloperPermissions],
 						UsersAllowedToPush:   []string{fmt.Sprintf("listest%d", rInt)},
 						UsersAllowedToMerge:  []string{fmt.Sprintf("listest2%d", rInt)},
 						GroupsAllowedToPush:  []string{fmt.Sprintf("test2-%d", rInt)},
@@ -323,8 +323,8 @@ func testAccCheckGitlabBranchProtectionAttributes(pb *gitlab.ProtectedBranch, wa
 				break
 			}
 		}
-		if pushAccessLevel != accessLevelID[want.PushAccessLevel] {
-			return fmt.Errorf("got Push access level %v; want %v", pushAccessLevel, accessLevelID[want.PushAccessLevel])
+		if pushAccessLevel != accessLevelNameToValue[want.PushAccessLevel] {
+			return fmt.Errorf("got Push access level %v; want %v", pushAccessLevel, accessLevelNameToValue[want.PushAccessLevel])
 		}
 
 		var mergeAccessLevel gitlab.AccessLevelValue
@@ -334,8 +334,8 @@ func testAccCheckGitlabBranchProtectionAttributes(pb *gitlab.ProtectedBranch, wa
 				break
 			}
 		}
-		if mergeAccessLevel != accessLevelID[want.MergeAccessLevel] {
-			return fmt.Errorf("got Merge access level %v; want %v", mergeAccessLevel, accessLevelID[want.MergeAccessLevel])
+		if mergeAccessLevel != accessLevelNameToValue[want.MergeAccessLevel] {
+			return fmt.Errorf("got Merge access level %v; want %v", mergeAccessLevel, accessLevelNameToValue[want.MergeAccessLevel])
 		}
 
 		conn := testAccProvider.Meta().(*gitlab.Client)
@@ -520,13 +520,13 @@ resource "gitlab_user" "test2" {
 resource "gitlab_project_share_group" "test" {
   project_id   = gitlab_project.test.id
   group_id     = gitlab_group.test.id
-  access_level = "developer"
+  group_access = "developer"
 }
 
 resource "gitlab_project_share_group" "test2" {
   project_id   = gitlab_project.test.id
   group_id     = gitlab_group.test2.id
-  access_level = "developer"
+  group_access = "developer"
 }
 
 resource "gitlab_project_membership" "test" {
@@ -637,13 +637,13 @@ resource "gitlab_user" "test2" {
 resource "gitlab_project_share_group" "test" {
   project_id   = gitlab_project.test.id
   group_id     = gitlab_group.test.id
-  access_level = "developer"
+  group_access = "developer"
 }
 
 resource "gitlab_project_share_group" "test2" {
   project_id   = gitlab_project.test.id
   group_id     = gitlab_group.test2.id
-  access_level = "developer"
+  group_access = "developer"
 }
 
 resource "gitlab_project_membership" "test" {

--- a/gitlab/resource_gitlab_group_ldap_link.go
+++ b/gitlab/resource_gitlab_group_ldap_link.go
@@ -2,6 +2,7 @@ package gitlab
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strings"
 
@@ -11,10 +12,6 @@ import (
 )
 
 func resourceGitlabGroupLdapLink() *schema.Resource {
-	acceptedAccessLevels := make([]string, 0, len(accessLevelID))
-	for k := range accessLevelID {
-		acceptedAccessLevels = append(acceptedAccessLevels, k)
-	}
 	// lintignore: XR002 // TODO: Resolve this tfproviderlint issue
 	return &schema.Resource{
 		Description: "This resource allows you to add an LDAP link to an existing GitLab group.",
@@ -36,13 +33,22 @@ func resourceGitlabGroupLdapLink() *schema.Resource {
 				Required:    true,
 				ForceNew:    true,
 			},
-			// Using the friendlier "access_level" here instead of the GitLab API "group_access".
 			"access_level": {
-				Description:      "Acceptable values are: guest, minimal, reporter, developer, maintainer, owner.",
+				Description:      fmt.Sprintf("Minimum access level for members of the LDAP group. Valid values are: %s", renderValueListForDocs(validGroupAccessLevelNames)),
 				Type:             schema.TypeString,
-				ValidateDiagFunc: validateValueFunc(acceptedAccessLevels),
-				Required:         true,
+				ValidateDiagFunc: validateValueFunc(validGroupAccessLevelNames),
+				Optional:         true,
 				ForceNew:         true,
+				Deprecated:       "Use `group_access` instead of the `access_level` attribute.",
+				ExactlyOneOf:     []string{"access_level", "group_access"},
+			},
+			"group_access": {
+				Description:      fmt.Sprintf("Minimum access level for members of the LDAP group. Valid values are: %s", renderValueListForDocs(validGroupAccessLevelNames)),
+				Type:             schema.TypeString,
+				ValidateDiagFunc: validateValueFunc(validGroupAccessLevelNames),
+				Optional:         true,
+				ForceNew:         true,
+				ExactlyOneOf:     []string{"access_level", "group_access"},
 			},
 			// Changing GitLab API parameter "provider" to "ldap_provider" to avoid clashing with the Terraform "provider" key word
 			"ldap_provider": {
@@ -67,13 +73,22 @@ func resourceGitlabGroupLdapLinkCreate(ctx context.Context, d *schema.ResourceDa
 
 	groupId := d.Get("group_id").(string)
 	cn := d.Get("cn").(string)
-	group_access := gitlab.AccessLevelValue(accessLevelNameToValue[d.Get("access_level").(string)])
+
+	var groupAccess gitlab.AccessLevelValue
+	if v, ok := d.GetOk("group_access"); ok {
+		groupAccess = gitlab.AccessLevelValue(accessLevelNameToValue[v.(string)])
+	} else if v, ok := d.GetOk("access_level"); ok {
+		groupAccess = gitlab.AccessLevelValue(accessLevelNameToValue[v.(string)])
+	} else {
+		return diag.Errorf("Neither `group_access` nor `access_level` (deprecated) is set")
+	}
+
 	ldap_provider := d.Get("ldap_provider").(string)
 	force := d.Get("force").(bool)
 
 	options := &gitlab.AddGroupLDAPLinkOptions{
 		CN:          &cn,
-		GroupAccess: &group_access,
+		GroupAccess: &groupAccess,
 		Provider:    &ldap_provider,
 	}
 

--- a/gitlab/resource_gitlab_group_ldap_link.go
+++ b/gitlab/resource_gitlab_group_ldap_link.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	gitlab "github.com/xanzy/go-gitlab"
 )
 
@@ -36,7 +37,7 @@ func resourceGitlabGroupLdapLink() *schema.Resource {
 			"access_level": {
 				Description:      fmt.Sprintf("Minimum access level for members of the LDAP group. Valid values are: %s", renderValueListForDocs(validGroupAccessLevelNames)),
 				Type:             schema.TypeString,
-				ValidateDiagFunc: validateValueFunc(validGroupAccessLevelNames),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(validGroupAccessLevelNames, false)),
 				Optional:         true,
 				ForceNew:         true,
 				Deprecated:       "Use `group_access` instead of the `access_level` attribute.",
@@ -45,7 +46,7 @@ func resourceGitlabGroupLdapLink() *schema.Resource {
 			"group_access": {
 				Description:      fmt.Sprintf("Minimum access level for members of the LDAP group. Valid values are: %s", renderValueListForDocs(validGroupAccessLevelNames)),
 				Type:             schema.TypeString,
-				ValidateDiagFunc: validateValueFunc(validGroupAccessLevelNames),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(validGroupAccessLevelNames, false)),
 				Optional:         true,
 				ForceNew:         true,
 				ExactlyOneOf:     []string{"access_level", "group_access"},

--- a/gitlab/resource_gitlab_group_ldap_link_test.go
+++ b/gitlab/resource_gitlab_group_ldap_link_test.go
@@ -102,7 +102,7 @@ type testAccGitlabGroupLdapLinkExpectedAttributes struct {
 func testAccCheckGitlabGroupLdapLinkAttributes(ldapLink *gitlab.LDAPGroupLink, want *testAccGitlabGroupLdapLinkExpectedAttributes) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		accessLevelId, ok := accessLevel[ldapLink.GroupAccess]
+		accessLevelId, ok := accessLevelValueToName[ldapLink.GroupAccess]
 		if !ok {
 			return fmt.Errorf("Invalid access level '%s'", accessLevelId)
 		}
@@ -149,7 +149,7 @@ func testAccGetGitlabGroupLdapLink(ldapLink *gitlab.LDAPGroupLink, resourceState
 	// Construct our desired LDAP Link from the config values
 	desiredLdapLink := gitlab.LDAPGroupLink{
 		CN:          resourceState.Primary.Attributes["cn"],
-		GroupAccess: accessLevelNameToValue[resourceState.Primary.Attributes["access_level"]],
+		GroupAccess: accessLevelNameToValue[resourceState.Primary.Attributes["group_access"]],
 		Provider:    resourceState.Primary.Attributes["ldap_provider"],
 	}
 
@@ -220,7 +220,7 @@ resource "gitlab_group" "foo" {
 resource "gitlab_group_ldap_link" "foo" {
     group_id 		= "${gitlab_group.foo.id}"
     cn				= "%s"
-	access_level 	= "developer"
+	group_access 	= "developer"
 	ldap_provider   = "%s"
 
 }`, rInt, rInt, testLdapLink.CN, testLdapLink.Provider)
@@ -237,7 +237,7 @@ resource "gitlab_group" "foo" {
 resource "gitlab_group_ldap_link" "foo" {
     group_id 		= "${gitlab_group.foo.id}"
     cn				= "%s"
-	access_level 	= "maintainer"
+	group_access 	= "maintainer"
 	ldap_provider   = "%s"
 }`, rInt, rInt, testLdapLink.CN, testLdapLink.Provider)
 }
@@ -253,14 +253,14 @@ resource "gitlab_group" "foo" {
 resource "gitlab_group_ldap_link" "foo" {
     group_id 		= "${gitlab_group.foo.id}"
     cn				= "%s"
-	access_level 	= "maintainer"
+	group_access 	= "maintainer"
 	ldap_provider   = "%s"
 }
 
 resource "gitlab_group_ldap_link" "bar" {
     group_id 		= "${gitlab_group.foo.id}"
     cn				= "%s"
-	access_level 	= "developer"
+	group_access 	= "developer"
 	ldap_provider   = "%s"
 	force			= true
 }`, rInt, rInt, testLdapLink.CN, testLdapLink.Provider, testLdapLink.CN, testLdapLink.Provider)

--- a/gitlab/resource_gitlab_group_membership.go
+++ b/gitlab/resource_gitlab_group_membership.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/xanzy/go-gitlab"
 )
 
@@ -40,7 +41,7 @@ func resourceGitlabGroupMembership() *schema.Resource {
 			"access_level": {
 				Description:      fmt.Sprintf("Access level for the member. Valid values are: %s.", renderValueListForDocs(validGroupAccessLevelNames)),
 				Type:             schema.TypeString,
-				ValidateDiagFunc: validateValueFunc(validGroupAccessLevelNames),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(validGroupAccessLevelNames, false)),
 				Required:         true,
 			},
 			"expires_at": {

--- a/gitlab/resource_gitlab_group_membership.go
+++ b/gitlab/resource_gitlab_group_membership.go
@@ -2,6 +2,7 @@ package gitlab
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strconv"
 	"strings"
@@ -12,10 +13,6 @@ import (
 )
 
 func resourceGitlabGroupMembership() *schema.Resource {
-	acceptedAccessLevels := make([]string, 0, len(accessLevelID))
-	for k := range accessLevelID {
-		acceptedAccessLevels = append(acceptedAccessLevels, k)
-	}
 	return &schema.Resource{
 		Description: "This resource allows you to add a user to an existing group.",
 
@@ -41,9 +38,9 @@ func resourceGitlabGroupMembership() *schema.Resource {
 				Required:    true,
 			},
 			"access_level": {
-				Description:      "Acceptable values are: guest, minimal, reporter, developer, maintainer, owner.",
+				Description:      fmt.Sprintf("Access level for the member. Valid values are: %s.", renderValueListForDocs(validGroupAccessLevelNames)),
 				Type:             schema.TypeString,
-				ValidateDiagFunc: validateValueFunc(acceptedAccessLevels),
+				ValidateDiagFunc: validateValueFunc(validGroupAccessLevelNames),
 				Required:         true,
 			},
 			"expires_at": {
@@ -62,7 +59,7 @@ func resourceGitlabGroupMembershipCreate(ctx context.Context, d *schema.Resource
 	userId := d.Get("user_id").(int)
 	groupId := d.Get("group_id").(string)
 	expiresAt := d.Get("expires_at").(string)
-	accessLevelId := accessLevelID[d.Get("access_level").(string)]
+	accessLevelId := accessLevelNameToValue[d.Get("access_level").(string)]
 
 	options := &gitlab.AddGroupMemberOptions{
 		UserID:      &userId,
@@ -122,7 +119,7 @@ func resourceGitlabGroupMembershipUpdate(ctx context.Context, d *schema.Resource
 	userId := d.Get("user_id").(int)
 	groupId := d.Get("group_id").(string)
 	expiresAt := d.Get("expires_at").(string)
-	accessLevelId := accessLevelID[strings.ToLower(d.Get("access_level").(string))]
+	accessLevelId := accessLevelNameToValue[strings.ToLower(d.Get("access_level").(string))]
 
 	options := gitlab.EditGroupMemberOptions{
 		AccessLevel: &accessLevelId,
@@ -161,7 +158,7 @@ func resourceGitlabGroupMembershipSetToState(d *schema.ResourceData, groupMember
 
 	d.Set("group_id", groupId)
 	d.Set("user_id", groupMember.ID)
-	d.Set("access_level", accessLevel[groupMember.AccessLevel])
+	d.Set("access_level", accessLevelValueToName[groupMember.AccessLevel])
 	if groupMember.ExpiresAt != nil {
 		d.Set("expires_at", groupMember.ExpiresAt.String())
 	}

--- a/gitlab/resource_gitlab_group_membership_test.go
+++ b/gitlab/resource_gitlab_group_membership_test.go
@@ -85,7 +85,7 @@ type testAccGitlabGroupMembershipExpectedAttributes struct {
 func testAccCheckGitlabGroupMembershipAttributes(membership *gitlab.GroupMember, want *testAccGitlabGroupMembershipExpectedAttributes) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		accessLevelId, ok := accessLevel[membership.AccessLevel]
+		accessLevelId, ok := accessLevelValueToName[membership.AccessLevel]
 		if !ok {
 			return fmt.Errorf("Invalid access level '%s'", accessLevelId)
 		}

--- a/gitlab/resource_gitlab_group_share_group.go
+++ b/gitlab/resource_gitlab_group_share_group.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	gitlab "github.com/xanzy/go-gitlab"
 )
 
@@ -40,7 +41,7 @@ func resourceGitlabGroupShareGroup() *schema.Resource {
 			"group_access": {
 				Description:      fmt.Sprintf("The access level to grant the group. Valid values are: %s", renderValueListForDocs(validGroupAccessLevelNames)),
 				Type:             schema.TypeString,
-				ValidateDiagFunc: validateValueFunc(validGroupAccessLevelNames),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(validGroupAccessLevelNames, false)),
 				ForceNew:         true,
 				Required:         true,
 			},

--- a/gitlab/resource_gitlab_project_membership.go
+++ b/gitlab/resource_gitlab_project_membership.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/xanzy/go-gitlab"
 )
 
@@ -41,7 +42,7 @@ func resourceGitlabProjectMembership() *schema.Resource {
 			"access_level": {
 				Description:      fmt.Sprintf("The access level for the member. Valid values are: %s", renderValueListForDocs(validProjectAccessLevelNames)),
 				Type:             schema.TypeString,
-				ValidateDiagFunc: validateValueFunc(validProjectAccessLevelNames),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(validProjectAccessLevelNames, false)),
 				Required:         true,
 			},
 		},

--- a/gitlab/resource_gitlab_project_membership_test.go
+++ b/gitlab/resource_gitlab_project_membership_test.go
@@ -83,7 +83,7 @@ type testAccGitlabProjectMembershipExpectedAttributes struct {
 func testAccCheckGitlabProjectMembershipAttributes(membership *gitlab.ProjectMember, want *testAccGitlabProjectMembershipExpectedAttributes) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 
-		access_level_id, ok := accessLevel[membership.AccessLevel]
+		access_level_id, ok := accessLevelValueToName[membership.AccessLevel]
 		if !ok {
 			return fmt.Errorf("Invalid access level '%s'", access_level_id)
 		}

--- a/gitlab/resource_gitlab_project_share_group.go
+++ b/gitlab/resource_gitlab_project_share_group.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/xanzy/go-gitlab"
 )
 
@@ -38,7 +39,7 @@ func resourceGitlabProjectShareGroup() *schema.Resource {
 			"group_access": {
 				Description:      fmt.Sprintf("The access level to grant the group for the project. Valid values are: %s", renderValueListForDocs(validProjectAccessLevelNames)),
 				Type:             schema.TypeString,
-				ValidateDiagFunc: validateValueFunc(validProjectAccessLevelNames),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(validProjectAccessLevelNames, false)),
 				ForceNew:         true,
 				Optional:         true,
 				ExactlyOneOf:     []string{"access_level", "group_access"},
@@ -46,7 +47,7 @@ func resourceGitlabProjectShareGroup() *schema.Resource {
 			"access_level": {
 				Description:      fmt.Sprintf("The access level to grant the group for the project. Valid values are: %s", renderValueListForDocs(validProjectAccessLevelNames)),
 				Type:             schema.TypeString,
-				ValidateDiagFunc: validateValueFunc(validProjectAccessLevelNames),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(validProjectAccessLevelNames, false)),
 				ForceNew:         true,
 				Optional:         true,
 				Deprecated:       "Use `group_access` instead of the `access_level` attribute.",
@@ -192,7 +193,7 @@ func resourceGitlabProjectShareGroupResourceV0() *schema.Resource {
 			"access_level": {
 				Description:      fmt.Sprintf("The access level to grant the group for the project. Valid values are: %s", renderValueListForDocs(validProjectAccessLevelNames)),
 				Type:             schema.TypeString,
-				ValidateDiagFunc: validateValueFunc(validProjectAccessLevelNames),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(validProjectAccessLevelNames, false)),
 				ForceNew:         true,
 				Required:         true,
 			},

--- a/gitlab/resource_gitlab_project_share_group.go
+++ b/gitlab/resource_gitlab_project_share_group.go
@@ -12,8 +12,6 @@ import (
 )
 
 func resourceGitlabProjectShareGroup() *schema.Resource {
-	acceptedAccessLevels := []string{"guest", "reporter", "developer", "maintainer"}
-
 	return &schema.Resource{
 		Description: "This resource allows you to share a project with a group",
 
@@ -37,12 +35,30 @@ func resourceGitlabProjectShareGroup() *schema.Resource {
 				ForceNew:    true,
 				Required:    true,
 			},
-			"access_level": {
-				Description:      "One of five levels of access to the project.",
+			"group_access": {
+				Description:      fmt.Sprintf("The access level to grant the group for the project. Valid values are: %s", renderValueListForDocs(validProjectAccessLevelNames)),
 				Type:             schema.TypeString,
-				ValidateDiagFunc: validateValueFunc(acceptedAccessLevels),
+				ValidateDiagFunc: validateValueFunc(validProjectAccessLevelNames),
 				ForceNew:         true,
-				Required:         true,
+				Optional:         true,
+				ExactlyOneOf:     []string{"access_level", "group_access"},
+			},
+			"access_level": {
+				Description:      fmt.Sprintf("The access level to grant the group for the project. Valid values are: %s", renderValueListForDocs(validProjectAccessLevelNames)),
+				Type:             schema.TypeString,
+				ValidateDiagFunc: validateValueFunc(validProjectAccessLevelNames),
+				ForceNew:         true,
+				Optional:         true,
+				Deprecated:       "Use `group_access` instead of the `access_level` attribute.",
+				ExactlyOneOf:     []string{"access_level", "group_access"},
+			},
+		},
+		SchemaVersion: 1,
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    resourceGitlabProjectShareGroupResourceV0().CoreConfigSchema().ImpliedType(),
+				Upgrade: resourceGitlabProjectShareGroupStateUpgradeV0,
+				Version: 0,
 			},
 		},
 	}
@@ -53,11 +69,19 @@ func resourceGitlabProjectShareGroupCreate(ctx context.Context, d *schema.Resour
 
 	groupId := d.Get("group_id").(int)
 	projectId := d.Get("project_id").(string)
-	accessLevelId := accessLevelID[d.Get("access_level").(string)]
+
+	var groupAccess gitlab.AccessLevelValue
+	if v, ok := d.GetOk("group_access"); ok {
+		groupAccess = gitlab.AccessLevelValue(accessLevelNameToValue[v.(string)])
+	} else if v, ok := d.GetOk("access_level"); ok {
+		groupAccess = gitlab.AccessLevelValue(accessLevelNameToValue[v.(string)])
+	} else {
+		return diag.Errorf("Neither `group_access` nor `access_level` (deprecated) is set")
+	}
 
 	options := &gitlab.ShareWithGroupOptions{
 		GroupID:     &groupId,
-		GroupAccess: &accessLevelId,
+		GroupAccess: &groupAccess,
 	}
 	log.Printf("[DEBUG] create gitlab project membership for %d in %s", options.GroupID, projectId)
 
@@ -144,8 +168,40 @@ func resourceGitlabProjectShareGroupSetToState(d *schema.ResourceData, group str
 
 	d.Set("project_id", projectId)
 	d.Set("group_id", group.GroupID)
-	d.Set("access_level", accessLevel[convertedAccessLevel])
+	d.Set("group_access", accessLevelValueToName[convertedAccessLevel])
 
 	groupId := strconv.Itoa(group.GroupID)
 	d.SetId(buildTwoPartID(projectId, &groupId))
+}
+
+func resourceGitlabProjectShareGroupResourceV0() *schema.Resource {
+	return &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"project_id": {
+				Description: "The id of the project.",
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Required:    true,
+			},
+			"group_id": {
+				Description: "The id of the group.",
+				Type:        schema.TypeInt,
+				ForceNew:    true,
+				Required:    true,
+			},
+			"access_level": {
+				Description:      fmt.Sprintf("The access level to grant the group for the project. Valid values are: %s", renderValueListForDocs(validProjectAccessLevelNames)),
+				Type:             schema.TypeString,
+				ValidateDiagFunc: validateValueFunc(validProjectAccessLevelNames),
+				ForceNew:         true,
+				Required:         true,
+			},
+		},
+	}
+}
+
+func resourceGitlabProjectShareGroupStateUpgradeV0(ctx context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	rawState["group_access"] = rawState["access_level"]
+	delete(rawState, "access_level")
+	return rawState, nil
 }

--- a/gitlab/resource_gitlab_tag_protection.go
+++ b/gitlab/resource_gitlab_tag_protection.go
@@ -2,6 +2,7 @@ package gitlab
 
 import (
 	"context"
+	"fmt"
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -10,11 +11,6 @@ import (
 )
 
 func resourceGitlabTagProtection() *schema.Resource {
-	acceptedAccessLevels := make([]string, 0, len(tagProtectionAccessLevelID))
-
-	for k := range tagProtectionAccessLevelID {
-		acceptedAccessLevels = append(acceptedAccessLevels, k)
-	}
 	return &schema.Resource{
 		Description: "This resource allows you to protect a specific tag or wildcard by an access level so that the user with less access level cannot Create the tags.",
 
@@ -39,9 +35,9 @@ func resourceGitlabTagProtection() *schema.Resource {
 				Required:    true,
 			},
 			"create_access_level": {
-				Description:      "One of five levels of access to the project.",
+				Description:      fmt.Sprintf("Access levels which are allowed to create. Valid values are: %s.", renderValueListForDocs(validProtectedBranchTagAccessLevelNames)),
 				Type:             schema.TypeString,
-				ValidateDiagFunc: validateValueFunc(acceptedAccessLevels),
+				ValidateDiagFunc: validateValueFunc(validProtectedBranchTagAccessLevelNames),
 				Required:         true,
 				ForceNew:         true,
 			},

--- a/gitlab/resource_gitlab_tag_protection.go
+++ b/gitlab/resource_gitlab_tag_protection.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	gitlab "github.com/xanzy/go-gitlab"
 )
 
@@ -37,7 +38,7 @@ func resourceGitlabTagProtection() *schema.Resource {
 			"create_access_level": {
 				Description:      fmt.Sprintf("Access levels which are allowed to create. Valid values are: %s.", renderValueListForDocs(validProtectedBranchTagAccessLevelNames)),
 				Type:             schema.TypeString,
-				ValidateDiagFunc: validateValueFunc(validProtectedBranchTagAccessLevelNames),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(validProtectedBranchTagAccessLevelNames, false)),
 				Required:         true,
 				ForceNew:         true,
 			},

--- a/gitlab/resource_gitlab_tag_protection_test.go
+++ b/gitlab/resource_gitlab_tag_protection_test.go
@@ -27,7 +27,7 @@ func TestAccGitlabTagProtection_basic(t *testing.T) {
 					testAccCheckGitlabTagProtectionExists("gitlab_tag_protection.TagProtect", &pt),
 					testAccCheckGitlabTagProtectionAttributes(&pt, &testAccGitlabTagProtectionExpectedAttributes{
 						Name:              fmt.Sprintf("TagProtect-%d", rInt),
-						CreateAccessLevel: accessLevel[gitlab.DeveloperPermissions],
+						CreateAccessLevel: accessLevelValueToName[gitlab.DeveloperPermissions],
 					}),
 				),
 			},
@@ -38,7 +38,7 @@ func TestAccGitlabTagProtection_basic(t *testing.T) {
 					testAccCheckGitlabTagProtectionExists("gitlab_tag_protection.TagProtect", &pt),
 					testAccCheckGitlabTagProtectionAttributes(&pt, &testAccGitlabTagProtectionExpectedAttributes{
 						Name:              fmt.Sprintf("TagProtect-%d", rInt),
-						CreateAccessLevel: accessLevel[gitlab.MasterPermissions],
+						CreateAccessLevel: accessLevelValueToName[gitlab.MasterPermissions],
 					}),
 				),
 			},
@@ -49,7 +49,7 @@ func TestAccGitlabTagProtection_basic(t *testing.T) {
 					testAccCheckGitlabTagProtectionExists("gitlab_tag_protection.TagProtect", &pt),
 					testAccCheckGitlabTagProtectionAttributes(&pt, &testAccGitlabTagProtectionExpectedAttributes{
 						Name:              fmt.Sprintf("TagProtect-%d", rInt),
-						CreateAccessLevel: accessLevel[gitlab.DeveloperPermissions],
+						CreateAccessLevel: accessLevelValueToName[gitlab.DeveloperPermissions],
 					}),
 				),
 			},
@@ -76,7 +76,7 @@ func TestAccGitlabTagProtection_wildcard(t *testing.T) {
 					testAccCheckGitlabTagProtectionExists("gitlab_tag_protection.TagProtect", &pt),
 					testAccCheckGitlabTagProtectionAttributes(&pt, &testAccGitlabTagProtectionExpectedAttributes{
 						Name:              fmt.Sprintf("TagProtect-%d%s", rInt, wildcard),
-						CreateAccessLevel: accessLevel[gitlab.DeveloperPermissions],
+						CreateAccessLevel: accessLevelValueToName[gitlab.DeveloperPermissions],
 					}),
 				),
 			},
@@ -87,7 +87,7 @@ func TestAccGitlabTagProtection_wildcard(t *testing.T) {
 					testAccCheckGitlabTagProtectionExists("gitlab_tag_protection.TagProtect", &pt),
 					testAccCheckGitlabTagProtectionAttributes(&pt, &testAccGitlabTagProtectionExpectedAttributes{
 						Name:              fmt.Sprintf("TagProtect-%d%s", rInt, wildcard),
-						CreateAccessLevel: accessLevel[gitlab.MasterPermissions],
+						CreateAccessLevel: accessLevelValueToName[gitlab.MasterPermissions],
 					}),
 				),
 			},
@@ -98,7 +98,7 @@ func TestAccGitlabTagProtection_wildcard(t *testing.T) {
 					testAccCheckGitlabTagProtectionExists("gitlab_tag_protection.TagProtect", &pt),
 					testAccCheckGitlabTagProtectionAttributes(&pt, &testAccGitlabTagProtectionExpectedAttributes{
 						Name:              fmt.Sprintf("TagProtect-%d%s", rInt, wildcard),
-						CreateAccessLevel: accessLevel[gitlab.DeveloperPermissions],
+						CreateAccessLevel: accessLevelValueToName[gitlab.DeveloperPermissions],
 					}),
 				),
 			},
@@ -165,8 +165,8 @@ func testAccCheckGitlabTagProtectionAttributes(pt *gitlab.ProtectedTag, want *te
 			return fmt.Errorf("got name %q; want %q", pt.Name, want.Name)
 		}
 
-		if pt.CreateAccessLevels[0].AccessLevel != accessLevelID[want.CreateAccessLevel] {
-			return fmt.Errorf("got Create access levels %q; want %q", pt.CreateAccessLevels[0].AccessLevel, accessLevelID[want.CreateAccessLevel])
+		if pt.CreateAccessLevels[0].AccessLevel != accessLevelNameToValue[want.CreateAccessLevel] {
+			return fmt.Errorf("got Create access levels %q; want %q", pt.CreateAccessLevels[0].AccessLevel, accessLevelNameToValue[want.CreateAccessLevel])
 		}
 
 		return nil

--- a/gitlab/util.go
+++ b/gitlab/util.go
@@ -14,27 +14,12 @@ import (
 	gitlab "github.com/xanzy/go-gitlab"
 )
 
-var accessLevelNameToValue = map[string]gitlab.AccessLevelValue{
-	"no one":     gitlab.NoPermissions,
-	"minimal":    gitlab.MinimalAccessPermissions,
-	"guest":      gitlab.GuestPermissions,
-	"reporter":   gitlab.ReporterPermissions,
-	"developer":  gitlab.DeveloperPermissions,
-	"maintainer": gitlab.MaintainerPermissions,
-	"owner":      gitlab.OwnerPermission,
-
-	// Deprecated
-	"master": gitlab.MaintainerPermissions,
-}
-
-var accessLevelValueToName = map[gitlab.AccessLevelValue]string{
-	gitlab.NoPermissions:            "no one",
-	gitlab.MinimalAccessPermissions: "minimal",
-	gitlab.GuestPermissions:         "guest",
-	gitlab.ReporterPermissions:      "reporter",
-	gitlab.DeveloperPermissions:     "developer",
-	gitlab.MaintainerPermissions:    "maintainer",
-	gitlab.OwnerPermissions:         "owner",
+func renderValueListForDocs(values []string) string {
+	inlineCodeValues := make([]string, 0, len(values))
+	for _, v := range values {
+		inlineCodeValues = append(inlineCodeValues, fmt.Sprintf("`%s`", v))
+	}
+	return strings.Join(inlineCodeValues, ", ")
 }
 
 // copied from ../github/util.go
@@ -233,27 +218,6 @@ var tagProtectionAccessLevelNames = map[gitlab.AccessLevelValue]string{
 	gitlab.NoPermissions:         "no one",
 	gitlab.DeveloperPermissions:  "developer",
 	gitlab.MaintainerPermissions: "maintainer",
-}
-
-var accessLevelID = map[string]gitlab.AccessLevelValue{
-	"no one":     gitlab.NoPermissions,
-	"guest":      gitlab.GuestPermissions,
-	"reporter":   gitlab.ReporterPermissions,
-	"developer":  gitlab.DeveloperPermissions,
-	"maintainer": gitlab.MaintainerPermissions,
-	"owner":      gitlab.OwnerPermission,
-
-	// Deprecated
-	"master": gitlab.MaintainerPermissions,
-}
-
-var accessLevel = map[gitlab.AccessLevelValue]string{
-	gitlab.NoPermissions:         "no one",
-	gitlab.GuestPermissions:      "guest",
-	gitlab.ReporterPermissions:   "reporter",
-	gitlab.DeveloperPermissions:  "developer",
-	gitlab.MaintainerPermissions: "maintainer",
-	gitlab.OwnerPermission:       "owner",
 }
 
 func stringSetToStringSlice(stringSet *schema.Set) *[]string {

--- a/gitlab/util.go
+++ b/gitlab/util.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hashicorp/go-cty/cty"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	gitlab "github.com/xanzy/go-gitlab"
 )
@@ -20,26 +18,6 @@ func renderValueListForDocs(values []string) string {
 		inlineCodeValues = append(inlineCodeValues, fmt.Sprintf("`%s`", v))
 	}
 	return strings.Join(inlineCodeValues, ", ")
-}
-
-// copied from ../github/util.go
-func validateValueFunc(values []string) schema.SchemaValidateDiagFunc {
-	return func(v interface{}, k cty.Path) diag.Diagnostics {
-		value := v.(string)
-		valid := false
-		for _, role := range values {
-			if value == role {
-				valid = true
-				break
-			}
-		}
-
-		if !valid {
-			return diag.Errorf("%s is an invalid value for argument %s acceptable values are: %v", value, k, values)
-		}
-
-		return nil
-	}
 }
 
 var validateDateFunc = func(v interface{}, k string) (we []string, errors []error) {

--- a/gitlab/util_test.go
+++ b/gitlab/util_test.go
@@ -3,39 +3,8 @@ package gitlab
 import (
 	"testing"
 
-	"github.com/hashicorp/go-cty/cty"
 	gitlab "github.com/xanzy/go-gitlab"
 )
-
-func TestGitlab_validation(t *testing.T) {
-	cases := []struct {
-		Value    string
-		ErrCount int
-	}{
-		{
-			Value:    "invalid",
-			ErrCount: 1,
-		},
-		{
-			Value:    "valid_one",
-			ErrCount: 0,
-		},
-		{
-			Value:    "valid_two",
-			ErrCount: 0,
-		},
-	}
-
-	validationFunc := validateValueFunc([]string{"valid_one", "valid_two"})
-
-	for _, tc := range cases {
-		diags := validationFunc(tc.Value, cty.Path{cty.IndexStep{Key: cty.StringVal("test_arg")}})
-
-		if len(diags) != tc.ErrCount {
-			t.Fatalf("Expected 1 validation error")
-		}
-	}
-}
 
 func TestGitlab_visbilityHelpers(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
The situation is a little more trickier than I've expected.
See my comments in `gitlab/access_level_helpers.go`.

I think that this should be a good enough first improvement and makes
some helpful clarifications in the docs. It also aligns API attributes
in the `gitlab_group_ldap_link` and `gitlab_project_share_group`
resources. The latter even includes a state migration to ensure
compatibility with older states.

Closes #794 