### PR TITLE
[gitlab_project] re-compute project attributes if path or namespace changed

### DIFF
--- a/internal/provider/resource_gitlab_project.go
+++ b/internal/provider/resource_gitlab_project.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -388,6 +389,12 @@ var _ = registerResource("gitlab_project", func() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Schema: resourceGitLabProjectSchema,
+		CustomizeDiff: customdiff.All(
+			customdiff.ComputedIf("path_with_namespace", namespaceOrPathChanged),
+			customdiff.ComputedIf("ssh_url_to_repo", namespaceOrPathChanged),
+			customdiff.ComputedIf("http_url_to_repo", namespaceOrPathChanged),
+			customdiff.ComputedIf("web_url", namespaceOrPathChanged),
+		),
 	}
 })
 
@@ -1136,4 +1143,8 @@ func flattenProjectPushRules(pushRules *gitlab.ProjectPushRules) (values []map[s
 			"max_file_size":                 pushRules.MaxFileSize,
 		},
 	}
+}
+
+func namespaceOrPathChanged(ctx context.Context, d *schema.ResourceDiff, meta interface{}) bool {
+	return d.HasChange("namespace_id") || d.HasChange("path")
 }


### PR DESCRIPTION
## Description

All project attributes which are affected by a namespace or path change are re-computed if changed and dependent resources on those attributes will be updated in the same run.

Closes: #874

## PR Checklist

<!-- For a smooth review process, please run through this checklist before submitting a PR. -->

- [x] **(not applicable)** Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
- [x] **(not applicable)** [Examples](/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
- [x] **(not applicable)** New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
- [x] Fix is covered via tests 
- [x] No new `//lintignore` comments that came from copied code. Linter rules are meant to be enforced on new code.
