### PR TITLE
resource/gitlab_user: Add support for `deactivated` user state. Closes #897

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -51,7 +51,7 @@ resource "gitlab_user" "example" {
 - **projects_limit** (Number) Integer, defaults to 0.  Number of projects user can create.
 - **reset_password** (Boolean) Boolean, defaults to false. Send user password reset link.
 - **skip_confirmation** (Boolean) Boolean, defaults to true. Whether to skip confirmation.
-- **state** (String) String, defaults to 'active'. The state of the user account. Valid values are either 'active' or 'blocked'
+- **state** (String) String, defaults to 'active'. The state of the user account. Valid values are `active`, `deactivated`, `blocked`.
 
 ## Import
 

--- a/internal/provider/resource_gitlab_user_test.go
+++ b/internal/provider/resource_gitlab_user_test.go
@@ -205,6 +205,108 @@ func TestAccGitlabUser_basic(t *testing.T) {
 					"skip_confirmation",
 				},
 			},
+			// Deactivate the user
+			{
+				Config: testAccGitlabUserConfigDeactivated(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabUserExists("gitlab_user.foo", &user),
+					testAccCheckGitlabUserAttributes(&user, &testAccGitlabUserExpectedAttributes{
+						Email:          fmt.Sprintf("listest%d@ssss.com", rInt),
+						Username:       fmt.Sprintf("listest%d", rInt),
+						Name:           fmt.Sprintf("foo %d", rInt),
+						ProjectsLimit:  0,
+						Admin:          false,
+						CanCreateGroup: false,
+						External:       false,
+						State:          "deactivated",
+					}),
+				),
+			},
+			// Re-activate the user
+			{
+				Config: testAccGitlabUserConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabUserExists("gitlab_user.foo", &user),
+					testAccCheckGitlabUserAttributes(&user, &testAccGitlabUserExpectedAttributes{
+						Email:          fmt.Sprintf("listest%d@ssss.com", rInt),
+						Username:       fmt.Sprintf("listest%d", rInt),
+						Name:           fmt.Sprintf("foo %d", rInt),
+						ProjectsLimit:  0,
+						Admin:          false,
+						CanCreateGroup: false,
+						External:       false,
+						State:          "active",
+					}),
+				),
+			},
+			// Block the user
+			{
+				Config: testAccGitlabUserConfigBlocked(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabUserExists("gitlab_user.foo", &user),
+					testAccCheckGitlabUserAttributes(&user, &testAccGitlabUserExpectedAttributes{
+						Email:          fmt.Sprintf("listest%d@ssss.com", rInt),
+						Username:       fmt.Sprintf("listest%d", rInt),
+						Name:           fmt.Sprintf("foo %d", rInt),
+						ProjectsLimit:  0,
+						Admin:          false,
+						CanCreateGroup: false,
+						External:       false,
+						State:          "blocked",
+					}),
+				),
+			},
+			// Deactivate the user from blocked state
+			{
+				Config: testAccGitlabUserConfigDeactivated(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabUserExists("gitlab_user.foo", &user),
+					testAccCheckGitlabUserAttributes(&user, &testAccGitlabUserExpectedAttributes{
+						Email:          fmt.Sprintf("listest%d@ssss.com", rInt),
+						Username:       fmt.Sprintf("listest%d", rInt),
+						Name:           fmt.Sprintf("foo %d", rInt),
+						ProjectsLimit:  0,
+						Admin:          false,
+						CanCreateGroup: false,
+						External:       false,
+						State:          "deactivated",
+					}),
+				),
+			},
+			// Block the user from deactivate state
+			{
+				Config: testAccGitlabUserConfigBlocked(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabUserExists("gitlab_user.foo", &user),
+					testAccCheckGitlabUserAttributes(&user, &testAccGitlabUserExpectedAttributes{
+						Email:          fmt.Sprintf("listest%d@ssss.com", rInt),
+						Username:       fmt.Sprintf("listest%d", rInt),
+						Name:           fmt.Sprintf("foo %d", rInt),
+						ProjectsLimit:  0,
+						Admin:          false,
+						CanCreateGroup: false,
+						External:       false,
+						State:          "blocked",
+					}),
+				),
+			},
+			// Unblock the user
+			{
+				Config: testAccGitlabUserConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabUserExists("gitlab_user.foo", &user),
+					testAccCheckGitlabUserAttributes(&user, &testAccGitlabUserExpectedAttributes{
+						Email:          fmt.Sprintf("listest%d@ssss.com", rInt),
+						Username:       fmt.Sprintf("listest%d", rInt),
+						Name:           fmt.Sprintf("foo %d", rInt),
+						ProjectsLimit:  0,
+						Admin:          false,
+						CanCreateGroup: false,
+						External:       false,
+						State:          "active",
+					}),
+				),
+			},
 		},
 	})
 }
@@ -439,4 +541,20 @@ resource "gitlab_user" "foo" {
   email            = "listest%d@ssss.com"
 }
   `, rInt, rInt, rInt)
+}
+
+func testAccGitlabUserConfigDeactivated(rInt int) string {
+	return fmt.Sprintf(`
+resource "gitlab_user" "foo" {
+  name             = "foo %d"
+  username         = "listest%d"
+  password         = "test%dtt"
+  email            = "listest%d@ssss.com"
+  is_admin         = false
+  projects_limit   = 0
+  can_create_group = false
+  is_external      = false
+  state            = "deactivated"
+}
+  `, rInt, rInt, rInt, rInt)
 }


### PR DESCRIPTION
This change will fix a regression from v3.9.0 to v3.10.0, see report in #897.

However, the regression is just because the user state has been changed outside of terraform, while it was supposed to be owner by terraform. It was changed outside of terraform, because the `gitlab_user` resource didn't support deactivating users.

Therefore, we could argue that this is actually a new feature and not a bug fix. But whatever, @ilpianista how urgent is the upgrade to 3.10 for you?