### PR TITLE
Add topic resource support, second trial

### DIFF
--- a/docs/resources/topic.md
+++ b/docs/resources/topic.md
@@ -1,0 +1,30 @@
+# gitlab\_topic
+
+This resource allows you to create and manage topics that are then assignable to projects. Topics are the successors for project tags. Aside from avoiding terminology collisions with Git tags, they are more descriptive and better searchable.
+
+For assigning topics, use the [project](./project.md) resource.
+
+## Example Usage
+
+```hcl
+resource "gitlab_topic" "functional-programming" {
+  name             = "Functional Programming"
+  description      = "In computer science, functional programming is a programming paradigm where programs are constructed by applying and composing functions."
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `name` - (Required) The name of the approval rule.
+
+* `description` - (Optional) A text describing the topic.
+
+## Import
+
+GitLab topics can also be imported, e.g.
+
+```
+$ terraform import gitlab_topic.functional-programming
+```

--- a/examples/resources/gitlab_topic/import.sh
+++ b/examples/resources/gitlab_topic/import.sh
@@ -1,0 +1,3 @@
+# You can import a topic to terraform state using `terraform import <resource>`.
+# for example:
+terraform terraform import gitlab_topic.functional-programming

--- a/examples/resources/gitlab_topic/resource.tf
+++ b/examples/resources/gitlab_topic/resource.tf
@@ -1,0 +1,4 @@
+resource "gitlab_topic" "functional-programming" {
+  name             = "Functional Programming"
+  description      = "In computer science, functional programming is a programming paradigm where programs are constructed by applying and composing functions."
+}

--- a/gitlab/provider.go
+++ b/gitlab/provider.go
@@ -108,8 +108,7 @@ func Provider() *schema.Provider {
 			"gitlab_project_freeze_period":      resourceGitlabProjectFreezePeriod(),
 			"gitlab_group_share_group":          resourceGitlabGroupShareGroup(),
 			"gitlab_project_badge":              resourceGitlabProjectBadge(),
-			"gitlab_group_badge":                resourceGitlabGroupBadge(),
-			"gitlab_repository_file":            resourceGitLabRepositoryFile(),
+			"gitlab_topic":                      resourceGitlabTopic(),
 		},
 	}
 

--- a/gitlab/resource_gitlab_topic.go
+++ b/gitlab/resource_gitlab_topic.go
@@ -1,9 +1,9 @@
 package gitlab
 
 import (
-	"fmt"
 	"log"
 	"net/http"
+	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/xanzy/go-gitlab"
@@ -44,12 +44,12 @@ func resourceGitlabTopicCreate(d *schema.ResourceData, meta interface{}) error {
 
 	log.Printf("[DEBUG] create gitlab topic %s", *options.Name)
 
-	label, _, err := client.Topics.CreateTopic(options)
+	topic, _, err := client.Topics.CreateTopic(options)
 	if err != nil {
 		return err
 	}
 
-	d.SetId(label.Name)
+	d.SetId(strconv.FormatInt(int64(topic.ID), 10))
 
 	return resourceGitlabTopicRead(d, meta)
 }
@@ -69,7 +69,7 @@ func resourceGitlabTopicRead(d *schema.ResourceData, meta interface{}) error {
 		return err
 	}
 
-	d.SetId(fmt.Sprintf("%d", topic.ID))
+	d.SetId(strconv.FormatInt(int64(topic.ID), 10))
 	d.Set("name", topic.Name)
 	d.Set("description", topic.Description)
 
@@ -99,9 +99,16 @@ func resourceGitlabTopicUpdate(d *schema.ResourceData, meta interface{}) error {
 }
 
 func resourceGitlabTopicDelete(d *schema.ResourceData, meta interface{}) error {
-	client := meta.(*gitlab.Client)
-	log.Printf("[DEBUG] Delete gitlab topic %s", d.Id())
 
-	_, err := client.Topics.DeleteTopic(d.Id())
-	return err
+	// TODO: Use outcommented code below as soon as deleting a topic is supported
+	log.Printf("[WARN] Not deleting gitlab topic %s as gitlab API doens't support deleting topics", d.Id())
+	return nil
+	/*
+		client := meta.(*gitlab.Client)
+		log.Printf("[DEBUG] Delete gitlab topic %s", d.Id())
+
+		_, err := client.Topics.DeleteTopic(d.Id())
+		return err
+
+	*/
 }

--- a/gitlab/resource_gitlab_topic.go
+++ b/gitlab/resource_gitlab_topic.go
@@ -23,12 +23,14 @@ func resourceGitlabTopic() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
+				Description: "The topic's name",
+				Type:        schema.TypeString,
+				Required:    true,
 			},
 			"description": {
-				Type:     schema.TypeString,
-				Optional: true,
+				Description: "A text describing the topic",
+				Type:        schema.TypeString,
+				Optional:    true,
 			},
 		},
 	}

--- a/gitlab/resource_gitlab_topic.go
+++ b/gitlab/resource_gitlab_topic.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net/http"
 	"strconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -66,9 +65,9 @@ func resourceGitlabTopicRead(ctx context.Context, d *schema.ResourceData, meta i
 	}
 	log.Printf("[DEBUG] read gitlab topic %d", topicID)
 
-	topic, resp, err := client.Topics.GetTopic(topicID, gitlab.WithContext(ctx))
+	topic, _, err := client.Topics.GetTopic(topicID, gitlab.WithContext(ctx))
 	if err != nil {
-		if resp != nil && resp.StatusCode == http.StatusNotFound {
+		if is404(err) {
 			log.Printf("[DEBUG] gitlab group %s not found so removing from state", d.Id())
 			d.SetId("")
 			return nil

--- a/gitlab/resource_gitlab_topic.go
+++ b/gitlab/resource_gitlab_topic.go
@@ -18,7 +18,7 @@ func resourceGitlabTopic() *schema.Resource {
 		UpdateContext: resourceGitlabTopicUpdate,
 		DeleteContext: resourceGitlabTopicDelete,
 		Importer: &schema.ResourceImporter{
-			State: schema.ImportStatePassthrough,
+			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema: map[string]*schema.Schema{

--- a/gitlab/resource_gitlab_topic.go
+++ b/gitlab/resource_gitlab_topic.go
@@ -1,0 +1,107 @@
+package gitlab
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/xanzy/go-gitlab"
+)
+
+func resourceGitlabTopic() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceGitlabTopicCreate,
+		Read:   resourceGitlabTopicRead,
+		Update: resourceGitlabTopicUpdate,
+		Delete: resourceGitlabTopicDelete,
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+		},
+	}
+}
+
+func resourceGitlabTopicCreate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	options := &gitlab.CreateTopicOptions{
+		Name: gitlab.String(d.Get("name").(string)),
+	}
+
+	if v, ok := d.GetOk("description"); ok {
+		options.Description = gitlab.String(v.(string))
+	}
+
+	log.Printf("[DEBUG] create gitlab topic %s", *options.Name)
+
+	label, _, err := client.Topics.CreateTopic(options)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(label.Name)
+
+	return resourceGitlabTopicRead(d, meta)
+}
+
+func resourceGitlabTopicRead(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	topicID := d.Id()
+	log.Printf("[DEBUG] read gitlab topic %s", topicID)
+
+	topic, resp, err := client.Topics.GetTopic(topicID, nil)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			log.Printf("[DEBUG] gitlab group %s not found so removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
+		return err
+	}
+
+	d.SetId(fmt.Sprintf("%d", topic.ID))
+	d.Set("name", topic.Name)
+	d.Set("description", topic.Description)
+
+	return nil
+}
+
+func resourceGitlabTopicUpdate(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	options := &gitlab.UpdateTopicOptions{}
+
+	if d.HasChange("name") {
+		options.Name = gitlab.String(d.Get("name").(string))
+	}
+
+	if d.HasChange("description") {
+		options.Description = gitlab.String(d.Get("description").(string))
+	}
+
+	log.Printf("[DEBUG] update gitlab topic %s", d.Id())
+
+	_, _, err := client.Topics.UpdateTopic(d.Id(), options)
+	if err != nil {
+		return err
+	}
+
+	return resourceGitlabTopicRead(d, meta)
+}
+
+func resourceGitlabTopicDelete(d *schema.ResourceData, meta interface{}) error {
+	client := meta.(*gitlab.Client)
+	log.Printf("[DEBUG] Delete gitlab topic %s", d.Id())
+
+	_, err := client.Topics.DeleteTopic(d.Id())
+	return err
+}

--- a/gitlab/resource_gitlab_topic.go
+++ b/gitlab/resource_gitlab_topic.go
@@ -100,15 +100,13 @@ func resourceGitlabTopicUpdate(d *schema.ResourceData, meta interface{}) error {
 
 func resourceGitlabTopicDelete(d *schema.ResourceData, meta interface{}) error {
 
-	// TODO: Use outcommented code below as soon as deleting a topic is supported
-	log.Printf("[WARN] Not deleting gitlab topic %s as gitlab API doens't support deleting topics", d.Id())
-	return nil
-	/*
-		client := meta.(*gitlab.Client)
-		log.Printf("[DEBUG] Delete gitlab topic %s", d.Id())
+	log.Printf("[WARN] Not deleting gitlab topic %s as gitlab API doens't support deleting topics. Instead emptying its description", d.Id())
 
-		_, err := client.Topics.DeleteTopic(d.Id())
-		return err
+	client := meta.(*gitlab.Client)
+	options := &gitlab.UpdateTopicOptions{
+		Description: gitlab.String(""),
+	}
 
-	*/
+	_, _, err := client.Topics.UpdateTopic(d.Id(), options)
+	return err
 }

--- a/gitlab/resource_gitlab_topic.go
+++ b/gitlab/resource_gitlab_topic.go
@@ -2,6 +2,7 @@ package gitlab
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/http"
 	"strconv"
@@ -51,7 +52,7 @@ func resourceGitlabTopicCreate(ctx context.Context, d *schema.ResourceData, meta
 		return diag.Errorf("Failed to create topic %q: %s", *options.Name, err)
 	}
 
-	d.SetId(strconv.FormatInt(int64(topic.ID), 10))
+	d.SetId(fmt.Sprintf("%d", topic.ID))
 
 	return resourceGitlabTopicRead(ctx, d, meta)
 }
@@ -75,7 +76,7 @@ func resourceGitlabTopicRead(ctx context.Context, d *schema.ResourceData, meta i
 		return diag.Errorf("Failed to read topic %d: %s", topicID, err)
 	}
 
-	d.SetId(strconv.FormatInt(int64(topic.ID), 10))
+	d.SetId(fmt.Sprintf("%d", topic.ID))
 	d.Set("name", topic.Name)
 	d.Set("description", topic.Description)
 

--- a/gitlab/resource_gitlab_topic_test.go
+++ b/gitlab/resource_gitlab_topic_test.go
@@ -1,0 +1,203 @@
+package gitlab
+
+/*
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/terraform"
+	"github.com/xanzy/go-gitlab"
+)
+
+func TestAccGitlabTopic_basic(t *testing.T) {
+	var topic gitlab.Topic
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGitlabTopicDestroy,
+		Steps: []resource.TestStep{
+			// Create a topic with default options
+			{
+				Config: testAccGitlabTopicCreateConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabTopicExists("gitlab_group_label.fixme", &topic),
+					testAccCheckGitlabTopicAttributes(&topic, &testAccGitlabTopicExpectedAttributes{
+						Name:        fmt.Sprintf("FIXME-%d", rInt),
+						Color:       "#ffcc00",
+						Description: "fix this test",
+					}),
+				),
+			},
+			// Update the topics values
+			{
+				Config: testAccGitlabTopicUpdateConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabTopicExists("gitlab_group_label.fixme", &topic),
+					testAccCheckGitlabTopicAttributes(&topic, &testAccGitlabTopicExpectedAttributes{
+						Name:        fmt.Sprintf("FIXME-%d", rInt),
+						Color:       "#ff0000",
+						Description: "red label",
+					}),
+				),
+			},
+			// Update the topic back to its initial state
+			{
+				Config: testAccGitlabTopicCreateConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabTopicExists("gitlab_group_label.fixme", &topic),
+					testAccCheckGitlabTopicAttributes(&topic, &testAccGitlabTopicExpectedAttributes{
+						Name:        fmt.Sprintf("FIXME-%d", rInt),
+						Color:       "#ff0000",
+						Description: "red label",
+					}),
+				),
+			},
+		},
+	})
+}
+
+// lintignore: AT002 // TODO: Resolve this tfproviderlint issue
+func TestAccGitlabTopic_import(t *testing.T) {
+	rInt := acctest.RandInt()
+	resourceName := "gitlab_group_label.fixme"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGitlabTopicDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGitlabTopicConfig(rInt),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportStateIdFunc: getTopicImportID(resourceName),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func getTopicImportID(n string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return "", fmt.Errorf("Not Found: %s", n)
+		}
+
+		labelID := rs.Primary.ID
+		if labelID == "" {
+			return "", fmt.Errorf("No deploy key ID is set")
+		}
+		groupID := rs.Primary.Attributes["group"]
+		if groupID == "" {
+			return "", fmt.Errorf("No group ID is set")
+		}
+
+		return fmt.Sprintf("%s:%s", groupID, labelID), nil
+	}
+}
+
+func testAccCheckGitlabTopicExists(n string, label *gitlab.Topic) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not Found: %s", n)
+		}
+
+		labelName := rs.Primary.ID
+		groupName := rs.Primary.Attributes["group"]
+		if groupName == "" {
+			return fmt.Errorf("No group ID is set")
+		}
+		conn := testAccProvider.Meta().(*gitlab.Client)
+
+		labels, _, err := conn.Topics.ListTopics(groupName, &gitlab.ListTopicsOptions{PerPage: 1000})
+		if err != nil {
+			return err
+		}
+		for _, gotLabel := range labels {
+			if gotLabel.Name == labelName {
+				*label = *gotLabel
+				return nil
+			}
+		}
+		return fmt.Errorf("Label does not exist")
+	}
+}
+
+type testAccGitlabTopicExpectedAttributes struct {
+	Name        string
+	Color       string
+	Description string
+}
+
+func testAccCheckGitlabTopicAttributes(label *gitlab.Topic, want *testAccGitlabTopicExpectedAttributes) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if label.Name != want.Name {
+			return fmt.Errorf("got name %q; want %q", label.Name, want.Name)
+		}
+
+		if label.Description != want.Description {
+			return fmt.Errorf("got description %q; want %q", label.Description, want.Description)
+		}
+
+		if label.Color != want.Color {
+			return fmt.Errorf("got color %q; want %q", label.Color, want.Color)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckGitlabTopicDestroy(s *terraform.State) error {
+	conn := testAccProvider.Meta().(*gitlab.Client)
+
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "gitlab_group" {
+			continue
+		}
+
+		group, resp, err := conn.Groups.GetGroup(rs.Primary.ID, nil)
+		if err == nil {
+			if group != nil && fmt.Sprintf("%d", group.ID) == rs.Primary.ID {
+				if group.MarkedForDeletionOn == nil {
+					return fmt.Errorf("Group still exists")
+				}
+			}
+		}
+		if resp.StatusCode != 404 {
+			return err
+		}
+		return nil
+	}
+	return nil
+}
+
+func testAccGitlabTopicCreateConfig(rInt int) string {
+	return fmt.Sprintf(`
+resource "gitlab_topic" "foo" {
+  name             = "foo-%d"
+  path             = "foo-%d"
+  description      = "Terraform acceptance tests"
+  visibility_level = "public"
+}
+	`, rInt)
+}
+
+func testAccGitlabTopicUpdateConfig(rInt int) string {
+	return fmt.Sprintf(`
+resource "gitlab_topic" "foo" {
+  name             = "foo-%d"
+  path             = "foo-%d"
+  description      = "Terraform acceptance tests"
+  visibility_level = "public"
+}
+	`, rInt)
+}
+*/

--- a/gitlab/resource_gitlab_topic_test.go
+++ b/gitlab/resource_gitlab_topic_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/xanzy/go-gitlab"
 )
 
-func TestAccGitlabTopic(t *testing.T) {
+func TestAccGitlabTopic_basic(t *testing.T) {
 	var topic gitlab.Topic
 	rInt := acctest.RandInt()
 

--- a/gitlab/resource_gitlab_topic_test.go
+++ b/gitlab/resource_gitlab_topic_test.go
@@ -1,17 +1,17 @@
 package gitlab
 
-/*
 import (
 	"fmt"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/acctest"
+
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/xanzy/go-gitlab"
 )
 
-func TestAccGitlabTopic_basic(t *testing.T) {
+func TestAccGitlabTopic(t *testing.T) {
 	var topic gitlab.Topic
 	rInt := acctest.RandInt()
 
@@ -22,37 +22,32 @@ func TestAccGitlabTopic_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create a topic with default options
 			{
-				Config: testAccGitlabTopicCreateConfig(rInt),
+				Config: testAccGitlabTopicRequiredConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabTopicExists("gitlab_group_label.fixme", &topic),
+					testAccCheckGitlabTopicExists("gitlab_topic.foo", &topic),
 					testAccCheckGitlabTopicAttributes(&topic, &testAccGitlabTopicExpectedAttributes{
-						Name:        fmt.Sprintf("FIXME-%d", rInt),
-						Color:       "#ffcc00",
-						Description: "fix this test",
+						Name: fmt.Sprintf("foo-req-%d", rInt),
 					}),
 				),
 			},
 			// Update the topics values
 			{
-				Config: testAccGitlabTopicUpdateConfig(rInt),
+				Config: testAccGitlabTopicFullConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabTopicExists("gitlab_group_label.fixme", &topic),
+					testAccCheckGitlabTopicExists("gitlab_topic.foo", &topic),
 					testAccCheckGitlabTopicAttributes(&topic, &testAccGitlabTopicExpectedAttributes{
-						Name:        fmt.Sprintf("FIXME-%d", rInt),
-						Color:       "#ff0000",
-						Description: "red label",
+						Name:        fmt.Sprintf("foo-full-%d", rInt),
+						Description: "Terraform acceptance tests",
 					}),
 				),
 			},
-			// Update the topic back to its initial state
+			// Update the topics values back to their initial state
 			{
-				Config: testAccGitlabTopicCreateConfig(rInt),
+				Config: testAccGitlabTopicRequiredConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabTopicExists("gitlab_group_label.fixme", &topic),
+					testAccCheckGitlabTopicExists("gitlab_topic.foo", &topic),
 					testAccCheckGitlabTopicAttributes(&topic, &testAccGitlabTopicExpectedAttributes{
-						Name:        fmt.Sprintf("FIXME-%d", rInt),
-						Color:       "#ff0000",
-						Description: "red label",
+						Name: fmt.Sprintf("foo-req-%d", rInt),
 					}),
 				),
 			},
@@ -60,95 +55,36 @@ func TestAccGitlabTopic_basic(t *testing.T) {
 	})
 }
 
-// lintignore: AT002 // TODO: Resolve this tfproviderlint issue
-func TestAccGitlabTopic_import(t *testing.T) {
-	rInt := acctest.RandInt()
-	resourceName := "gitlab_group_label.fixme"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
-		CheckDestroy: testAccCheckGitlabTopicDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccGitlabTopicConfig(rInt),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportStateIdFunc: getTopicImportID(resourceName),
-				ImportState:       true,
-				ImportStateVerify: true,
-			},
-		},
-	})
-}
-
-func getTopicImportID(n string) resource.ImportStateIdFunc {
-	return func(s *terraform.State) (string, error) {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return "", fmt.Errorf("Not Found: %s", n)
-		}
-
-		labelID := rs.Primary.ID
-		if labelID == "" {
-			return "", fmt.Errorf("No deploy key ID is set")
-		}
-		groupID := rs.Primary.Attributes["group"]
-		if groupID == "" {
-			return "", fmt.Errorf("No group ID is set")
-		}
-
-		return fmt.Sprintf("%s:%s", groupID, labelID), nil
-	}
-}
-
-func testAccCheckGitlabTopicExists(n string, label *gitlab.Topic) resource.TestCheckFunc {
+func testAccCheckGitlabTopicExists(n string, assign *gitlab.Topic) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
-			return fmt.Errorf("Not Found: %s", n)
+			return fmt.Errorf("not Found: %s", n)
 		}
 
-		labelName := rs.Primary.ID
-		groupName := rs.Primary.Attributes["group"]
-		if groupName == "" {
-			return fmt.Errorf("No group ID is set")
-		}
+		topicID := rs.Primary.ID
 		conn := testAccProvider.Meta().(*gitlab.Client)
 
-		labels, _, err := conn.Topics.ListTopics(groupName, &gitlab.ListTopicsOptions{PerPage: 1000})
-		if err != nil {
-			return err
-		}
-		for _, gotLabel := range labels {
-			if gotLabel.Name == labelName {
-				*label = *gotLabel
-				return nil
-			}
-		}
-		return fmt.Errorf("Label does not exist")
+		topic, _, err := conn.Topics.GetTopic(topicID)
+		*assign = *topic
+
+		return err
 	}
 }
 
 type testAccGitlabTopicExpectedAttributes struct {
 	Name        string
-	Color       string
 	Description string
 }
 
-func testAccCheckGitlabTopicAttributes(label *gitlab.Topic, want *testAccGitlabTopicExpectedAttributes) resource.TestCheckFunc {
+func testAccCheckGitlabTopicAttributes(topic *gitlab.Topic, want *testAccGitlabTopicExpectedAttributes) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
-		if label.Name != want.Name {
-			return fmt.Errorf("got name %q; want %q", label.Name, want.Name)
+		if topic.Name != want.Name {
+			return fmt.Errorf("got name %q; want %q", topic.Name, want.Name)
 		}
 
-		if label.Description != want.Description {
-			return fmt.Errorf("got description %q; want %q", label.Description, want.Description)
-		}
-
-		if label.Color != want.Color {
-			return fmt.Errorf("got color %q; want %q", label.Color, want.Color)
+		if topic.Description != want.Description {
+			return fmt.Errorf("got description %q; want %q", topic.Description, want.Description)
 		}
 
 		return nil
@@ -159,16 +95,16 @@ func testAccCheckGitlabTopicDestroy(s *terraform.State) error {
 	conn := testAccProvider.Meta().(*gitlab.Client)
 
 	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "gitlab_group" {
+		if rs.Type != "gitlab_topic" {
 			continue
 		}
 
-		group, resp, err := conn.Groups.GetGroup(rs.Primary.ID, nil)
+		topic, resp, err := conn.Topics.GetTopic(rs.Primary.ID)
 		if err == nil {
-			if group != nil && fmt.Sprintf("%d", group.ID) == rs.Primary.ID {
-				if group.MarkedForDeletionOn == nil {
-					return fmt.Errorf("Group still exists")
-				}
+			if topic != nil && fmt.Sprintf("%d", topic.ID) == rs.Primary.ID {
+				// TODO: Return error as soon as deleting a topic is supported
+				return nil
+				//				return fmt.Errorf("topic still exists")
 			}
 		}
 		if resp.StatusCode != 404 {
@@ -179,25 +115,17 @@ func testAccCheckGitlabTopicDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccGitlabTopicCreateConfig(rInt int) string {
+func testAccGitlabTopicRequiredConfig(rInt int) string {
 	return fmt.Sprintf(`
 resource "gitlab_topic" "foo" {
-  name             = "foo-%d"
-  path             = "foo-%d"
-  description      = "Terraform acceptance tests"
-  visibility_level = "public"
-}
-	`, rInt)
+  name             = "foo-req-%d"
+}`, rInt)
 }
 
-func testAccGitlabTopicUpdateConfig(rInt int) string {
+func testAccGitlabTopicFullConfig(rInt int) string {
 	return fmt.Sprintf(`
 resource "gitlab_topic" "foo" {
-  name             = "foo-%d"
-  path             = "foo-%d"
+  name             = "foo-full-%d"
   description      = "Terraform acceptance tests"
-  visibility_level = "public"
+}`, rInt)
 }
-	`, rInt)
-}
-*/

--- a/gitlab/resource_gitlab_topic_test.go
+++ b/gitlab/resource_gitlab_topic_test.go
@@ -62,6 +62,12 @@ func TestAccGitlabTopic(t *testing.T) {
 					}),
 				),
 			},
+			// Verify import
+			{
+				ResourceName:      "gitlab_topic.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
 }


### PR DESCRIPTION
## Description

This PR replaces #764. Also see reviews/discussions there. 

## PR Checklist

- [x] Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
- [ ] [Examples](/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
- [x] New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
- [x] No new `//lintignore` comments that came from copied code. Linter rules are meant to be enforced on new code.
