### PR TITLE
resource/gitlab_project: fix backwards-compatibility with 14.1 regarding the `squash_option`. Closes #770

### DIFF
--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -78,7 +78,7 @@ resource "gitlab_project" "example-two" {
 - **request_access_enabled** (Boolean) Allow users to request member access.
 - **shared_runners_enabled** (Boolean) Enable shared runners for this project.
 - **snippets_enabled** (Boolean) Enable snippets for the project.
-- **squash_option** (String) Squash commits when merge request. Valid values are `never`, `always`, `default_on`, or `default_off`. The default value is `default_off`.
+- **squash_option** (String) Squash commits when merge request. Valid values are `never`, `always`, `default_on`, or `default_off`. The default value is `default_off`. [GitLab >= 14.1]
 - **tags** (Set of String) Tags (topics) of the project.
 - **template_name** (String) When used without use_custom_template, name of a built-in project template. When used with use_custom_template, name of a custom project template. This option is mutually exclusive with `template_project_id`.
 - **template_project_id** (Number) When used with use_custom_template, project ID of a custom project template. This is preferable to using template_name since template_name may be ambiguous (enterprise edition). This option is mutually exclusive with `template_name`.

--- a/internal/provider/resource_gitlab_project_test.go
+++ b/internal/provider/resource_gitlab_project_test.go
@@ -964,11 +964,11 @@ func testAccCheckAggregateGitlabProject(expected, received *gitlab.Project) reso
 				}
 			}
 
-			if err := resourceGitlabProjectSetToState(expectedData, expected); err != nil {
+			if err := resourceGitlabProjectSetToState(testGitlabClient, expectedData, expected); err != nil {
 				return err
 			}
 
-			if err := resourceGitlabProjectSetToState(receivedData, received); err != nil {
+			if err := resourceGitlabProjectSetToState(testGitlabClient, receivedData, received); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
…
I gotta admit that I'm not support happy with the implementation,
nor the approach in general.

However, I think we agree that it's best to not break backwards
compatiblity as first priority.

In any case, we have #550 to discuss that :)

Closes #770
Closes #776
