### PR TITLE
Add `allowed_to_unprotect` and `unprotect_access_level` fields to branch protection

### DIFF
--- a/docs/resources/branch_protection.md
+++ b/docs/resources/branch_protection.md
@@ -4,7 +4,7 @@ page_title: "gitlab_branch_protection Resource - terraform-provider-gitlab"
 subcategory: ""
 description: |-
   The gitlab_branch_protection resource allows to manage the lifecycle of a protected branch of a repository.
-  ~> The allowedtopush, allowedtomerge and codeownerapproval_required attributes require a GitLab Enterprise instance.
+  ~> The allowed_to_push, allowed_to_merge, allowed_to_unprotect, unprotect_access_level and code_owner_approval_required attributes require a GitLab Enterprise instance.
   Upstream API: GitLab REST API docs https://docs.gitlab.com/ee/api/protected_branches.html
 ---
 
@@ -12,7 +12,7 @@ description: |-
 
 The `gitlab_branch_protection` resource allows to manage the lifecycle of a protected branch of a repository.
 
-~> The allowed_to_push, allowed_to_merge and code_owner_approval_required attributes require a GitLab Enterprise instance.
+~> The `allowed_to_push`, `allowed_to_merge`, `allowed_to_unprotect`, `unprotect_access_level` and `code_owner_approval_required` attributes require a GitLab Enterprise instance.
 
 **Upstream API**: [GitLab REST API docs](https://docs.gitlab.com/ee/api/protected_branches.html)
 
@@ -24,6 +24,7 @@ resource "gitlab_branch_protection" "BranchProtect" {
   branch                       = "BranchProtected"
   push_access_level            = "developer"
   merge_access_level           = "developer"
+  unprotect_access_level       = "developer"
   allow_force_push             = true
   code_owner_approval_required = true
   allowed_to_push {
@@ -38,14 +39,21 @@ resource "gitlab_branch_protection" "BranchProtect" {
   allowed_to_merge {
     user_id = 37
   }
+  allowed_to_unprotect {
+    user_id = 15
+  }
+  allowed_to_unprotect {
+    group_id = 42
+  }
 }
 
 # Example using dynamic block
 resource "gitlab_branch_protection" "main" {
-  project            = "12345"
-  branch             = "main"
-  push_access_level  = "maintainer"
-  merge_access_level = "maintainer"
+  project                = "12345"
+  branch                 = "main"
+  push_access_level      = "maintainer"
+  merge_access_level     = "maintainer"
+  unprotect_access_level = "maintainer"
 
   dynamic "allowed_to_push" {
     for_each = [50, 55, 60]
@@ -62,17 +70,19 @@ resource "gitlab_branch_protection" "main" {
 ### Required
 
 - **branch** (String) Name of the branch.
-- **merge_access_level** (String) Access levels allowed to merge. Valid values are: `no one`, `developer`, `maintainer`.
 - **project** (String) The id of the project.
-- **push_access_level** (String) Access levels allowed to push. Valid values are: `no one`, `developer`, `maintainer`.
 
 ### Optional
 
 - **allow_force_push** (Boolean) Can be set to true to allow users with push access to force push.
 - **allowed_to_merge** (Block Set) Defines permissions for action. (see [below for nested schema](#nestedblock--allowed_to_merge))
 - **allowed_to_push** (Block Set) Defines permissions for action. (see [below for nested schema](#nestedblock--allowed_to_push))
+- **allowed_to_unprotect** (Block Set) Defines permissions for action. (see [below for nested schema](#nestedblock--allowed_to_unprotect))
 - **code_owner_approval_required** (Boolean) Can be set to true to require code owner approval before merging.
 - **id** (String) The ID of this resource.
+- **merge_access_level** (String) Access levels allowed to merge. Valid values are: `no one`, `developer`, `maintainer`.
+- **push_access_level** (String) Access levels allowed to push. Valid values are: `no one`, `developer`, `maintainer`.
+- **unprotect_access_level** (String) Access levels allowed to unprotect. Valid values are: `developer`, `maintainer`.
 
 ### Read-Only
 
@@ -94,6 +104,20 @@ Read-Only:
 
 <a id="nestedblock--allowed_to_push"></a>
 ### Nested Schema for `allowed_to_push`
+
+Optional:
+
+- **group_id** (Number) The ID of a GitLab group allowed to perform the relevant action. Mutually exclusive with `user_id`.
+- **user_id** (Number) The ID of a GitLab user allowed to perform the relevant action. Mutually exclusive with `group_id`.
+
+Read-Only:
+
+- **access_level** (String) Level of access.
+- **access_level_description** (String) Readable description of level of access.
+
+
+<a id="nestedblock--allowed_to_unprotect"></a>
+### Nested Schema for `allowed_to_unprotect`
 
 Optional:
 

--- a/examples/resources/gitlab_branch_protection/resource.tf
+++ b/examples/resources/gitlab_branch_protection/resource.tf
@@ -3,6 +3,7 @@ resource "gitlab_branch_protection" "BranchProtect" {
   branch                       = "BranchProtected"
   push_access_level            = "developer"
   merge_access_level           = "developer"
+  unprotect_access_level       = "developer"
   allow_force_push             = true
   code_owner_approval_required = true
   allowed_to_push {
@@ -17,14 +18,21 @@ resource "gitlab_branch_protection" "BranchProtect" {
   allowed_to_merge {
     user_id = 37
   }
+  allowed_to_unprotect {
+    user_id = 15
+  }
+  allowed_to_unprotect {
+    group_id = 42
+  }
 }
 
 # Example using dynamic block
 resource "gitlab_branch_protection" "main" {
-  project            = "12345"
-  branch             = "main"
-  push_access_level  = "maintainer"
-  merge_access_level = "maintainer"
+  project                = "12345"
+  branch                 = "main"
+  push_access_level      = "maintainer"
+  merge_access_level     = "maintainer"
+  unprotect_access_level = "maintainer"
 
   dynamic "allowed_to_push" {
     for_each = [50, 55, 60]

--- a/internal/provider/access_level_helpers.go
+++ b/internal/provider/access_level_helpers.go
@@ -49,6 +49,12 @@ var validProtectedBranchTagAccessLevelNames = []string{
 	"no one", "developer", "maintainer",
 }
 
+// The only access levels allowed to be configured to unprotect a protected branch
+// The API states the others are either forbidden (via 403) or invalid
+var validProtectedBranchUnprotectAccessLevelNames = []string{
+	"developer", "maintainer",
+}
+
 var accessLevelNameToValue = map[string]gitlab.AccessLevelValue{
 	"no one":     gitlab.NoPermissions,
 	"minimal":    gitlab.MinimalAccessPermissions,

--- a/internal/provider/resource_gitlab_branch_protection.go
+++ b/internal/provider/resource_gitlab_branch_protection.go
@@ -71,14 +71,16 @@ var _ = registerResource("gitlab_branch_protection", func() *schema.Resource {
 				Description:      fmt.Sprintf("Access levels allowed to merge. Valid values are: %s.", renderValueListForDocs(validProtectedBranchTagAccessLevelNames)),
 				Type:             schema.TypeString,
 				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(validProtectedBranchTagAccessLevelNames, false)),
-				Required:         true,
+				Optional:         true,
+				Default:          accessLevelValueToName[gitlab.MaintainerPermissions],
 				ForceNew:         true,
 			},
 			"push_access_level": {
 				Description:      fmt.Sprintf("Access levels allowed to push. Valid values are: %s.", renderValueListForDocs(validProtectedBranchTagAccessLevelNames)),
 				Type:             schema.TypeString,
 				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(validProtectedBranchTagAccessLevelNames, false)),
-				Required:         true,
+				Optional:         true,
+				Default:          accessLevelValueToName[gitlab.MaintainerPermissions],
 				ForceNew:         true,
 			},
 			"allow_force_push": {

--- a/internal/provider/resource_gitlab_branch_protection.go
+++ b/internal/provider/resource_gitlab_branch_protection.go
@@ -43,7 +43,7 @@ var _ = registerResource("gitlab_branch_protection", func() *schema.Resource {
 	return &schema.Resource{
 		Description: `The ` + "`gitlab_branch_protection`" + ` resource allows to manage the lifecycle of a protected branch of a repository.
 
-~> The allowed_to_push, allowed_to_merge and code_owner_approval_required attributes require a GitLab Enterprise instance.
+~> The ` + "`allowed_to_push`" + `, ` + "`allowed_to_merge`" + `, ` + "`allowed_to_unprotect`" + `, ` + "`unprotect_access_level`" + ` and ` + "`code_owner_approval_required`" + ` attributes require a GitLab Enterprise instance.
 
 **Upstream API**: [GitLab REST API docs](https://docs.gitlab.com/ee/api/protected_branches.html)`,
 
@@ -83,6 +83,14 @@ var _ = registerResource("gitlab_branch_protection", func() *schema.Resource {
 				Default:          accessLevelValueToName[gitlab.MaintainerPermissions],
 				ForceNew:         true,
 			},
+			"unprotect_access_level": {
+				Description:      fmt.Sprintf("Access levels allowed to unprotect. Valid values are: %s.", renderValueListForDocs(validProtectedBranchUnprotectAccessLevelNames)),
+				Type:             schema.TypeString,
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(validProtectedBranchUnprotectAccessLevelNames, false)),
+				Optional:         true,
+				Default:          accessLevelValueToName[gitlab.MaintainerPermissions],
+				ForceNew:         true,
+			},
 			"allow_force_push": {
 				Description: "Can be set to true to allow users with push access to force push.",
 				Type:        schema.TypeBool,
@@ -90,8 +98,9 @@ var _ = registerResource("gitlab_branch_protection", func() *schema.Resource {
 				Default:     false,
 				ForceNew:    true,
 			},
-			"allowed_to_push":  schemaAllowedTo(),
-			"allowed_to_merge": schemaAllowedTo(),
+			"allowed_to_push":      schemaAllowedTo(),
+			"allowed_to_merge":     schemaAllowedTo(),
+			"allowed_to_unprotect": schemaAllowedTo(),
 			"code_owner_approval_required": {
 				Description: "Can be set to true to require code owner approval before merging.",
 				Type:        schema.TypeBool,
@@ -126,19 +135,24 @@ func resourceGitlabBranchProtectionCreate(ctx context.Context, d *schema.Resourc
 
 	mergeAccessLevel := accessLevelNameToValue[d.Get("merge_access_level").(string)]
 	pushAccessLevel := accessLevelNameToValue[d.Get("push_access_level").(string)]
+	unprotectAccessLevel := accessLevelNameToValue[d.Get("unprotect_access_level").(string)]
+
 	allowForcePush := d.Get("allow_force_push").(bool)
 	codeOwnerApprovalRequired := d.Get("code_owner_approval_required").(bool)
 
 	allowedToPush := expandBranchPermissionOptions(d.Get("allowed_to_push").(*schema.Set).List())
 	allowedToMerge := expandBranchPermissionOptions(d.Get("allowed_to_merge").(*schema.Set).List())
+	allowedToUnprotect := expandBranchPermissionOptions(d.Get("allowed_to_unprotect").(*schema.Set).List())
 
 	pb, _, err := client.ProtectedBranches.ProtectRepositoryBranches(project, &gitlab.ProtectRepositoryBranchesOptions{
 		Name:                      &branch,
 		PushAccessLevel:           &pushAccessLevel,
 		MergeAccessLevel:          &mergeAccessLevel,
+		UnprotectAccessLevel:      &unprotectAccessLevel,
 		AllowForcePush:            &allowForcePush,
 		AllowedToPush:             &allowedToPush,
 		AllowedToMerge:            &allowedToMerge,
+		AllowedToUnprotect:        &allowedToUnprotect,
 		CodeOwnerApprovalRequired: &codeOwnerApprovalRequired,
 	}, gitlab.WithContext(ctx))
 	if err != nil {
@@ -186,6 +200,12 @@ func resourceGitlabBranchProtectionRead(ctx context.Context, d *schema.ResourceD
 		}
 	}
 
+	if unprotectAccessLevels, err := firstValidAccessLevel(pb.UnprotectAccessLevels); err == nil {
+		if err := d.Set("unprotect_access_level", accessLevelValueToName[*unprotectAccessLevels]); err != nil {
+			return diag.Errorf("error setting unprotect_access_level: %v", err)
+		}
+	}
+
 	if err := d.Set("allow_force_push", pb.AllowForcePush); err != nil {
 		return diag.Errorf("error setting allow_force_push: %v", err)
 	}
@@ -195,6 +215,10 @@ func resourceGitlabBranchProtectionRead(ctx context.Context, d *schema.ResourceD
 	}
 	if err := d.Set("allowed_to_merge", flattenNonZeroBranchAccessDescriptions(pb.MergeAccessLevels)); err != nil {
 		return diag.Errorf("error setting allowed_to_merge: %v", err)
+	}
+
+	if err := d.Set("allowed_to_unprotect", flattenNonZeroBranchAccessDescriptions(pb.UnprotectAccessLevels)); err != nil {
+		return diag.Errorf("error setting allowed_to_unprotect: %v", err)
 	}
 
 	if err := d.Set("code_owner_approval_required", pb.CodeOwnerApprovalRequired); err != nil {

--- a/internal/provider/resource_gitlab_branch_protection_test.go
+++ b/internal/provider/resource_gitlab_branch_protection_test.go
@@ -24,41 +24,58 @@ func TestAccGitlabBranchProtection_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create a project and Branch Protection with default options
 			{
-				Config: testAccGitlabBranchProtectionConfig(rInt),
+				Config: testAccGitlabBranchProtectionConfigRequiredFields(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionComputedAttributes("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
-						Name:             fmt.Sprintf("BranchProtect-%d", rInt),
-						PushAccessLevel:  accessLevelValueToName[gitlab.DeveloperPermissions],
-						MergeAccessLevel: accessLevelValueToName[gitlab.DeveloperPermissions],
+						Name:                 fmt.Sprintf("BranchProtect-%d", rInt),
+						PushAccessLevel:      accessLevelValueToName[gitlab.MaintainerPermissions],
+						MergeAccessLevel:     accessLevelValueToName[gitlab.MaintainerPermissions],
+						UnprotectAccessLevel: accessLevelValueToName[gitlab.MaintainerPermissions],
 					}),
 				),
 			},
-			// Update the Branch Protection
+			// Configure the Branch Protection access levels
 			{
-				Config: testAccGitlabBranchProtectionUpdateConfig(rInt),
+				Config: testAccGitlabBranchProtectionConfigAccessLevels(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
-						Name:             fmt.Sprintf("BranchProtect-%d", rInt),
-						PushAccessLevel:  accessLevelValueToName[gitlab.MasterPermissions],
-						MergeAccessLevel: accessLevelValueToName[gitlab.MasterPermissions],
+						Name:                 fmt.Sprintf("BranchProtect-%d", rInt),
+						PushAccessLevel:      accessLevelValueToName[gitlab.DeveloperPermissions],
+						MergeAccessLevel:     accessLevelValueToName[gitlab.DeveloperPermissions],
+						UnprotectAccessLevel: accessLevelValueToName[gitlab.DeveloperPermissions],
+					}),
+				),
+			},
+			// Update the Branch Protection access levels
+			{
+				Config: testAccGitlabBranchProtectionUpdateConfigAccessLevels(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.branch_protect", &pb),
+					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
+					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
+						Name:                 fmt.Sprintf("BranchProtect-%d", rInt),
+						PushAccessLevel:      accessLevelValueToName[gitlab.MaintainerPermissions],
+						MergeAccessLevel:     accessLevelValueToName[gitlab.MaintainerPermissions],
+						UnprotectAccessLevel: accessLevelValueToName[gitlab.MaintainerPermissions],
 					}),
 				),
 			},
 			// Update the Branch Protection to get back to initial settings
 			{
-				Config: testAccGitlabBranchProtectionConfig(rInt),
+				Config: testAccGitlabBranchProtectionConfigRequiredFields(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
-						Name:             fmt.Sprintf("BranchProtect-%d", rInt),
-						PushAccessLevel:  accessLevelValueToName[gitlab.DeveloperPermissions],
-						MergeAccessLevel: accessLevelValueToName[gitlab.DeveloperPermissions],
+						Name:                 fmt.Sprintf("BranchProtect-%d", rInt),
+						PushAccessLevel:      accessLevelValueToName[gitlab.MaintainerPermissions],
+						MergeAccessLevel:     accessLevelValueToName[gitlab.MaintainerPermissions],
+						UnprotectAccessLevel: accessLevelValueToName[gitlab.MaintainerPermissions],
 					}),
 				),
 			},
@@ -69,23 +86,25 @@ func TestAccGitlabBranchProtection_basic(t *testing.T) {
 					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
-						Name:             fmt.Sprintf("BranchProtect-%d", rInt),
-						PushAccessLevel:  accessLevelValueToName[gitlab.DeveloperPermissions],
-						MergeAccessLevel: accessLevelValueToName[gitlab.DeveloperPermissions],
-						AllowForcePush:   true,
+						Name:                 fmt.Sprintf("BranchProtect-%d", rInt),
+						PushAccessLevel:      accessLevelValueToName[gitlab.MaintainerPermissions],
+						MergeAccessLevel:     accessLevelValueToName[gitlab.MaintainerPermissions],
+						UnprotectAccessLevel: accessLevelValueToName[gitlab.MaintainerPermissions],
+						AllowForcePush:       true,
 					}),
 				),
 			},
 			// Update the Branch Protection to get back to initial settings
 			{
-				Config: testAccGitlabBranchProtectionConfig(rInt),
+				Config: testAccGitlabBranchProtectionConfigRequiredFields(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
-						Name:             fmt.Sprintf("BranchProtect-%d", rInt),
-						PushAccessLevel:  accessLevelValueToName[gitlab.DeveloperPermissions],
-						MergeAccessLevel: accessLevelValueToName[gitlab.DeveloperPermissions],
+						Name:                 fmt.Sprintf("BranchProtect-%d", rInt),
+						PushAccessLevel:      accessLevelValueToName[gitlab.MaintainerPermissions],
+						MergeAccessLevel:     accessLevelValueToName[gitlab.MaintainerPermissions],
+						UnprotectAccessLevel: accessLevelValueToName[gitlab.MaintainerPermissions],
 					}),
 				),
 			},
@@ -98,8 +117,9 @@ func TestAccGitlabBranchProtection_basic(t *testing.T) {
 					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
 						Name:                      fmt.Sprintf("BranchProtect-%d", rInt),
-						PushAccessLevel:           accessLevelValueToName[gitlab.DeveloperPermissions],
-						MergeAccessLevel:          accessLevelValueToName[gitlab.DeveloperPermissions],
+						PushAccessLevel:           accessLevelValueToName[gitlab.MaintainerPermissions],
+						MergeAccessLevel:          accessLevelValueToName[gitlab.MaintainerPermissions],
+						UnprotectAccessLevel:      accessLevelValueToName[gitlab.MaintainerPermissions],
 						CodeOwnerApprovalRequired: true,
 					}),
 				),
@@ -113,22 +133,24 @@ func TestAccGitlabBranchProtection_basic(t *testing.T) {
 					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
-						Name:             fmt.Sprintf("BranchProtect-%d", rInt),
-						PushAccessLevel:  accessLevelValueToName[gitlab.DeveloperPermissions],
-						MergeAccessLevel: accessLevelValueToName[gitlab.DeveloperPermissions],
+						Name:                 fmt.Sprintf("BranchProtect-%d", rInt),
+						PushAccessLevel:      accessLevelValueToName[gitlab.MaintainerPermissions],
+						MergeAccessLevel:     accessLevelValueToName[gitlab.MaintainerPermissions],
+						UnprotectAccessLevel: accessLevelValueToName[gitlab.MaintainerPermissions],
 					}),
 				),
 			},
 			// Update the Branch Protection to get back to initial settings
 			{
-				Config: testAccGitlabBranchProtectionConfig(rInt),
+				Config: testAccGitlabBranchProtectionConfigRequiredFields(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
-						Name:             fmt.Sprintf("BranchProtect-%d", rInt),
-						PushAccessLevel:  accessLevelValueToName[gitlab.DeveloperPermissions],
-						MergeAccessLevel: accessLevelValueToName[gitlab.DeveloperPermissions],
+						Name:                 fmt.Sprintf("BranchProtect-%d", rInt),
+						PushAccessLevel:      accessLevelValueToName[gitlab.MaintainerPermissions],
+						MergeAccessLevel:     accessLevelValueToName[gitlab.MaintainerPermissions],
+						UnprotectAccessLevel: accessLevelValueToName[gitlab.MaintainerPermissions],
 					}),
 				),
 			},
@@ -148,14 +170,15 @@ func TestAccGitlabBranchProtection_createWithCodeOwnerApproval(t *testing.T) {
 			// Start with code owner approval required disabled
 			{
 				SkipFunc: isRunningInEE,
-				Config:   testAccGitlabBranchProtectionConfig(rInt),
+				Config:   testAccGitlabBranchProtectionConfigRequiredFields(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
-						Name:             fmt.Sprintf("BranchProtect-%d", rInt),
-						PushAccessLevel:  accessLevelValueToName[gitlab.DeveloperPermissions],
-						MergeAccessLevel: accessLevelValueToName[gitlab.DeveloperPermissions],
+						Name:                 fmt.Sprintf("BranchProtect-%d", rInt),
+						PushAccessLevel:      accessLevelValueToName[gitlab.MaintainerPermissions],
+						MergeAccessLevel:     accessLevelValueToName[gitlab.MaintainerPermissions],
+						UnprotectAccessLevel: accessLevelValueToName[gitlab.MaintainerPermissions],
 					}),
 				),
 			},
@@ -168,8 +191,9 @@ func TestAccGitlabBranchProtection_createWithCodeOwnerApproval(t *testing.T) {
 					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
 						Name:                      fmt.Sprintf("BranchProtect-%d", rInt),
-						PushAccessLevel:           accessLevelValueToName[gitlab.DeveloperPermissions],
-						MergeAccessLevel:          accessLevelValueToName[gitlab.DeveloperPermissions],
+						PushAccessLevel:           accessLevelValueToName[gitlab.MaintainerPermissions],
+						MergeAccessLevel:          accessLevelValueToName[gitlab.MaintainerPermissions],
+						UnprotectAccessLevel:      accessLevelValueToName[gitlab.MaintainerPermissions],
 						CodeOwnerApprovalRequired: true,
 					}),
 				),
@@ -184,22 +208,24 @@ func TestAccGitlabBranchProtection_createWithCodeOwnerApproval(t *testing.T) {
 					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
 						Name:                      fmt.Sprintf("BranchProtect-%d", rInt),
-						PushAccessLevel:           accessLevelValueToName[gitlab.DeveloperPermissions],
-						MergeAccessLevel:          accessLevelValueToName[gitlab.DeveloperPermissions],
+						PushAccessLevel:           accessLevelValueToName[gitlab.MaintainerPermissions],
+						MergeAccessLevel:          accessLevelValueToName[gitlab.MaintainerPermissions],
+						UnprotectAccessLevel:      accessLevelValueToName[gitlab.MaintainerPermissions],
 						CodeOwnerApprovalRequired: true,
 					}),
 				),
 			},
 			// Update the Branch Protection to get back to initial settings
 			{
-				Config: testAccGitlabBranchProtectionConfig(rInt),
+				Config: testAccGitlabBranchProtectionConfigRequiredFields(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
-						Name:             fmt.Sprintf("BranchProtect-%d", rInt),
-						PushAccessLevel:  accessLevelValueToName[gitlab.DeveloperPermissions],
-						MergeAccessLevel: accessLevelValueToName[gitlab.DeveloperPermissions],
+						Name:                 fmt.Sprintf("BranchProtect-%d", rInt),
+						PushAccessLevel:      accessLevelValueToName[gitlab.MaintainerPermissions],
+						MergeAccessLevel:     accessLevelValueToName[gitlab.MaintainerPermissions],
+						UnprotectAccessLevel: accessLevelValueToName[gitlab.MaintainerPermissions],
 					}),
 				),
 			},
@@ -218,14 +244,15 @@ func TestAccGitlabBranchProtection_createWithAllowForcePush(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Start with allow force push disabled
 			{
-				Config: testAccGitlabBranchProtectionConfig(rInt),
+				Config: testAccGitlabBranchProtectionConfigRequiredFields(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
-						Name:             fmt.Sprintf("BranchProtect-%d", rInt),
-						PushAccessLevel:  accessLevelValueToName[gitlab.DeveloperPermissions],
-						MergeAccessLevel: accessLevelValueToName[gitlab.DeveloperPermissions],
+						Name:                 fmt.Sprintf("BranchProtect-%d", rInt),
+						PushAccessLevel:      accessLevelValueToName[gitlab.MaintainerPermissions],
+						MergeAccessLevel:     accessLevelValueToName[gitlab.MaintainerPermissions],
+						UnprotectAccessLevel: accessLevelValueToName[gitlab.MaintainerPermissions],
 					}),
 				),
 			},
@@ -236,23 +263,66 @@ func TestAccGitlabBranchProtection_createWithAllowForcePush(t *testing.T) {
 					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
-						Name:             fmt.Sprintf("BranchProtect-%d", rInt),
-						PushAccessLevel:  accessLevelValueToName[gitlab.DeveloperPermissions],
-						MergeAccessLevel: accessLevelValueToName[gitlab.DeveloperPermissions],
-						AllowForcePush:   true,
+						Name:                 fmt.Sprintf("BranchProtect-%d", rInt),
+						PushAccessLevel:      accessLevelValueToName[gitlab.MaintainerPermissions],
+						MergeAccessLevel:     accessLevelValueToName[gitlab.MaintainerPermissions],
+						UnprotectAccessLevel: accessLevelValueToName[gitlab.MaintainerPermissions],
+						AllowForcePush:       true,
 					}),
 				),
 			},
 			// Update the Branch Protection to get back to initial settings
 			{
-				Config: testAccGitlabBranchProtectionConfig(rInt),
+				Config: testAccGitlabBranchProtectionConfigRequiredFields(rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
-						Name:             fmt.Sprintf("BranchProtect-%d", rInt),
-						PushAccessLevel:  accessLevelValueToName[gitlab.DeveloperPermissions],
-						MergeAccessLevel: accessLevelValueToName[gitlab.DeveloperPermissions],
+						Name:                 fmt.Sprintf("BranchProtect-%d", rInt),
+						PushAccessLevel:      accessLevelValueToName[gitlab.MaintainerPermissions],
+						MergeAccessLevel:     accessLevelValueToName[gitlab.MaintainerPermissions],
+						UnprotectAccessLevel: accessLevelValueToName[gitlab.MaintainerPermissions],
+					}),
+				),
+			},
+		},
+	})
+}
+
+func TestAccGitlabBranchProtection_createWithUnprotectAccessLevel(t *testing.T) {
+	var pb gitlab.ProtectedBranch
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckGitlabBranchProtectionDestroy,
+		Steps: []resource.TestStep{
+			// Configure the Branch Protection access levels
+			{
+				Config: testAccGitlabBranchProtectionConfigAccessLevels(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.branch_protect", &pb),
+					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
+					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
+						Name:                 fmt.Sprintf("BranchProtect-%d", rInt),
+						PushAccessLevel:      accessLevelValueToName[gitlab.DeveloperPermissions],
+						MergeAccessLevel:     accessLevelValueToName[gitlab.DeveloperPermissions],
+						UnprotectAccessLevel: accessLevelValueToName[gitlab.DeveloperPermissions],
+					}),
+				),
+			},
+			// Update the Branch Protection access levels
+			{
+				Config: testAccGitlabBranchProtectionUpdateConfigAccessLevels(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.branch_protect", &pb),
+					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
+					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
+						Name:                 fmt.Sprintf("BranchProtect-%d", rInt),
+						PushAccessLevel:      accessLevelValueToName[gitlab.MaintainerPermissions],
+						MergeAccessLevel:     accessLevelValueToName[gitlab.MaintainerPermissions],
+						UnprotectAccessLevel: accessLevelValueToName[gitlab.MaintainerPermissions],
 					}),
 				),
 			},
@@ -277,13 +347,16 @@ func TestAccGitlabBranchProtection_createWithMultipleAccessLevels(t *testing.T) 
 					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
-						Name:                 fmt.Sprintf("BranchProtect-%d", rInt),
-						PushAccessLevel:      accessLevelValueToName[gitlab.MaintainerPermissions],
-						MergeAccessLevel:     accessLevelValueToName[gitlab.MaintainerPermissions],
-						UsersAllowedToPush:   []string{fmt.Sprintf("listest2%d", rInt)},
-						UsersAllowedToMerge:  []string{fmt.Sprintf("listest%d", rInt), fmt.Sprintf("listest2%d", rInt)},
-						GroupsAllowedToPush:  []string{fmt.Sprintf("test-%d", rInt), fmt.Sprintf("test2-%d", rInt)},
-						GroupsAllowedToMerge: []string{fmt.Sprintf("test-%d", rInt), fmt.Sprintf("test2-%d", rInt)},
+						Name:                     fmt.Sprintf("BranchProtect-%d", rInt),
+						PushAccessLevel:          accessLevelValueToName[gitlab.MaintainerPermissions],
+						MergeAccessLevel:         accessLevelValueToName[gitlab.MaintainerPermissions],
+						UnprotectAccessLevel:     accessLevelValueToName[gitlab.MaintainerPermissions],
+						UsersAllowedToPush:       []string{fmt.Sprintf("listest2%d", rInt)},
+						UsersAllowedToMerge:      []string{fmt.Sprintf("listest%d", rInt), fmt.Sprintf("listest2%d", rInt)},
+						UsersAllowedToUnprotect:  []string{fmt.Sprintf("listest%d", rInt), fmt.Sprintf("listest2%d", rInt)},
+						GroupsAllowedToPush:      []string{fmt.Sprintf("test-%d", rInt), fmt.Sprintf("test2-%d", rInt)},
+						GroupsAllowedToMerge:     []string{fmt.Sprintf("test-%d", rInt), fmt.Sprintf("test2-%d", rInt)},
+						GroupsAllowedToUnprotect: []string{fmt.Sprintf("test-%d", rInt), fmt.Sprintf("test2-%d", rInt)},
 					}),
 				),
 			},
@@ -295,13 +368,16 @@ func TestAccGitlabBranchProtection_createWithMultipleAccessLevels(t *testing.T) 
 					testAccCheckGitlabBranchProtectionExists("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionPersistsInStateCorrectly("gitlab_branch_protection.branch_protect", &pb),
 					testAccCheckGitlabBranchProtectionAttributes(&pb, &testAccGitlabBranchProtectionExpectedAttributes{
-						Name:                 fmt.Sprintf("BranchProtect-%d", rInt),
-						PushAccessLevel:      accessLevelValueToName[gitlab.DeveloperPermissions],
-						MergeAccessLevel:     accessLevelValueToName[gitlab.DeveloperPermissions],
-						UsersAllowedToPush:   []string{fmt.Sprintf("listest%d", rInt)},
-						UsersAllowedToMerge:  []string{fmt.Sprintf("listest2%d", rInt)},
-						GroupsAllowedToPush:  []string{fmt.Sprintf("test2-%d", rInt)},
-						GroupsAllowedToMerge: []string{fmt.Sprintf("test-%d", rInt)},
+						Name:                     fmt.Sprintf("BranchProtect-%d", rInt),
+						PushAccessLevel:          accessLevelValueToName[gitlab.DeveloperPermissions],
+						MergeAccessLevel:         accessLevelValueToName[gitlab.DeveloperPermissions],
+						UnprotectAccessLevel:     accessLevelValueToName[gitlab.DeveloperPermissions],
+						UsersAllowedToPush:       []string{fmt.Sprintf("listest%d", rInt)},
+						UsersAllowedToMerge:      []string{fmt.Sprintf("listest2%d", rInt)},
+						UsersAllowedToUnprotect:  []string{fmt.Sprintf("listest%d", rInt)},
+						GroupsAllowedToPush:      []string{fmt.Sprintf("test2-%d", rInt)},
+						GroupsAllowedToMerge:     []string{fmt.Sprintf("test-%d", rInt)},
+						GroupsAllowedToUnprotect: []string{fmt.Sprintf("test2-%d", rInt)},
 					}),
 				),
 			},
@@ -336,6 +412,12 @@ func testAccCheckGitlabBranchProtectionPersistsInStateCorrectly(n string, pb *gi
 		}
 		if rs.Primary.Attributes["push_access_level"] != accessLevelValueToName[pushAccessLevel] {
 			return fmt.Errorf("push access level not persisted in state correctly")
+		}
+
+		if unprotectAccessLevel, err := firstValidAccessLevel(pb.UnprotectAccessLevels); err == nil {
+			if rs.Primary.Attributes["unprotect_access_level"] != accessLevelValueToName[*unprotectAccessLevel] {
+				return fmt.Errorf("unprotect access level not persisted in state correctly")
+			}
 		}
 
 		if rs.Primary.Attributes["allow_force_push"] != strconv.FormatBool(pb.AllowForcePush) {
@@ -385,11 +467,14 @@ type testAccGitlabBranchProtectionExpectedAttributes struct {
 	Name                      string
 	PushAccessLevel           string
 	MergeAccessLevel          string
+	UnprotectAccessLevel      string
 	AllowForcePush            bool
 	UsersAllowedToPush        []string
 	UsersAllowedToMerge       []string
+	UsersAllowedToUnprotect   []string
 	GroupsAllowedToPush       []string
 	GroupsAllowedToMerge      []string
+	GroupsAllowedToUnprotect  []string
 	CodeOwnerApprovalRequired bool
 }
 
@@ -407,7 +492,7 @@ func testAccCheckGitlabBranchProtectionAttributes(pb *gitlab.ProtectedBranch, wa
 			}
 		}
 		if pushAccessLevel != accessLevelNameToValue[want.PushAccessLevel] {
-			return fmt.Errorf("got Push access level %v; want %v", pushAccessLevel, accessLevelNameToValue[want.PushAccessLevel])
+			return fmt.Errorf("got push access level %v; want %v", pushAccessLevel, accessLevelNameToValue[want.PushAccessLevel])
 		}
 
 		var mergeAccessLevel gitlab.AccessLevelValue
@@ -418,7 +503,21 @@ func testAccCheckGitlabBranchProtectionAttributes(pb *gitlab.ProtectedBranch, wa
 			}
 		}
 		if mergeAccessLevel != accessLevelNameToValue[want.MergeAccessLevel] {
-			return fmt.Errorf("got Merge access level %v; want %v", mergeAccessLevel, accessLevelNameToValue[want.MergeAccessLevel])
+			return fmt.Errorf("got merge access level %v; want %v", mergeAccessLevel, accessLevelNameToValue[want.MergeAccessLevel])
+		}
+
+		// unprotect access level will be nil in CE as it is not returned on the response, but in EE it is returned
+		if pb.UnprotectAccessLevels != nil {
+			var unprotectAccessLevel gitlab.AccessLevelValue
+			for _, v := range pb.UnprotectAccessLevels {
+				if v.UserID == 0 && v.GroupID == 0 {
+					unprotectAccessLevel = v.AccessLevel
+					break
+				}
+			}
+			if unprotectAccessLevel != accessLevelNameToValue[want.UnprotectAccessLevel] {
+				return fmt.Errorf("got unprotect access level %v; want %v", unprotectAccessLevel, accessLevelNameToValue[want.UnprotectAccessLevel])
+			}
 		}
 
 		if pb.AllowForcePush != want.AllowForcePush {
@@ -466,6 +565,88 @@ func testAccCheckGitlabBranchProtectionAttributes(pb *gitlab.ProtectedBranch, wa
 			return fmt.Errorf("failed to find wanted group IDs %v", remainingWantedGroupIDsAllowedToPush)
 		}
 
+		remainingWantedUserIDsAllowedToMerge := map[int]struct{}{}
+		for _, v := range want.UsersAllowedToMerge {
+			users, _, err := testGitlabClient.Users.ListUsers(&gitlab.ListUsersOptions{
+				Username: gitlab.String(v),
+			})
+			if err != nil {
+				return fmt.Errorf("error looking up user by path %v: %v", v, err)
+			}
+			if len(users) != 1 {
+				return fmt.Errorf("error finding user by username %v; found %v", v, len(users))
+			}
+			remainingWantedUserIDsAllowedToMerge[users[0].ID] = struct{}{}
+		}
+		remainingWantedGroupIDsAllowedToMerge := map[int]struct{}{}
+		for _, v := range want.GroupsAllowedToMerge {
+			group, _, err := testGitlabClient.Groups.GetGroup(v, nil)
+			if err != nil {
+				return fmt.Errorf("error looking up group by path %v: %v", v, err)
+			}
+			remainingWantedGroupIDsAllowedToMerge[group.ID] = struct{}{}
+		}
+		for _, v := range pb.MergeAccessLevels {
+			if v.UserID != 0 {
+				if _, ok := remainingWantedUserIDsAllowedToMerge[v.UserID]; !ok {
+					return fmt.Errorf("found unwanted user ID %v", v.UserID)
+				}
+				delete(remainingWantedUserIDsAllowedToMerge, v.UserID)
+			} else if v.GroupID != 0 {
+				if _, ok := remainingWantedGroupIDsAllowedToMerge[v.GroupID]; !ok {
+					return fmt.Errorf("found unwanted group ID %v", v.GroupID)
+				}
+				delete(remainingWantedGroupIDsAllowedToMerge, v.GroupID)
+			}
+		}
+		if len(remainingWantedUserIDsAllowedToMerge) > 0 {
+			return fmt.Errorf("failed to find wanted user IDs %v", remainingWantedUserIDsAllowedToMerge)
+		}
+		if len(remainingWantedGroupIDsAllowedToMerge) > 0 {
+			return fmt.Errorf("failed to find wanted group IDs %v", remainingWantedGroupIDsAllowedToMerge)
+		}
+
+		remainingWantedUserIDsAllowedToUnprotect := map[int]struct{}{}
+		for _, v := range want.UsersAllowedToUnprotect {
+			users, _, err := testGitlabClient.Users.ListUsers(&gitlab.ListUsersOptions{
+				Username: gitlab.String(v),
+			})
+			if err != nil {
+				return fmt.Errorf("error looking up user by path %v: %v", v, err)
+			}
+			if len(users) != 1 {
+				return fmt.Errorf("error finding user by username %v; found %v", v, len(users))
+			}
+			remainingWantedUserIDsAllowedToUnprotect[users[0].ID] = struct{}{}
+		}
+		remainingWantedGroupIDsAllowedToUnprotect := map[int]struct{}{}
+		for _, v := range want.GroupsAllowedToUnprotect {
+			group, _, err := testGitlabClient.Groups.GetGroup(v, nil)
+			if err != nil {
+				return fmt.Errorf("error looking up group by path %v: %v", v, err)
+			}
+			remainingWantedGroupIDsAllowedToUnprotect[group.ID] = struct{}{}
+		}
+		for _, v := range pb.UnprotectAccessLevels {
+			if v.UserID != 0 {
+				if _, ok := remainingWantedUserIDsAllowedToUnprotect[v.UserID]; !ok {
+					return fmt.Errorf("found unwanted user ID %v", v.UserID)
+				}
+				delete(remainingWantedUserIDsAllowedToUnprotect, v.UserID)
+			} else if v.GroupID != 0 {
+				if _, ok := remainingWantedGroupIDsAllowedToUnprotect[v.GroupID]; !ok {
+					return fmt.Errorf("found unwanted group ID %v", v.GroupID)
+				}
+				delete(remainingWantedGroupIDsAllowedToUnprotect, v.GroupID)
+			}
+		}
+		if len(remainingWantedUserIDsAllowedToUnprotect) > 0 {
+			return fmt.Errorf("failed to find wanted user IDs %v", remainingWantedUserIDsAllowedToUnprotect)
+		}
+		if len(remainingWantedGroupIDsAllowedToUnprotect) > 0 {
+			return fmt.Errorf("failed to find wanted group IDs %v", remainingWantedGroupIDsAllowedToUnprotect)
+		}
+
 		if pb.CodeOwnerApprovalRequired != want.CodeOwnerApprovalRequired {
 			return fmt.Errorf("got code_owner_approval_required %v; want %v", pb.CodeOwnerApprovalRequired, want.CodeOwnerApprovalRequired)
 		}
@@ -497,7 +678,7 @@ func testAccCheckGitlabBranchProtectionDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccGitlabBranchProtectionConfig(rInt int) string {
+func testAccGitlabBranchProtectionConfigRequiredFields(rInt int) string {
 	return fmt.Sprintf(`
 resource "gitlab_project" "foo" {
   name = "foo-%[1]d"
@@ -511,13 +692,11 @@ resource "gitlab_project" "foo" {
 resource "gitlab_branch_protection" "branch_protect" {
   project            = gitlab_project.foo.id
   branch             = "BranchProtect-%[1]d"
-  push_access_level  = "developer"
-  merge_access_level = "developer"
 }
 	`, rInt)
 }
 
-func testAccGitlabBranchProtectionUpdateConfig(rInt int) string {
+func testAccGitlabBranchProtectionConfigAccessLevels(rInt int) string {
 	return fmt.Sprintf(`
 resource "gitlab_project" "foo" {
   name = "foo-%[1]d"
@@ -529,10 +708,32 @@ resource "gitlab_project" "foo" {
 }
 
 resource "gitlab_branch_protection" "branch_protect" {
-  project            = gitlab_project.foo.id
-  branch             = "BranchProtect-%[1]d"
-  push_access_level  = "maintainer"
-  merge_access_level = "maintainer"
+  project                = gitlab_project.foo.id
+  branch                 = "BranchProtect-%[1]d"
+  push_access_level      = "developer"
+  merge_access_level     = "developer"
+  unprotect_access_level = "developer"
+}
+	`, rInt)
+}
+
+func testAccGitlabBranchProtectionUpdateConfigAccessLevels(rInt int) string {
+	return fmt.Sprintf(`
+resource "gitlab_project" "foo" {
+  name = "foo-%[1]d"
+  description = "Terraform acceptance tests"
+
+  # So that acceptance tests can be run in a gitlab organization
+  # with no billing
+  visibility_level = "public"
+}
+
+resource "gitlab_branch_protection" "branch_protect" {
+  project                = gitlab_project.foo.id
+  branch                 = "BranchProtect-%[1]d"
+  push_access_level      = "maintainer"
+  merge_access_level     = "maintainer"
+  unprotect_access_level = "maintainer"
 }
 	`, rInt)
 }
@@ -551,8 +752,6 @@ resource "gitlab_project" "foo" {
 resource "gitlab_branch_protection" "branch_protect" {
   project                      = gitlab_project.foo.id
   branch                       = "BranchProtect-%[1]d"
-  push_access_level            = "developer"
-  merge_access_level           = "developer"
   allow_force_push             = true
 }
 	`, rInt)
@@ -572,8 +771,6 @@ resource "gitlab_project" "foo" {
 resource "gitlab_branch_protection" "branch_protect" {
   project                      = gitlab_project.foo.id
   branch                       = "BranchProtect-%[1]d"
-  push_access_level            = "developer"
-  merge_access_level           = "developer"
   code_owner_approval_required = true
 }
 	`, rInt)
@@ -667,10 +864,11 @@ resource "gitlab_branch_protection" "branch_protect" {
 	gitlab_project_membership.test,
 	gitlab_project_membership.test2,
   ]
-  project            = gitlab_project.test.id
-  branch             = "BranchProtect-%[1]d"
-  push_access_level  = "maintainer"
-  merge_access_level = "maintainer"
+  project                = gitlab_project.test.id
+  branch                 = "BranchProtect-%[1]d"
+  push_access_level      = "maintainer"
+  merge_access_level     = "maintainer"
+  unprotect_access_level = "maintainer"
   allowed_to_push {
     user_id = gitlab_user.test2.id
   }
@@ -690,6 +888,18 @@ resource "gitlab_branch_protection" "branch_protect" {
     user_id = gitlab_user.test2.id
   }
   allowed_to_merge {
+    group_id = gitlab_group.test2.id
+  }
+  allowed_to_unprotect {
+    user_id = gitlab_user.test.id
+  }
+  allowed_to_unprotect {
+    group_id = gitlab_group.test.id
+  }
+  allowed_to_unprotect {
+    user_id = gitlab_user.test2.id
+  }
+  allowed_to_unprotect {
     group_id = gitlab_group.test2.id
   }
 }
@@ -784,10 +994,11 @@ resource "gitlab_branch_protection" "branch_protect" {
 	gitlab_project_membership.test,
 	gitlab_project_membership.test2,
   ]
-  project            = gitlab_project.test.id
-  branch             = "BranchProtect-%[1]d"
-  push_access_level  = "developer"
-  merge_access_level = "developer"
+  project                = gitlab_project.test.id
+  branch                 = "BranchProtect-%[1]d"
+  push_access_level      = "developer"
+  merge_access_level     = "developer"
+  unprotect_access_level = "developer"
   allowed_to_push {
     user_id = gitlab_user.test.id
   }
@@ -799,6 +1010,12 @@ resource "gitlab_branch_protection" "branch_protect" {
   }
   allowed_to_merge {
     group_id = gitlab_group.test.id
+  }
+  allowed_to_unprotect {
+    user_id = gitlab_user.test.id
+  }
+  allowed_to_unprotect {
+    group_id = gitlab_group.test2.id
   }
 }
 	`, rInt)


### PR DESCRIPTION
## Description

<!-- Which issue/s does this PR close? Is there any more context you can give the reviewer? -->

Closes #878.

Adds `unprotect_access_level` and `allowed_to_unprotect` attributes to the branch protection resource, which should bring the resource in line with the API.  Also changes `merge_access_level` and `push_access_level` to optional, as they were previously marked as required, but they are not required in the API.  A default is also configured, to match the default that is set via the API.

### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
