### PR TITLE
resource/gitlab_group_ldap_link: remove doc for import, because it is not supported

### DIFF
--- a/docs/resources/group_ldap_link.md
+++ b/docs/resources/group_ldap_link.md
@@ -37,11 +37,4 @@ resource "gitlab_group_ldap_link" "test" {
 - **group_access** (String) Minimum access level for members of the LDAP group. Valid values are: `no one`, `minimal`, `guest`, `reporter`, `developer`, `maintainer`, `owner`, `master`
 - **id** (String) The ID of this resource.
 
-## Import
 
-Import is supported using the following syntax:
-
-```shell
-# GitLab group ldap links can be imported using an id made up of `ldap_provider:cn`, e.g.
-terraform import gitlab_group_ldap_link.test "ldapmain:testuser"
-```

--- a/examples/resources/gitlab_group_ldap_link/import.sh
+++ b/examples/resources/gitlab_group_ldap_link/import.sh
@@ -1,2 +1,0 @@
-# GitLab group ldap links can be imported using an id made up of `ldap_provider:cn`, e.g.
-terraform import gitlab_group_ldap_link.test "ldapmain:testuser"


### PR DESCRIPTION
This is very unsatisfying, because I don't see a reason that the resource couldn't support import.
However, I suspect a necessary incompatibility there - I'll open another issue -> #869.

Closes #448