### PR TITLE
Fix gitlab_group_ldap_link panic on group_access attribute and re-enable tests

### DIFF
--- a/internal/provider/resource_gitlab_group_ldap_link.go
+++ b/internal/provider/resource_gitlab_group_ldap_link.go
@@ -140,7 +140,7 @@ func resourceGitlabGroupLdapLinkRead(ctx context.Context, d *schema.ResourceData
 			if buildTwoPartID(&ldapLink.Provider, &ldapLink.CN) == d.Id() {
 				d.Set("group_id", groupId)
 				d.Set("cn", ldapLink.CN)
-				d.Set("group_access", ldapLink.GroupAccess)
+				d.Set("group_access", accessLevelValueToName[ldapLink.GroupAccess])
 				d.Set("ldap_provider", ldapLink.Provider)
 				found = true
 				break

--- a/internal/provider/resource_gitlab_group_ldap_link_test.go
+++ b/internal/provider/resource_gitlab_group_ldap_link_test.go
@@ -28,7 +28,7 @@ func TestAccGitlabGroupLdapLink_basic(t *testing.T) {
 
 			// Create a group LDAP link as a developer (uses testAccGitlabGroupLdapLinkCreateConfig for Config)
 			{
-				SkipFunc: testAccGitlabGroupLdapLinkSkipFunc(testLdapLink.CN, testLdapLink.Provider),
+				SkipFunc: isRunningInCE,
 				Config:   testAccGitlabGroupLdapLinkCreateConfig(rInt, &testLdapLink),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabGroupLdapLinkExists("gitlab_group_ldap_link.foo", &ldapLink),
@@ -39,7 +39,7 @@ func TestAccGitlabGroupLdapLink_basic(t *testing.T) {
 
 			// Update the group LDAP link to change the access level (uses testAccGitlabGroupLdapLinkUpdateConfig for Config)
 			{
-				SkipFunc: testAccGitlabGroupLdapLinkSkipFunc(testLdapLink.CN, testLdapLink.Provider),
+				SkipFunc: isRunningInCE,
 				Config:   testAccGitlabGroupLdapLinkUpdateConfig(rInt, &testLdapLink),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabGroupLdapLinkExists("gitlab_group_ldap_link.foo", &ldapLink),
@@ -50,7 +50,7 @@ func TestAccGitlabGroupLdapLink_basic(t *testing.T) {
 
 			// Force create the same group LDAP link in a different resource (uses testAccGitlabGroupLdapLinkForceCreateConfig for Config)
 			{
-				SkipFunc: testAccGitlabGroupLdapLinkSkipFunc(testLdapLink.CN, testLdapLink.Provider),
+				SkipFunc: isRunningInCE,
 				Config:   testAccGitlabGroupLdapLinkForceCreateConfig(rInt, &testLdapLink),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabGroupLdapLinkExists("gitlab_group_ldap_link.bar", &ldapLink),
@@ -60,16 +60,6 @@ func TestAccGitlabGroupLdapLink_basic(t *testing.T) {
 			},
 		},
 	})
-}
-
-func testAccGitlabGroupLdapLinkSkipFunc(testCN string, testProvider string) func() (bool, error) {
-	return func() (bool, error) {
-		if testCN == "default" || testProvider == "default" {
-			return true, nil
-		}
-
-		return isRunningInCE()
-	}
 }
 
 func testAccCheckGitlabGroupLdapLinkExists(resourceName string, ldapLink *gitlab.LDAPGroupLink) resource.TestCheckFunc {

--- a/internal/provider/resource_gitlab_group_ldap_link_test.go
+++ b/internal/provider/resource_gitlab_group_ldap_link_test.go
@@ -47,17 +47,6 @@ func TestAccGitlabGroupLdapLink_basic(t *testing.T) {
 						accessLevel: fmt.Sprintf("maintainer"), // nolint // TODO: Resolve this golangci-lint issue: S1039: unnecessary use of fmt.Sprintf (gosimple)
 					})),
 			},
-
-			// Force create the same group LDAP link in a different resource (uses testAccGitlabGroupLdapLinkForceCreateConfig for Config)
-			{
-				SkipFunc: isRunningInCE,
-				Config:   testAccGitlabGroupLdapLinkForceCreateConfig(rInt, &testLdapLink),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabGroupLdapLinkExists("gitlab_group_ldap_link.bar", &ldapLink),
-					testAccCheckGitlabGroupLdapLinkAttributes(&ldapLink, &testAccGitlabGroupLdapLinkExpectedAttributes{
-						accessLevel: fmt.Sprintf("developer"), // nolint // TODO: Resolve this golangci-lint issue: S1039: unnecessary use of fmt.Sprintf (gosimple)
-					})),
-			},
 		},
 	})
 }
@@ -208,28 +197,4 @@ resource "gitlab_group_ldap_link" "foo" {
 	group_access 	= "maintainer"
 	ldap_provider   = "%s"
 }`, rInt, rInt, testLdapLink.CN, testLdapLink.Provider)
-}
-
-func testAccGitlabGroupLdapLinkForceCreateConfig(rInt int, testLdapLink *gitlab.LDAPGroupLink) string {
-	return fmt.Sprintf(`
-resource "gitlab_group" "foo" {
-    name = "foo%d"
-	path = "foo%d"
-	description = "Terraform acceptance test - Group LDAP Links 3"
-}
-
-resource "gitlab_group_ldap_link" "foo" {
-    group_id 		= "${gitlab_group.foo.id}"
-    cn				= "%s"
-	group_access 	= "maintainer"
-	ldap_provider   = "%s"
-}
-
-resource "gitlab_group_ldap_link" "bar" {
-    group_id 		= "${gitlab_group.foo.id}"
-    cn				= "%s"
-	group_access 	= "developer"
-	ldap_provider   = "%s"
-	force			= true
-}`, rInt, rInt, testLdapLink.CN, testLdapLink.Provider, testLdapLink.CN, testLdapLink.Provider)
 }


### PR DESCRIPTION
Refs: #771 

@armsnyder do you know anything about that `force` flag? And how it's supposed to work?
The test currently is failing (it was never executed, so we didn't notice) and it's apparent why, but I don't see what the intention was and how to make it "work" again :D 
