### PR TITLE
Add failing group variable update test to test issue #861

### DIFF
--- a/internal/provider/environment_scope_helper.go
+++ b/internal/provider/environment_scope_helper.go
@@ -1,0 +1,26 @@
+package provider
+
+import (
+	"context"
+	"net/url"
+
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/xanzy/go-gitlab"
+)
+
+// withEnvironmentScopeFilter adds the environment scope filter query parameter to the URL.
+// This function is supposed to be used as `gitlab.RequestOptionFunc` parameter.
+// The parameter is documented in the upstream GitLab API docs:
+// https://docs.gitlab.com/ee/api/project_level_variables.html#the-filter-parameter
+func withEnvironmentScopeFilter(ctx context.Context, environmentScope string) gitlab.RequestOptionFunc {
+	return func(req *retryablehttp.Request) error {
+		*req = *req.WithContext(ctx)
+		query, err := url.ParseQuery(req.Request.URL.RawQuery)
+		if err != nil {
+			return err
+		}
+		query.Set("filter[environment_scope]", environmentScope)
+		req.Request.URL.RawQuery = query.Encode()
+		return nil
+	}
+}

--- a/internal/provider/resource_gitlab_project_variable.go
+++ b/internal/provider/resource_gitlab_project_variable.go
@@ -5,10 +5,8 @@ import (
 	"errors"
 	"log"
 	"net/http"
-	"net/url"
 	"strings"
 
-	retryablehttp "github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	gitlab "github.com/xanzy/go-gitlab"
@@ -228,19 +226,6 @@ func isInvalidValueError(err error) bool {
 		httpErr.Response.StatusCode == http.StatusBadRequest &&
 		strings.Contains(httpErr.Message, "value") &&
 		strings.Contains(httpErr.Message, "invalid")
-}
-
-func withEnvironmentScopeFilter(ctx context.Context, environmentScope string) gitlab.RequestOptionFunc {
-	return func(req *retryablehttp.Request) error {
-		*req = *req.WithContext(ctx)
-		query, err := url.ParseQuery(req.Request.URL.RawQuery)
-		if err != nil {
-			return err
-		}
-		query.Set("filter[environment_scope]", environmentScope)
-		req.Request.URL.RawQuery = query.Encode()
-		return nil
-	}
 }
 
 var errProjectVariableNotExist = errors.New("project variable does not exist")


### PR DESCRIPTION
It's currently sporadically failing, because of the upstream bug here: https://gitlab.com/gitlab-org/gitlab/-/issues/333296

I've also refactored the `withEnvironmentScopeFilter` function into a separate file.