### PR TITLE
Support creating project in group without default branch protection

### DIFF
--- a/internal/provider/resource_gitlab_group.go
+++ b/internal/provider/resource_gitlab_group.go
@@ -208,7 +208,9 @@ func resourceGitlabGroupCreate(ctx context.Context, d *schema.ResourceData, meta
 		options.ParentID = gitlab.Int(v.(int))
 	}
 
-	if v, ok := d.GetOk("default_branch_protection"); ok {
+	// nolint:staticcheck // SA1019 ignore deprecated GetOkExists
+	// lintignore: XR001 // TODO: replace with alternative for GetOkExists
+	if v, ok := d.GetOkExists("default_branch_protection"); ok {
 		options.DefaultBranchProtection = gitlab.Int(v.(int))
 	}
 

--- a/internal/provider/resource_gitlab_group_test.go
+++ b/internal/provider/resource_gitlab_group_test.go
@@ -41,7 +41,7 @@ func TestAccGitlabGroup_basic(t *testing.T) {
 			},
 			// Update the group to change the description
 			{
-				Config: testAccGitlabGroupUpdateConfig(rInt),
+				Config: testAccGitlabGroupUpdateConfig(rInt, 1),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabGroupExists("gitlab_group.foo", &group),
 					testAccCheckGitlabGroupAttributes(&group, &testAccGitlabGroupExpectedAttributes{
@@ -60,6 +60,30 @@ func TestAccGitlabGroup_basic(t *testing.T) {
 						MentionsDisabled:        true,
 						ShareWithGroupLock:      true,
 						DefaultBranchProtection: 1,
+					}),
+				),
+			},
+			// Update the group to use zero-value `default_branch_protection`
+			{
+				Config: testAccGitlabGroupUpdateConfig(rInt, 0),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabGroupExists("gitlab_group.foo", &group),
+					testAccCheckGitlabGroupAttributes(&group, &testAccGitlabGroupExpectedAttributes{
+						Name:                    fmt.Sprintf("bar-name-%d", rInt),
+						Path:                    fmt.Sprintf("bar-path-%d", rInt),
+						Description:             "Terraform acceptance tests! Updated description",
+						LFSEnabled:              false,
+						Visibility:              "public", // default value
+						RequestAccessEnabled:    true,
+						ProjectCreationLevel:    "developer",
+						SubGroupCreationLevel:   "maintainer",
+						RequireTwoFactorAuth:    true,
+						TwoFactorGracePeriod:    56,
+						AutoDevopsEnabled:       true,
+						EmailsDisabled:          true,
+						MentionsDisabled:        true,
+						ShareWithGroupLock:      true,
+						DefaultBranchProtection: 0,
 					}),
 				),
 			},
@@ -398,7 +422,7 @@ resource "gitlab_group" "foo" {
   `, rInt, rInt)
 }
 
-func testAccGitlabGroupUpdateConfig(rInt int) string {
+func testAccGitlabGroupUpdateConfig(rInt int, defaultBranchProtection int) string {
 	return fmt.Sprintf(`
 resource "gitlab_group" "foo" {
   name = "bar-name-%d"
@@ -414,13 +438,13 @@ resource "gitlab_group" "foo" {
   emails_disabled = true
   mentions_disabled = true
   share_with_group_lock = true
-  default_branch_protection = 1
+  default_branch_protection = %d
 
   # So that acceptance tests can be run in a gitlab organization
   # with no billing
   visibility_level = "public"
 }
-  `, rInt, rInt)
+  `, rInt, rInt, defaultBranchProtection)
 }
 
 func testAccGitlabNestedGroupConfig(rInt int) string {

--- a/internal/provider/resource_gitlab_project.go
+++ b/internal/provider/resource_gitlab_project.go
@@ -600,8 +600,8 @@ func resourceGitlabProjectCreate(ctx context.Context, d *schema.ResourceData, me
 		}
 
 		log.Printf("[DEBUG] check for protection on old default branch %q for project %q", oldDefaultBranch, d.Id())
-		branch, resp, err := client.ProtectedBranches.GetProtectedBranch(project.ID, oldDefaultBranch, gitlab.WithContext(ctx))
-		if err != nil && resp.StatusCode != http.StatusNotFound {
+		branch, _, err := client.ProtectedBranches.GetProtectedBranch(project.ID, oldDefaultBranch, gitlab.WithContext(ctx))
+		if err != nil && !is404(err) {
 			return diag.Errorf("Failed to check for protected default branch %q for project %q: %v", oldDefaultBranch, d.Id(), err)
 		}
 		if branch == nil {

--- a/internal/provider/resource_gitlab_project_test.go
+++ b/internal/provider/resource_gitlab_project_test.go
@@ -411,6 +411,23 @@ member_check = false
 	})
 }
 
+func TestAccGitlabProject_groupWithoutDefaultBranchProtection(t *testing.T) {
+	var project gitlab.Project
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckGitlabProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccGitlabProjectConfigWithoutDefaultBranchProtection(rInt),
+				Check:  testAccCheckGitlabProjectExists("gitlab_project.foo", &project),
+			},
+		},
+	})
+}
+
 func TestAccGitlabProject_IssueMergeRequestTemplates(t *testing.T) {
 	var project gitlab.Project
 	rInt := acctest.RandInt()
@@ -1071,6 +1088,23 @@ resource "gitlab_project" "foo" {
   # with no billing
   visibility_level = "public"
   build_coverage_regex = "foo"
+}
+	`, rInt, rInt, rInt)
+}
+
+func testAccGitlabProjectConfigWithoutDefaultBranchProtection(rInt int) string {
+	return fmt.Sprintf(`
+resource "gitlab_group" "foo" {
+  name = "foogroup-%d"
+  path = "foogroup-%d"
+  default_branch_protection = 0
+  visibility_level = "public"
+}
+
+resource "gitlab_project" "foo" {
+  name = "foo-%d"
+  description = "Terraform acceptance tests"
+  namespace_id = "${gitlab_group.foo.id}"
 }
 	`, rInt, rInt, rInt)
 }


### PR DESCRIPTION
This change includes what is in #760 from @switchboardOp, but adds an acceptance tests.

I also had to fix the `gitlab_group` resource to support groups setting the default branch protection to `0`.

Closes #759 
Closes #760 
