### PR TITLE
fix: fix failure if project has been manually deleted

### DIFF
--- a/internal/provider/resource_gitlab_project.go
+++ b/internal/provider/resource_gitlab_project.go
@@ -748,7 +748,9 @@ func resourceGitlabProjectRead(ctx context.Context, d *schema.ResourceData, meta
 
 	project, _, err := client.Projects.GetProject(d.Id(), nil, gitlab.WithContext(ctx))
 	if err != nil {
-		return diag.FromErr(err)
+		log.Printf("[DEBUG] gitlab project %s has been deleted", d.Id())
+		d.SetId("")
+		return nil
 	}
 	if project.MarkedForDeletionAt != nil {
 		log.Printf("[DEBUG] gitlab project %s is marked for deletion", d.Id())


### PR DESCRIPTION
## Description

This provider currently fails with `404 {message: 404 Project Not Found}` when trying to refresh a `gitlab_project` resource that have been created by Terraform but manually deleted.

This PR will reset the ID of the resource so that it is marked to be recreated instead of crashing.

### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
