### PR TITLE
CI/CD variable values should be non-sensitive by default

### DIFF
--- a/docs/resources/group_variable.md
+++ b/docs/resources/group_variable.md
@@ -34,7 +34,7 @@ resource "gitlab_group_variable" "example" {
 
 - **group** (String) The name or id of the group.
 - **key** (String) The name of the variable.
-- **value** (String, Sensitive) The value of the variable.
+- **value** (String) The value of the variable.
 
 ### Optional
 

--- a/docs/resources/instance_variable.md
+++ b/docs/resources/instance_variable.md
@@ -31,7 +31,7 @@ resource "gitlab_instance_variable" "example" {
 ### Required
 
 - **key** (String) The name of the variable.
-- **value** (String, Sensitive) The value of the variable.
+- **value** (String) The value of the variable.
 
 ### Optional
 

--- a/docs/resources/project_variable.md
+++ b/docs/resources/project_variable.md
@@ -41,7 +41,7 @@ resource "gitlab_project_variable" "example" {
 
 - **key** (String) The name of the variable.
 - **project** (String) The name or id of the project.
-- **value** (String, Sensitive) The value of the variable.
+- **value** (String) The value of the variable.
 
 ### Optional
 

--- a/internal/provider/resource_gitlab_group_variable.go
+++ b/internal/provider/resource_gitlab_group_variable.go
@@ -43,7 +43,6 @@ var _ = registerResource("gitlab_group_variable", func() *schema.Resource {
 				Description: "The value of the variable.",
 				Type:        schema.TypeString,
 				Required:    true,
-				Sensitive:   true,
 			},
 			"variable_type": {
 				Description:  "The type of a variable. Available types are: env_var (default) and file.",

--- a/internal/provider/resource_gitlab_instance_variable.go
+++ b/internal/provider/resource_gitlab_instance_variable.go
@@ -36,7 +36,6 @@ var _ = registerResource("gitlab_instance_variable", func() *schema.Resource {
 				Description: "The value of the variable.",
 				Type:        schema.TypeString,
 				Required:    true,
-				Sensitive:   true,
 			},
 			"variable_type": {
 				Description:  "The type of a variable. Available types are: env_var (default) and file.",

--- a/internal/provider/resource_gitlab_project_variable.go
+++ b/internal/provider/resource_gitlab_project_variable.go
@@ -48,7 +48,6 @@ var _ = registerResource("gitlab_project_variable", func() *schema.Resource {
 				Description: "The value of the variable.",
 				Type:        schema.TypeString,
 				Required:    true,
-				Sensitive:   true,
 			},
 			"variable_type": {
 				Description:  "The type of a variable. Available types are: env_var (default) and file.",


### PR DESCRIPTION
## Description

<!-- Which issue/s does this PR close? Is there any more context you can give the reviewer? -->

Removes the sensitive setting from instance/group/project level CI/CD variables. It should be at the discretion of Terraform and the infra developer to mark values as sensitive.

In a very big gitops project of us all sensitive values are still marked as sensitive in the state as they are either input variables set as sensitive or derived from sensitive values like the `runner_token`.

Closes: #758

## PR Checklist

<!-- For a smooth review process, please run through this checklist before submitting a PR. -->

- [x] **(not applicable)** Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
- [x] **(not applicable)** [Examples](/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
- [x] Documentation re-generated.
- [x] **(not applicable)** New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
- [x] No new `//lintignore` comments that came from copied code. Linter rules are meant to be enforced on new code.
