### PR TITLE
Auto remove safe to test on acceptance EE run and push

### DIFF
--- a/.github/workflows/pr-acceptance-ee.yml
+++ b/.github/workflows/pr-acceptance-ee.yml
@@ -60,6 +60,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [go-version, license-encryption-password]
     steps:
+      - uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: 'safe to test'
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ needs.go-version.outputs.go-version }}

--- a/.github/workflows/pr-push.yml
+++ b/.github/workflows/pr-push.yml
@@ -1,10 +1,10 @@
 name: pr-push
 
 on: 
-  push:
-    branches-ignore:
-      - 'main'
-
+  workflows: ["pr-required-labels"]
+    types: 
+      - completed
+  
 concurrency: 
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true

--- a/.github/workflows/pr-push.yml
+++ b/.github/workflows/pr-push.yml
@@ -1,0 +1,18 @@
+name: pr-push
+
+on: 
+  push:
+    branches-ignore:
+      - 'main'
+
+concurrency: 
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  clean-labels:
+    runs-on: ubuntu-latest
+    steps:
+     - uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: 'safe to test'

--- a/.github/workflows/pr-push.yml
+++ b/.github/workflows/pr-push.yml
@@ -14,5 +14,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
      - uses: actions-ecosystem/action-remove-labels@v1
-        with:
-          labels: 'safe to test'
+       with:
+        labels: 'safe to test'


### PR DESCRIPTION
## Description

This MR updates the acceptance-EE workflow to auto remove safe to test label when:
- a new commit is pushed to the branch
-  the workflow runs

### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
