### PR TITLE
resource/service_slack: use pass through importer and start alignment with upstream API. Refs #790

### DIFF
--- a/docs/resources/service_slack.md
+++ b/docs/resources/service_slack.md
@@ -50,7 +50,7 @@ resource "gitlab_service_slack" "slack" {
 - **note_channel** (String) The name of the channel to receive note events notifications.
 - **note_events** (Boolean) Enable notifications for note events.
 - **notify_only_broken_pipelines** (Boolean) Send notifications for broken pipelines.
-- **notify_only_default_branch** (Boolean, Deprecated) DEPRECATED: This parameter has been replaced with `branches_to_be_notified`.
+- **notify_only_default_branch** (Boolean, Deprecated) This parameter has been replaced with `branches_to_be_notified`.
 - **pipeline_channel** (String) The name of the channel to receive pipeline events notifications.
 - **pipeline_events** (Boolean) Enable notifications for pipeline events.
 - **push_channel** (String) The name of the channel to receive push events notifications.
@@ -63,7 +63,7 @@ resource "gitlab_service_slack" "slack" {
 
 ### Read-Only
 
-- **job_events** (Boolean) Enable notifications for job events.
+- **job_events** (Boolean) Enable notifications for job events. **ATTENTION**: This attribute is currently not being submitted to the GitLab API, due to https://github.com/xanzy/go-gitlab/issues/1354.
 
 ## Import
 

--- a/gitlab/resource_gitlab_service_slack_test.go
+++ b/gitlab/resource_gitlab_service_slack_test.go
@@ -36,6 +36,11 @@ func TestAccGitlabServiceSlack_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(slackResourceName, "webhook", "https://test.com"),
 					resource.TestCheckResourceAttr(slackResourceName, "push_events", "true"),
 					resource.TestCheckResourceAttr(slackResourceName, "push_channel", "test"),
+					// TODO: Currently, GitLab doesn't correctly implement the API, so this is
+					//       impossible to implement here at the moment.
+					//       see https://gitlab.com/gitlab-org/gitlab/-/issues/28903
+					// resource.TestCheckResourceAttr(slackResourceName, "deployment_events", "true"),
+					// resource.TestCheckResourceAttr(slackResourceName, "deployment_channel", "test"),
 					resource.TestCheckResourceAttr(slackResourceName, "notify_only_broken_pipelines", "true"),
 				),
 			},
@@ -204,6 +209,11 @@ resource "gitlab_service_slack" "slack" {
   confidential_issues_events   = true
   confidential_issue_channel   = "test"
   confidential_note_events     = true
+// TODO: Currently, GitLab doesn't correctly implement the API, so this is
+//       impossible to implement here at the moment.
+//       see https://gitlab.com/gitlab-org/gitlab/-/issues/28903
+//   deployment_channel           = "test"
+//   deployment_events            = true
   merge_requests_events        = true
   merge_request_channel        = "test"
   tag_push_events              = true
@@ -242,6 +252,11 @@ resource "gitlab_service_slack" "slack" {
   confidential_issues_events   = false
   confidential_issue_channel   = "test confidential_issue_channel"
   confidential_note_events     = false
+// TODO: Currently, GitLab doesn't correctly implement the API, so this is
+//       impossible to implement here at the moment.
+//       see https://gitlab.com/gitlab-org/gitlab/-/issues/28903
+//   deployment_channel           = "test deployment_channel"
+//   deployment_events            = false
   merge_requests_events        = false
   merge_request_channel        = "test merge_request_channel"
   tag_push_events              = false


### PR DESCRIPTION
This is a start towards correctly implementing the Slack Notification
Integration Service. When I started I wasn't aware of the problems in
the upstream GitLab API and the misalignment between `go-gitlab` and the
upstream GitLab API (maybe by intention because the upstream API is broken).

Long story short, there is a GitLab upstream issue here:

* https://gitlab.com/gitlab-org/gitlab/-/issues/28903

a go-gitlab issue here:

* https://github.com/xanzy/go-gitlab/issues/1354

And we have one here:

* https://github.com/gitlabhq/terraform-provider-gitlab/issues/790

Nevertheless, I think we should merge this change set. It uses the pass
through importer for the resource and also cleans up a few things. In
addition I've aligned the resource schema with the upstream API and
commented out the missing parts with matching comments and links to the
issues.
I'd say we continue work on this once both GitLab and go-gitlab APIs are
fixed / aligned.
