### PR TITLE
datasource/gitlab_user(s): aligned email description with upstream API. Refs #839

### DIFF
--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -33,7 +33,7 @@ data "gitlab_user" "example-two" {
 
 ### Optional
 
-- **email** (String) The email address of the user.
+- **email** (String) The public email address of the user. **Note**: before GitLab 14.8 the lookup was based on the users primary email address.
 - **id** (String) The ID of this resource.
 - **user_id** (Number) The ID of the user.
 - **username** (String) The username of the user.

--- a/gitlab/data_source_gitlab_user.go
+++ b/gitlab/data_source_gitlab_user.go
@@ -39,7 +39,7 @@ func dataSourceGitlabUser() *schema.Resource {
 				},
 			},
 			"email": {
-				Description: "The email address of the user.",
+				Description: "The public email address of the user. **Note**: before GitLab 14.8 the lookup was based on the users primary email address.",
 				Type:        schema.TypeString,
 				Computed:    true,
 				Optional:    true,

--- a/gitlab/data_source_gitlab_users.go
+++ b/gitlab/data_source_gitlab_users.go
@@ -88,7 +88,7 @@ func dataSourceGitlabUsers() *schema.Resource {
 							Computed:    true,
 						},
 						"email": {
-							Description: "The e-mail address of the user.",
+							Description: "The public email address of the user. **Note**: before GitLab 14.8 the lookup was based on the users primary email address.",
 							Type:        schema.TypeString,
 							Computed:    true,
 						},


### PR DESCRIPTION
Refs #839

see https://gitlab.com/gitlab-org/gitlab/-/commit/eb4d94f44a42848dcaffd4afd499b8559d1b3d4e
which contains a change to lookup the user by its public email address instead of the primary one.
