### PR TITLE
Add branch protection support for allow_force_push

### DIFF
--- a/docs/resources/branch_protection.md
+++ b/docs/resources/branch_protection.md
@@ -21,6 +21,7 @@ resource "gitlab_branch_protection" "BranchProtect" {
   branch                       = "BranchProtected"
   push_access_level            = "developer"
   merge_access_level           = "developer"
+  allow_force_push             = true
   code_owner_approval_required = true
   allowed_to_push {
     user_id = 5
@@ -64,6 +65,7 @@ resource "gitlab_branch_protection" "main" {
 
 ### Optional
 
+- **allow_force_push** (Boolean) Can be set to true to allow users with push access to force push.
 - **allowed_to_merge** (Block Set) Defines permissions for action. (see [below for nested schema](#nestedblock--allowed_to_merge))
 - **allowed_to_push** (Block Set) Defines permissions for action. (see [below for nested schema](#nestedblock--allowed_to_push))
 - **code_owner_approval_required** (Boolean) Can be set to true to require code owner approval before merging.

--- a/examples/resources/gitlab_branch_protection/resource.tf
+++ b/examples/resources/gitlab_branch_protection/resource.tf
@@ -3,6 +3,7 @@ resource "gitlab_branch_protection" "BranchProtect" {
   branch                       = "BranchProtected"
   push_access_level            = "developer"
   merge_access_level           = "developer"
+  allow_force_push             = true
   code_owner_approval_required = true
   allowed_to_push {
     user_id = 5


### PR DESCRIPTION
Issue 709 requested the `allow_force_push` option to be added to the branch protection resource.  These changes add that feature, along with the appropriate tests.  The API does not support updating the allow force push configuration, so any changes will force a new resource to be created.

## Description

Closes #709 .  Adds `allow_force_push` attribute to branch protection resource.

## PR Checklist

<!-- For a smooth review process, please run through this checklist before submitting a PR. -->

- [x] Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
- [x] [Examples](/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
- [x] New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
- [x] No new `//lintignore` comments that came from copied code. Linter rules are meant to be enforced on new code.
