### PR TITLE
Workflows: Disable triage labels for collaborators

### DIFF
--- a/.github/workflows/issue-comment-created.yml
+++ b/.github/workflows/issue-comment-created.yml
@@ -12,8 +12,19 @@ permissions:
 jobs:
   remove-labels:
     runs-on: ubuntu-latest
+    # This job contains steps which are expected to fail.
+    continue-on-error: true
     steps:
+      - name: Is comment from a collaborator?
+        uses: octokit/request-action@v2.x
+        with:
+          route: GET /repos/${{ github.repository }}/collaborators/${{ github.event.sender.login }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Only remove labels if they are NOT a collaborator.
+      # Reason being, a collaborator may post a comment and add a waiting-response label.
       - uses: actions-ecosystem/action-remove-labels@v1
+        if: ${{ failure() }}
         with:
           labels: |
             stale

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -12,9 +12,21 @@ permissions:
 jobs:
   add-labels:
     runs-on: ubuntu-latest
+    # This job contains steps which are expected to fail.
+    continue-on-error: true
     steps:
+      - name: Is opened by a collaborator?
+        uses: octokit/request-action@v2.x
+        with:
+          route: GET /repos/${{ github.repository }}/collaborators/${{ github.event.sender.login }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Only add triage labels if they are NOT a collaborator.
+      # This prevents the needs-triage label from being added.
       - uses: actions/checkout@v2
+        if: ${{ failure() }}
       - uses: github/issue-labeler@v2.4
+        if: ${{ failure() }}
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/labeler-issue-triage.yml


### PR DESCRIPTION
## Description

<!-- Which issue/s does this PR close? Is there any more context you can give the reviewer? -->

Fixed some annoyances fighting with automation over labels.
- Issues opened by collaborators now won't get labels added (e.g. "needs-triage")
- Comments from collaborators now won't cause labels to be removed (e.g. "waiting-response")

Tested in my fork 👍 

## PR Checklist

<!-- For a smooth review process, please run through this checklist before submitting a PR. -->

- [x] Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
- [x] [Examples](/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
- [x] New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
- [x] No new `//lintignore` comments that came from copied code. Linter rules are meant to be enforced on new code.
