### PR TITLE
Workflows: Require PRs to have "safe to test" or "skip-ee-test" label before merging

### DIFF
--- a/.github/workflows/pr-required-labels.yml
+++ b/.github/workflows/pr-required-labels.yml
@@ -27,7 +27,7 @@ jobs:
           mode: exactly
           count: 0
           labels: needs-rebase
-      - name: Check "safe to test" or skip-ee-test
+      - name: Check "safe to test" or "skip-ee-test"
         uses: mheap/github-action-required-labels@v1
         with:
           mode: minimum

--- a/.github/workflows/pr-required-labels.yml
+++ b/.github/workflows/pr-required-labels.yml
@@ -27,3 +27,9 @@ jobs:
           mode: exactly
           count: 0
           labels: needs-rebase
+      - name: Check "safe to test" or skip-ee-test
+        uses: mheap/github-action-required-labels@v1
+        with:
+          mode: minimum
+          count: 1
+          labels: safe to test, skip-ee-test


### PR DESCRIPTION
## Description

<!-- Which issue/s does this PR close? Is there any more context you can give the reviewer? -->

Since EE tests do not run by default, this will prevent us (mostly me, I'm bad) from merging a PR accidentally that has not had EE tests run, or explicitly ignored with "skip-ee-test".

### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
