### PR TITLE
resource/gitlab_label: Add priority attribute 

### DIFF
--- a/docs/resources/label.md
+++ b/docs/resources/label.md
@@ -46,5 +46,6 @@ resource "gitlab_label" "devops_create" {
 
 - **description** (String) The description of the label.
 - **id** (String) The ID of this resource.
+- **priority** (Number) The priority of the label. Must be greater or equal than zero or null to remove the priority.
 
 

--- a/internal/provider/resource_gitlab_label.go
+++ b/internal/provider/resource_gitlab_label.go
@@ -78,7 +78,6 @@ func resourceGitlabLabelCreate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	d.SetId(label.Name)
-
 	return resourceGitlabLabelRead(ctx, d, meta)
 }
 

--- a/internal/provider/resource_gitlab_label_test.go
+++ b/internal/provider/resource_gitlab_label_test.go
@@ -83,7 +83,7 @@ func TestAccGitlabLabel_basic(t *testing.T) {
 					resource.TestCheckResourceAttr("gitlab_label.fixme", "name", fmt.Sprintf("FIXME-%d", rInt)),
 					resource.TestCheckResourceAttr("gitlab_label.fixme", "color", "#ffcc00"),
 					resource.TestCheckResourceAttr("gitlab_label.fixme", "description", "fix this test"),
-					resource.TestCheckResourceAttr("gitlab_label.fixme", "priority", "0"),
+					resource.TestCheckResourceAttr("gitlab_label.fixme", "priority", "null"),
 				),
 			},
 		},

--- a/internal/provider/resource_gitlab_label_test.go
+++ b/internal/provider/resource_gitlab_label_test.go
@@ -28,6 +28,7 @@ func TestAccGitlabLabel_basic(t *testing.T) {
 						Name:        fmt.Sprintf("FIXME-%d", rInt),
 						Color:       "#ffcc00",
 						Description: "fix this test",
+						Priority:    5,
 					}),
 				),
 			},
@@ -40,6 +41,7 @@ func TestAccGitlabLabel_basic(t *testing.T) {
 						Name:        fmt.Sprintf("FIXME-%d", rInt),
 						Color:       "#ff0000",
 						Description: "red label",
+						Priority:    1,
 					}),
 				),
 			},
@@ -52,6 +54,7 @@ func TestAccGitlabLabel_basic(t *testing.T) {
 						Name:        fmt.Sprintf("FIXME-%d", rInt),
 						Color:       "#ffcc00",
 						Description: "fix this test",
+						Priority:    5,
 					}),
 				),
 			},
@@ -120,6 +123,7 @@ type testAccGitlabLabelExpectedAttributes struct {
 	Name        string
 	Color       string
 	Description string
+	Priority    int
 }
 
 func testAccCheckGitlabLabelAttributes(label *gitlab.Label, want *testAccGitlabLabelExpectedAttributes) resource.TestCheckFunc {
@@ -134,6 +138,10 @@ func testAccCheckGitlabLabelAttributes(label *gitlab.Label, want *testAccGitlabL
 
 		if label.Color != want.Color {
 			return fmt.Errorf("got color %q; want %q", label.Color, want.Color)
+		}
+
+		if label.Priority != want.Priority {
+			return fmt.Errorf("got priority %d; want %d", label.Priority, want.Priority)
 		}
 
 		return nil
@@ -178,6 +186,7 @@ resource "gitlab_label" "fixme" {
   name = "FIXME-%d"
   color = "#ffcc00"
   description = "fix this test"
+  priority = 5
 }
 	`, rInt, rInt)
 }
@@ -198,6 +207,7 @@ resource "gitlab_label" "fixme" {
   name = "FIXME-%d"
   color = "#ff0000"
   description = "red label"
+  priority = 1
 }
 	`, rInt, rInt)
 }

--- a/internal/provider/resource_gitlab_label_test.go
+++ b/internal/provider/resource_gitlab_label_test.go
@@ -30,6 +30,10 @@ func TestAccGitlabLabel_basic(t *testing.T) {
 						Description: "fix this test",
 						Priority:    5,
 					}),
+					resource.TestCheckResourceAttr("gitlab_label.fixme", "name", fmt.Sprintf("FIXME-%d", rInt)),
+					resource.TestCheckResourceAttr("gitlab_label.fixme", "color", "#ffcc00"),
+					resource.TestCheckResourceAttr("gitlab_label.fixme", "description", "fix this test"),
+					resource.TestCheckResourceAttr("gitlab_label.fixme", "priority", "5"),
 				),
 			},
 			// Update the label to change the parameters
@@ -43,6 +47,10 @@ func TestAccGitlabLabel_basic(t *testing.T) {
 						Description: "red label",
 						Priority:    1,
 					}),
+					resource.TestCheckResourceAttr("gitlab_label.fixme", "name", fmt.Sprintf("FIXME-%d", rInt)),
+					resource.TestCheckResourceAttr("gitlab_label.fixme", "color", "#ff0000"),
+					resource.TestCheckResourceAttr("gitlab_label.fixme", "description", "red label"),
+					resource.TestCheckResourceAttr("gitlab_label.fixme", "priority", "1"),
 				),
 			},
 			// Update the label to get back to initial settings
@@ -56,36 +64,26 @@ func TestAccGitlabLabel_basic(t *testing.T) {
 						Description: "fix this test",
 						Priority:    5,
 					}),
+					resource.TestCheckResourceAttr("gitlab_label.fixme", "name", fmt.Sprintf("FIXME-%d", rInt)),
+					resource.TestCheckResourceAttr("gitlab_label.fixme", "color", "#ffcc00"),
+					resource.TestCheckResourceAttr("gitlab_label.fixme", "description", "fix this test"),
+					resource.TestCheckResourceAttr("gitlab_label.fixme", "priority", "5"),
 				),
 			},
-			// Create a project and lots of labels with default options
+			// Remove the priority
 			{
-				Config: testAccGitlabLabelLargeConfig(rInt),
+				Config: testAccGitlabLabelRemovePriorityLabel(rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabLabelExists("gitlab_label.fixme.20", &label),
-					testAccCheckGitlabLabelExists("gitlab_label.fixme.30", &label),
-					testAccCheckGitlabLabelExists("gitlab_label.fixme.40", &label),
-					testAccCheckGitlabLabelExists("gitlab_label.fixme.10", &label),
+					testAccCheckGitlabLabelExists("gitlab_label.fixme", &label),
 					testAccCheckGitlabLabelAttributes(&label, &testAccGitlabLabelExpectedAttributes{
-						Name:        "FIXME11",
+						Name:        fmt.Sprintf("FIXME-%d", rInt),
 						Color:       "#ffcc00",
 						Description: "fix this test",
 					}),
-				),
-			},
-			// Update the lots of labels to change the parameters
-			{
-				Config: testAccGitlabLabelUpdateLargeConfig(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabLabelExists("gitlab_label.fixme.20", &label),
-					testAccCheckGitlabLabelExists("gitlab_label.fixme.30", &label),
-					testAccCheckGitlabLabelExists("gitlab_label.fixme.40", &label),
-					testAccCheckGitlabLabelExists("gitlab_label.fixme.10", &label),
-					testAccCheckGitlabLabelAttributes(&label, &testAccGitlabLabelExpectedAttributes{
-						Name:        "FIXME11",
-						Color:       "#ff0000",
-						Description: "red label",
-					}),
+					resource.TestCheckResourceAttr("gitlab_label.fixme", "name", fmt.Sprintf("FIXME-%d", rInt)),
+					resource.TestCheckResourceAttr("gitlab_label.fixme", "color", "#ffcc00"),
+					resource.TestCheckResourceAttr("gitlab_label.fixme", "description", "fix this test"),
+					resource.TestCheckResourceAttr("gitlab_label.fixme", "priority", "0"),
 				),
 			},
 		},
@@ -212,7 +210,7 @@ resource "gitlab_label" "fixme" {
 	`, rInt, rInt)
 }
 
-func testAccGitlabLabelLargeConfig(rInt int) string {
+func testAccGitlabLabelRemovePriorityLabel(rInt int) string {
 	return fmt.Sprintf(`
 resource "gitlab_project" "foo" {
   name = "foo-%d"
@@ -225,31 +223,9 @@ resource "gitlab_project" "foo" {
 
 resource "gitlab_label" "fixme" {
   project = "${gitlab_project.foo.id}"
-  name = format("FIXME%%02d", count.index+1)
-  count = 100
+  name = "FIXME-%d"
   color = "#ffcc00"
   description = "fix this test"
 }
-	`, rInt)
-}
-
-func testAccGitlabLabelUpdateLargeConfig(rInt int) string {
-	return fmt.Sprintf(`
-resource "gitlab_project" "foo" {
-  name = "foo-%d"
-  description = "Terraform acceptance tests"
-
-  # So that acceptance tests can be run in a gitlab organization
-  # with no billing
-  visibility_level = "public"
-}
-
-resource "gitlab_label" "fixme" {
-  project = "${gitlab_project.foo.id}"
-  name = format("FIXME%%02d", count.index+1)
-  count = 99
-  color = "#ff0000"
-  description = "red label"
-}
-	`, rInt)
+	`, rInt, rInt)
 }


### PR DESCRIPTION
Closes: #69

Blocked by:

* https://github.com/xanzy/go-gitlab/pull/1407

The PR above highlights the issue why this is blocked: basically go-gitlab doesn't support nullable fields in responses, which would be required for the `priority` field.