### PR TITLE
Workflows: Prevent merging PRs with needs-rebase or do-not-merge labels

### DIFF
--- a/.github/workflows/pr-required-labels.yml
+++ b/.github/workflows/pr-required-labels.yml
@@ -1,0 +1,29 @@
+# GitHub Action reference: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+#
+# Enforce label requirements on pull requests, to prevent accidental merging.
+
+name: pr-required-labels
+
+on:
+  pull_request_target:
+    types: [opened, reopened, labeled, unlabeled]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  required-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check do-not-merge
+        uses: mheap/github-action-required-labels@v1
+        with:
+          mode: exactly
+          count: 0
+          labels: do-not-merge
+      - name: Check needs-rebase
+        uses: mheap/github-action-required-labels@v1
+        with:
+          mode: exactly
+          count: 0
+          labels: needs-rebase


### PR DESCRIPTION
## Description

<!-- Which issue/s does this PR close? Is there any more context you can give the reviewer? -->

This action fails if either `needs-rebase` or `do-not-merge` labels are present on the PR.

The benefit is we have a way to communicate that a PR should not be merged (`do-not-merge`) that has some enforcement with it.

I don't know how useful this is right now, but we can also expound on it to add other label rules, for example a PR must have one of N different labels before it can be merged. It could be useful for PR triaging purposes.

Tested in my fork.

## PR Checklist

<!-- For a smooth review process, please run through this checklist before submitting a PR. -->

- [x] Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
- [x] [Examples](/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
- [x] New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
- [x] No new `//lintignore` comments that came from copied code. Linter rules are meant to be enforced on new code.
