### PR TITLE
resource/gitlab_branch_protection: fix issue claiming that no valid access level can be found. Closes #890

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.10.0 (2022-02-24)
+
+BUG FIXES:
+
+* resource/gitlab_branch_protection: Fix issue which claimed that `no valid access level` can be found ([#892](https://github.com/gitlabhq/terraform-provider-gitlab/pull/892))
+
 ## 3.10.0 (2022-02-23)
 
 FEATURES:
@@ -19,7 +25,7 @@ IMPROVEMENTS:
 * resource/gitlab_service_jira: Add `api_url` attribute ([#597](https://github.com/gitlabhq/terraform-provider-gitlab/pull/597))
 * resource/gitlab_user: Add `state` attribute to allow blocking users ([#762](https://github.com/gitlabhq/terraform-provider-gitlab/pull/762))
 
-BUG FIXES
+BUG FIXES:
 
 * datasource/gitlab_projects: Allow to get archived and unarchived repositories ([#855](https://github.com/gitlabhq/terraform-provider-gitlab/pull/855))
 * resource/gitlab_group: Support setting `default_branch_protection` to `0` ([#856](https://github.com/gitlabhq/terraform-provider-gitlab/pull/856))

--- a/internal/provider/resource_gitlab_branch_protection.go
+++ b/internal/provider/resource_gitlab_branch_protection.go
@@ -173,16 +173,12 @@ func resourceGitlabBranchProtectionRead(ctx context.Context, d *schema.ResourceD
 		if err := d.Set("push_access_level", accessLevelValueToName[*pushAccessLevel]); err != nil {
 			return diag.Errorf("error setting push_access_level: %v", err)
 		}
-	} else {
-		return diag.Errorf("unable to get push_access_level: %v", err)
 	}
 
 	if mergeAccessLevels, err := firstValidAccessLevel(pb.MergeAccessLevels); err == nil {
 		if err := d.Set("merge_access_level", accessLevelValueToName[*mergeAccessLevels]); err != nil {
 			return diag.Errorf("error setting merge_access_level: %v", err)
 		}
-	} else {
-		return diag.Errorf("unable to get merge_access_level: %v", err)
 	}
 
 	if err := d.Set("allow_force_push", pb.AllowForcePush); err != nil {


### PR DESCRIPTION
I don't really understand yet what happens here. However, that behavior
changed from v3.9.1 to v3.10.0. Thus, I'm simply reverting it back.

We've had a brief exchange about this already when the "broken" code was
merged here: https://github.com/gitlabhq/terraform-provider-gitlab/pull/881#discussion_r812109889

Obviously, we made the wrong call in that this situation doesn't
happen ... well, it happened.

Looking at the `gitlab_branch_protection` resource I find that it's
kinda unclear what's going on, also looking at the upstream API docs
doesn't shed any lights on this as the documentation is quite sparse.
Some of this was lately raised by @beekeep in
https://github.com/gitlabhq/terraform-provider-gitlab/issues/878#issuecomment-1048902570
, that is that some fields are arguments in the provider, but optional
in the upstream API. Also the implemented logic to retrieve the set
`push_access_level` and `merge_access_level` can only be guessed when
trying to understand how those values come to be from a `POST` to a
`GET` request of the [Protected Branches
API](https://docs.gitlab.com/ee/api/protected_branches.html).

Closes #890

## Description

<!-- Which issue/s does this PR close? Is there any more context you can give the reviewer? -->

### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
