### PR TITLE
Correctly handle deletion outside of terraform

### DIFF
--- a/internal/provider/resource_gitlab_group_badge.go
+++ b/internal/provider/resource_gitlab_group_badge.go
@@ -90,6 +90,11 @@ func resourceGitlabGroupBadgeRead(ctx context.Context, d *schema.ResourceData, m
 
 	badge, _, err := client.GroupBadges.GetGroupBadge(groupID, badgeID, gitlab.WithContext(ctx))
 	if err != nil {
+		if is404(err) {
+			log.Printf("[DEBUG] group badge %d in group %s doesn't exist anymore, removing from state", badgeID, groupID)
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 

--- a/internal/provider/resource_gitlab_project.go
+++ b/internal/provider/resource_gitlab_project.go
@@ -748,10 +748,15 @@ func resourceGitlabProjectRead(ctx context.Context, d *schema.ResourceData, meta
 
 	project, _, err := client.Projects.GetProject(d.Id(), nil, gitlab.WithContext(ctx))
 	if err != nil {
+		if is404(err) {
+			log.Printf("[DEBUG] gitlab project %s has already been deleted, removing from state", d.Id())
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 	if project.MarkedForDeletionAt != nil {
-		log.Printf("[DEBUG] gitlab project %s is marked for deletion", d.Id())
+		log.Printf("[DEBUG] gitlab project %s is marked for deletion, removing from state", d.Id())
 		d.SetId("")
 		return nil
 	}

--- a/internal/provider/resource_gitlab_project_badge.go
+++ b/internal/provider/resource_gitlab_project_badge.go
@@ -90,6 +90,11 @@ func resourceGitlabProjectBadgeRead(ctx context.Context, d *schema.ResourceData,
 
 	badge, _, err := client.ProjectBadges.GetProjectBadge(projectID, badgeID, gitlab.WithContext(ctx))
 	if err != nil {
+		if is404(err) {
+			log.Printf("[DEBUG] project badge %d in project %s doesn't exist anymore, removing from state", badgeID, projectID)
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
This change fixes the read function of the following resources to properly handle out of bound deletions:

- `gitlab_project` 
- `gitlab_project_badge`
- `gitlab_group_badge`

In case a resource is deleted outside of terraform the tf state drift and we need to remove it if the read function received a `404`.

@armsnyder any ideas for how to test this in a non-hacky way? 