### PR TITLE
Workflows: Automate applying merge-conflict label

### DIFF
--- a/.github/workflows/pr-check-conflicts.yml
+++ b/.github/workflows/pr-check-conflicts.yml
@@ -1,0 +1,28 @@
+# GitHub Action reference: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+
+name: pr-check-conflicts
+
+on:
+  # For adding the merge-conflict label.
+  push:
+    branches:
+      - main
+      - master
+  # For removing the merge-conflict label.
+  pull_request_target:
+    types: [synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      # Docs: https://github.com/marketplace/actions/label-conflicting-pull-requests
+      - uses: eps1lon/actions-label-merge-conflict@v2.0.1
+        with:
+          dirtyLabel: merge-conflict
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          commentOnDirty: 'This pull request has merge conflicts. Please rebase your branch onto `${{ github.event.repository.default_branch }}`.'
+          commentOnClean: 'Conflicts are resolved. Thank you! :grinning:'


### PR DESCRIPTION
## Description

<!-- Which issue/s does this PR close? Is there any more context you can give the reviewer? -->

Automatically adds and removes the `merge-conflict` label based on whether the PR has merge conflicts.

Action docs: https://github.com/marketplace/actions/label-conflicting-pull-requests

I configured it to comment on the PRs, but we can turn that off if it's too noisy.

Tested in my fork.

## PR Checklist

<!-- For a smooth review process, please run through this checklist before submitting a PR. -->

- [x] Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
- [x] [Examples](/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
- [x] New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
- [x] No new `//lintignore` comments that came from copied code. Linter rules are meant to be enforced on new code.
