### PR TITLE
Add missing line continuation in example terraform init command

### DIFF
--- a/examples/gitlab-managed-state/README.md
+++ b/examples/gitlab-managed-state/README.md
@@ -32,7 +32,7 @@ $ terraform init \
     -backend-config="password=${ACCESS_TOKEN}" \
     -backend-config="lock_method=POST" \
     -backend-config="unlock_method=DELETE" \
-    -backend-config="retry_wait_min=5"
+    -backend-config="retry_wait_min=5" \
     -backend-config="password=${ACCESS_TOKEN}"
 ```
 


### PR DESCRIPTION
Fixes missing line continuation in the example `terraform init` command in the GitLab managed state README.

