### PR TITLE
resource/gitlab_project: correctly handle push rules add and edit

### DIFF
--- a/gitlab/resource_gitlab_project_test.go
+++ b/gitlab/resource_gitlab_project_test.go
@@ -398,6 +398,27 @@ func TestAccGitlabProject_archiveOnDestroy(t *testing.T) {
 	})
 }
 
+func TestAccGitlabProject_setSinglePushRuleToDefault(t *testing.T) {
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckGitlabProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				SkipFunc: isRunningInCE,
+				Config: testAccGitlabProjectConfigPushRules(rInt, `
+member_check = false
+`),
+				Check: testAccCheckGitlabProjectPushRules("gitlab_project.foo", &gitlab.ProjectPushRules{
+					MemberCheck: false,
+				}),
+			},
+		},
+	})
+}
+
 func TestAccGitlabProject_IssueMergeRequestTemplates(t *testing.T) {
 	var project gitlab.Project
 	rInt := acctest.RandInt()


### PR DESCRIPTION
This is a possible approach to fix https://github.com/gitlabhq/terraform-provider-gitlab/issues/836. Even though, I am not sure if that is
really that elegant of a solution ...

The root problem here is that the SDK v2 doesn't support to check if an
attribute value was set in config, state or the plan. During creation of
push rules, we don't have a way to distinguish between the default and
if the user has set the default explicitly. This makes the behavior
working for all cases (AFAIK) (incl. changing the instance default push
rules, no automated test possible yet).

This will be possbile in the new terraform provider framework