### PR TITLE
Workflows: Label stale issues and PRs, and issue triage labels

### DIFF
--- a/.github/labeler-issue-triage.yml
+++ b/.github/labeler-issue-triage.yml
@@ -1,0 +1,17 @@
+# Issue Labeler documentation: https://github.com/marketplace/actions/regex-issue-labeler
+
+bug:
+  # General:
+  #   panic:
+  # Terraform CLI:
+  #   Provider produced inconsistent final plan
+  #   Provider produced inconsistent result after apply
+  #   produced an invalid new value
+  #   produced an unexpected new value
+  # Terraform Plugin SDK:
+  #   doesn't support update
+  #   Invalid address to set
+  - "(panic:|Provider produced inconsistent (final plan|result after apply)|produced an (invalid|unexpected) new value|doesn't support update|Invalid address to set)"
+
+needs-triage:
+  - '.*'

--- a/.github/workflows/issue-comment-created.yml
+++ b/.github/workflows/issue-comment-created.yml
@@ -1,0 +1,20 @@
+# GitHub Action reference: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+
+name: issue-comment-created
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  remove-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: |
+            stale
+            waiting-response

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -1,0 +1,21 @@
+# GitHub Action reference: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+
+name: issue-opened
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  add-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: github/issue-labeler@v2.4
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/labeler-issue-triage.yml
+          enable-versioned-regex: 0

--- a/.github/workflows/issue-or-pr-closed.yml
+++ b/.github/workflows/issue-or-pr-closed.yml
@@ -1,0 +1,26 @@
+# GitHub Action reference: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+
+name: issue-or-pr-closed
+
+on:
+  issues:
+    types: [closed]
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  remove-labels:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        labels: ['needs-triage', 'waiting-response']
+    steps:
+      - name: Remove ${{ matrix.labels }} label
+        uses: actions-ecosystem/action-remove-labels@v1
+        if: contains(github.event.*.labels.*.name, matrix.labels)
+        with:
+          labels: ${{ matrix.labels }}

--- a/.github/workflows/issue-or-pr-closed.yml
+++ b/.github/workflows/issue-or-pr-closed.yml
@@ -17,10 +17,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        labels: ['needs-triage', 'waiting-response', 'needs-rebase']
+        label:
+          - 'needs-triage'
+          - 'waiting-response'
+          - 'needs-rebase'
+          - 'merge-conflict'
     steps:
-      - name: Remove ${{ matrix.labels }} label
+      - name: Remove ${{ matrix.label }} label
         uses: actions-ecosystem/action-remove-labels@v1
-        if: contains(github.event.*.labels.*.name, matrix.labels)
+        if: contains(github.event.*.labels.*.name, matrix.label)
         with:
-          labels: ${{ matrix.labels }}
+          labels: ${{ matrix.label }}

--- a/.github/workflows/issue-or-pr-closed.yml
+++ b/.github/workflows/issue-or-pr-closed.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        labels: ['needs-triage', 'waiting-response']
+        labels: ['needs-triage', 'waiting-response', 'needs-rebase']
     steps:
       - name: Remove ${{ matrix.labels }} label
         uses: actions-ecosystem/action-remove-labels@v1

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,44 @@
+# GitHub Action reference: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+#
+# Automated handling of stale issues and pull requests.
+#
+# NOTE: When changing "days-before-*" values, please also update the "stale-issue-message" and/or
+# "stale-pr-message" values.
+
+name: stale
+
+on:
+  schedule:
+    #        ┌───────────── minute (0 - 59)
+    #        │ ┌───────────── hour (0 - 23)
+    #        │ │ ┌───────────── day of the month (1 - 31)
+    #        │ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+    #        │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+    #        * * * * *
+    - cron: '8 3 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          stale-issue-message: |
+            Marking this issue as stale due to 90 days of inactivity. This helps our maintainers find and focus on the active issues. If this issue receives no comments in the next 14 days it will automatically be closed. Maintainers can also remove the `stale` label.
+            If this issue was automatically closed and you feel this issue should be reopened, we encourage creating a new issue linking back to this one for added context. Thank you!
+          stale-pr-message: |
+            Marking this pull request as stale due to 30 days of inactivity. This helps our maintainers find and focus on the active pull requests. If this pull request receives no comments in the next 14 days it will automatically be closed. Maintainers can also remove the `stale` label.
+            If this pull request was automatically closed and you feel this pull request should be reopened, we encourage creating a new pull request linking back to this one for added context. Thank you!
+          close-issue-message: 'This issue was closed because it has been stale for 14 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stale for 14 days with no activity.'
+          days-before-issue-stale: 90
+          days-before-pr-stale: 30
+          days-before-issue-close: 14
+          days-before-pr-close: 14
+          exempt-issue-labels: keep-open,bug,enhancement


### PR DESCRIPTION
## Description

<!-- Which issue/s does this PR close? Is there any more context you can give the reviewer? -->

Adds workflows for:
- Marking issues and PRs as "stale" and then closing them after 2 weeks
- Adding "needs-triage" and conditionally "bug" labels (based on a regex) for newly opened issues
- Unmarking issues as "stale" or "waiting-response" whenever there is activity
- Removing labels "waiting-response" or "needs-triage" if an issue is closed with those labels

Note that I configured the stale workflow to never close an issue with a "bug", "enhancement", or "keep-open" label.

I tested most of this in my fork, but I have not tested the cron job workflow. It is copied from the action documentation, so it should work.

## PR Checklist

<!-- For a smooth review process, please run through this checklist before submitting a PR. -->

- [x] Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
- [x] [Examples](/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
- [x] New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
- [x] No new `//lintignore` comments that came from copied code. Linter rules are meant to be enforced on new code.
