### PR TITLE
Fix gitlab_user datasource crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## 3.9.0 (2022-01-04)
+## 3.9.1 (Unreleased)
+
+BUGFIXES:
+
+* Fix crash in `gitlab_user` data source
+
+## 3.9.0 (2022-02-04)
 
 FEATURES:
 

--- a/gitlab/data_source_gitlab_user.go
+++ b/gitlab/data_source_gitlab_user.go
@@ -231,7 +231,13 @@ func dataSourceGitlabUserRead(ctx context.Context, d *schema.ResourceData, meta 
 	d.Set("state", user.State)
 	d.Set("external", user.External)
 	d.Set("extern_uid", user.ExternUID)
-	d.Set("created_at", user.CreatedAt.String())
+
+	if user.CreatedAt != nil {
+		d.Set("created_at", user.CreatedAt.String())
+	} else {
+		d.Set("created_at", "")
+	}
+
 	d.Set("organization", user.Organization)
 	d.Set("two_factor_enabled", user.TwoFactorEnabled)
 	d.Set("note", user.Note)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.16
 require (
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/aws/aws-sdk-go v1.37.0 // indirect
-	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-retryablehttp v0.7.0
 	github.com/hashicorp/hcl/v2 v2.8.2 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.10.1


### PR DESCRIPTION
## Description

<!-- Which issue/s does this PR close? Is there any more context you can give the reviewer? -->

fixes #841 

We do not have a `created_at` attribute on the `gitlab_user` resource; only the data-source.

I'm not sure why the panic was not caught in our tests, but I assume it has to do with how we create the users in the test. The stack trace in the bug report made this bug very obvious, so I'm confident in the change regardless.

@nagyv Could you release a patch after merging this please? (This is a regression in 3.9.0 resulting from #725)

## PR Checklist

<!-- For a smooth review process, please run through this checklist before submitting a PR. -->

- [x] Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
- [x] [Examples](/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
- [x] New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
- [x] No new `//lintignore` comments that came from copied code. Linter rules are meant to be enforced on new code.
