### PR TITLE
Workflows: stale adjustment

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -30,15 +30,17 @@ jobs:
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
           stale-issue-message: |
-            Marking this issue as stale due to 90 days of inactivity. This helps our maintainers find and focus on the active issues. If this issue receives no comments in the next 14 days it will automatically be closed. Maintainers can also remove the `stale` label.
-            If this issue was automatically closed and you feel this issue should be reopened, we encourage creating a new issue linking back to this one for added context. Thank you!
+            Marking this issue as stale due to 120 days of inactivity. If this issue receives no comments in the next 30 days it will be closed. Maintainers can also remove the `stale` label.
+            
+            Please comment with more information if you would like this issue to remain open.
           stale-pr-message: |
-            Marking this pull request as stale due to 30 days of inactivity. This helps our maintainers find and focus on the active pull requests. If this pull request receives no comments in the next 14 days it will automatically be closed. Maintainers can also remove the `stale` label.
-            If this pull request was automatically closed and you feel this pull request should be reopened, we encourage creating a new pull request linking back to this one for added context. Thank you!
+            Marking this pull request as stale due to 30 days of inactivity. If this pull request receives no comments in the next 14 days it will be closed. Maintainers can also remove the `stale` label.
+            
+            To help this pull request get reviewed, please check that it is rebased onto the latest ${{ github.event.repository.default_branch }} and is passing automated checks. It also helps if you could reference an issue that the pull request resolves, and create one if it doesn't exist.
           close-issue-message: 'This issue was closed because it has been stale for 14 days with no activity.'
           close-pr-message: 'This PR was closed because it has been stale for 14 days with no activity.'
-          days-before-issue-stale: 90
+          days-before-issue-stale: 120
           days-before-pr-stale: 30
-          days-before-issue-close: 14
+          days-before-issue-close: 30
           days-before-pr-close: 14
-          exempt-issue-labels: keep-open,bug,enhancement
+          exempt-issue-labels: keep-open,bug,enhancement,documentation


### PR DESCRIPTION
## Description

<!-- Which issue/s does this PR close? Is there any more context you can give the reviewer? -->

Some minor adjustments based on early feedback to the stale workflow.

- Increase inactivity time from 90 days to 120 days
- Increase time before closing issue from 14 days to 30 days
- Add `documentation` as another label which can prevent an issue from being stale (idea being that for now we don't make an issue stale if it fits into a triage status that we are able to act upon)
- Minor tweaking of language in the message to be more positive by encouraging new information in the case of an issue, and regular PR hygiene in the case of a PR.

I'd like it if we could merge this before the next batch goes out today. 😄 

## PR Checklist

<!-- For a smooth review process, please run through this checklist before submitting a PR. -->

- [x] Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
- [x] [Examples](/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
- [x] New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
- [x] No new `//lintignore` comments that came from copied code. Linter rules are meant to be enforced on new code.
