### PR TITLE
Fix issue in coverage tool

### DIFF
--- a/tools/passes/apicovered/apicovered.go
+++ b/tools/passes/apicovered/apicovered.go
@@ -42,6 +42,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 	}
 
 	process(result, goGitLab.TypeToFilenames, usage.Types)
+	process(result, goGitLab.FuncToFilenames, usage.Funcs)
 	process(result, goGitLab.MethodToFilenames, usage.Methods)
 	process(result, goGitLab.FieldToFilenames, usage.Fields)
 


### PR DESCRIPTION
## Description

<!-- Which issue/s does this PR close? Is there any more context you can give the reviewer? -->

Aghh, saw this right after hitting the merge button.

## PR Checklist

<!-- For a smooth review process, please run through this checklist before submitting a PR. -->

- [x] Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
- [x] [Examples](/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
- [x] New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
- [x] No new `//lintignore` comments that came from copied code. Linter rules are meant to be enforced on new code.
