### PR TITLE
Workflows: Add triage labels to PRs

### DIFF
--- a/.github/labeler-pr-triage.yml
+++ b/.github/labeler-pr-triage.yml
@@ -4,22 +4,34 @@ dependencies:
   - '.github/dependabot.yml'
   - '**/go.mod'
   - '**/go.sum'
+
 documentation:
   - '**/*.md'
   - 'docs/**/*'
   - 'examples/**/*'
+
 linter:
   - '.github/workflows/*-lint.yml'
   - '.golangci.yml'
+
 provider:
   - '.go-version'
   - 'gitlab/**/*'
   - 'main.go'
+
+resource:
+  - 'gitlab/resource_*.go'
+
+data-source:
+  - 'gitlab/data_source_*.go'
+
 tests:
   - '**/*_test.go'
+
 tools:
   - 'tools/**/*'
   - 'scripts/**/*'
   - 'GNUMakefile'
+
 workflows:
   - '.github/**/*'

--- a/.github/labeler-pr-triage.yml
+++ b/.github/labeler-pr-triage.yml
@@ -1,0 +1,25 @@
+# PR Labeler documentation: https://github.com/marketplace/actions/labeler
+
+dependencies:
+  - '.github/dependabot.yml'
+  - '**/go.mod'
+  - '**/go.sum'
+documentation:
+  - '**/*.md'
+  - 'docs/**/*'
+  - 'examples/**/*'
+linter:
+  - '.github/workflows/*-lint.yml'
+  - '.golangci.yml'
+provider:
+  - '.go-version'
+  - 'gitlab/**/*'
+  - 'main.go'
+tests:
+  - '**/*_test.go'
+tools:
+  - 'tools/**/*'
+  - 'scripts/**/*'
+  - 'GNUMakefile'
+workflows:
+  - '.github/**/*'

--- a/.github/workflows/pr-target.yml
+++ b/.github/workflows/pr-target.yml
@@ -1,0 +1,37 @@
+# GitHub Action reference: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+#
+# Automation for pull requests that requires "write" access.
+
+name: pr-target
+
+on: [pull_request_target]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/labeler@v3
+        with:
+          configuration-path: .github/labeler-pr-triage.yml
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: pascalgn/size-label-action@v0.4.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Ignore generated files.
+          IGNORED: |
+            **/go.sum
+            docs/**/*
+        with:
+          sizes: |
+            {
+              "0": "XS",
+              "10": "S",
+              "50": "M",
+              "200": "L",
+              "800": "XL",
+              "2000": "XXL"
+            }


### PR DESCRIPTION
## Description

<!-- Which issue/s does this PR close? Is there any more context you can give the reviewer? -->

closes #428 

New workflows for pull requests that automatically add `size/*` and other area-like labels to pull requests.

Tested in my fork.

## PR Checklist

<!-- For a smooth review process, please run through this checklist before submitting a PR. -->

- [x] Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
- [x] [Examples](/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
- [x] New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
- [x] No new `//lintignore` comments that came from copied code. Linter rules are meant to be enforced on new code.
