### PR TITLE
Workflows: Run EE tests on PRs without label requirement

### DIFF
--- a/.github/workflows/pr-acceptance-ee.yml
+++ b/.github/workflows/pr-acceptance-ee.yml
@@ -15,7 +15,6 @@ on:
   # The pull_request_target event type fires for pull requests, but in the context of the target
   # project.
   pull_request_target:
-    types: [labeled]
     # Acceptance tests are unnecessary to run on some types of PRs.
     paths-ignore:
       - 'docs/**'
@@ -62,7 +61,7 @@ jobs:
   acceptance-ee:
     # Only run EE tests if the LICENSE_ENCRYPTION_PASSWORD secret exists, so that the workflow
     # doesn't fail when code is pushed to a fork.
-    if: needs.license-encryption-password.outputs.defined && contains(github.event.pull_request.labels.*.name, 'safe to test')
+    if: ${{ needs.license-encryption-password.outputs.defined }}
     timeout-minutes: 60
     runs-on: ubuntu-latest
     needs: [go-version, license-encryption-password]

--- a/.github/workflows/pr-required-labels.yml
+++ b/.github/workflows/pr-required-labels.yml
@@ -27,9 +27,3 @@ jobs:
           mode: exactly
           count: 0
           labels: needs-rebase
-      - name: Check "safe to test" or "skip-ee-test"
-        uses: mheap/github-action-required-labels@v1
-        with:
-          mode: minimum
-          count: 1
-          labels: safe to test, skip-ee-test


### PR DESCRIPTION
## Description

<!-- Which issue/s does this PR close? Is there any more context you can give the reviewer? -->

Addresses an issue where EE tests only run when the `safe to test` label is added by returning to the previous behavior of running EE tests on all pushes to a PR.

I'm opening this as an alternative to #898 which I believe is now feasible since #902 was merged.

### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
