### PR TITLE
Workflows: Fix issue where forks would still run EE tests

### DIFF
--- a/.github/workflows/pr-acceptance.yml
+++ b/.github/workflows/pr-acceptance.yml
@@ -38,6 +38,19 @@ jobs:
       - id: go-version
         run: echo "::set-output name=go-version::$(cat .go-version)"
 
+  # Check whether the LICENSE_ENCRYPTION_PASSWORD secret exists.
+  # Workaround for https://github.com/actions/runner/issues/520.
+  license-encryption-password:
+    runs-on: ubuntu-latest
+    outputs:
+      defined: ${{ steps.defined.outputs.defined }}
+    steps:
+      - id: defined
+        env:
+          LICENSE_ENCRYPTION_PASSWORD: ${{ secrets.LICENSE_ENCRYPTION_PASSWORD }}
+        if: ${{ env.LICENSE_ENCRYPTION_PASSWORD != '' }}
+        run: echo "::set-output name=defined::true"
+
   acceptance-ce:
     timeout-minutes: 60
     runs-on: ubuntu-latest
@@ -61,9 +74,12 @@ jobs:
       - run: make testacc
 
   acceptance-ee:
+    # Only run EE tests if the LICENSE_ENCRYPTION_PASSWORD secret exists, so that the workflow
+    # doesn't fail when code is pushed to a fork.
+    if: ${{ needs.license-encryption-password.outputs.defined }}
     timeout-minutes: 60
     runs-on: ubuntu-latest
-    needs: [go-version]
+    needs: [go-version, license-encryption-password]
     steps:
       - uses: actions/setup-go@v2
         with:


### PR DESCRIPTION
## Description

<!-- Which issue/s does this PR close? Is there any more context you can give the reviewer? -->

This is my last workflow-related PR, and it is a bug fix. 😛 

Minor annoyance. I saw workflow failures on my fork on the EE job, which was not supposed to run. It was due to a bug introduced in #426 where it does not check if the LICENSE_ENCRYPTION_PASSWORD is set, so the workflow would trigger anyway from the fork's main branch.

I copied this workflow code over from the `push.yml` one.

In the future we can probably de-duplicate some workflow config, but at the moment there are some bugs with workflow templating.
- https://github.community/t/support-for-yaml-anchors/16128
- https://github.community/t/ref-head-in-reusable-workflows/203690/66

## PR Checklist

<!-- For a smooth review process, please run through this checklist before submitting a PR. -->

- [x] Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
- [x] [Examples](/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
- [x] New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
- [x] No new `//lintignore` comments that came from copied code. Linter rules are meant to be enforced on new code.
