### PR TITLE
Workflows: Lint docs for upstream API link

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -32,6 +32,7 @@ jobs:
           - lint-examples-tf
           - lint-examples-sh
           - lint-generated
+          - lint-custom
     steps:
       - uses: actions/setup-go@v2
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -44,6 +44,7 @@ jobs:
           - lint-examples-tf
           - lint-examples-sh
           - lint-generated
+          - lint-custom
     steps:
       - uses: actions/setup-go@v2
         with:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -51,6 +51,9 @@ lint-generated: generate ## Check that "make generate" was called. Note this onl
 		exit 1; \
 	}
 
+lint-custom: ## Run custom checks and validations that do not fit into an existing lint framework.
+	@./scripts/lint-custom.sh
+
 apicovered: tool-apicovered ## Run an analysis tool to estimate the GitLab API coverage.
 	@$(GOBIN)/apicovered ./gitlab
 

--- a/docs/data-sources/project_issue.md
+++ b/docs/data-sources/project_issue.md
@@ -11,7 +11,7 @@ description: |-
 
 The `gitlab_project_issue` data source allows to retrieve details about an issue in a project.
 
-**Upstream API:** [GitLab API docs](https://docs.gitlab.com/ee/api/issues.html)
+**Upstream API**: [GitLab API docs](https://docs.gitlab.com/ee/api/issues.html)
 
 ## Example Usage
 

--- a/docs/data-sources/project_issues.md
+++ b/docs/data-sources/project_issues.md
@@ -11,7 +11,7 @@ description: |-
 
 The `gitlab_project_issues` data source allows to retrieve details about issues in a project.
 
-**Upstream API:** [GitLab API docs](https://docs.gitlab.com/ee/api/issues.html)
+**Upstream API**: [GitLab API docs](https://docs.gitlab.com/ee/api/issues.html)
 
 ## Example Usage
 

--- a/docs/data-sources/project_tag.md
+++ b/docs/data-sources/project_tag.md
@@ -4,14 +4,14 @@ page_title: "gitlab_project_tag Data Source - terraform-provider-gitlab"
 subcategory: ""
 description: |-
   The gitlab_project_tag data source allows details of a project tag to be retrieved by its name.
-  Upstream API : GitLab API docs https://docs.gitlab.com/ee/api/tags.html
+  Upstream API: GitLab API docs https://docs.gitlab.com/ee/api/tags.html
 ---
 
 # gitlab_project_tag (Data Source)
 
 The `gitlab_project_tag` data source allows details of a project tag to be retrieved by its name.
 
-**Upstream API** : [GitLab API docs](https://docs.gitlab.com/ee/api/tags.html)
+**Upstream API**: [GitLab API docs](https://docs.gitlab.com/ee/api/tags.html)
 
 ## Example Usage
 

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -5,12 +5,16 @@ subcategory: ""
 description: |-
   This resource allows you to create and manage GitLab groups.
   Note your provider will need to be configured with admin-level access for this resource to work.
+  Upstream API: GitLab Groups API https://docs.gitlab.com/ee/api/groups.html
 ---
 
 # gitlab_group (Resource)
 
 This resource allows you to create and manage GitLab groups.
+
 Note your provider will need to be configured with admin-level access for this resource to work.
+
+**Upstream API**: [GitLab Groups API](https://docs.gitlab.com/ee/api/groups.html)
 
 ## Example Usage
 

--- a/docs/resources/project_issue.md
+++ b/docs/resources/project_issue.md
@@ -17,7 +17,7 @@ The `gitlab_project_issue` resource allows to manage the lifecycle of an issue w
 
 ~> **Experimental**: while the base functionality of this resource works, it may be subject to minor change.
 
-**Upstream API:** [GitLab API docs](https://docs.gitlab.com/ee/api/issues.html)
+**Upstream API**: [GitLab API docs](https://docs.gitlab.com/ee/api/issues.html)
 
 ## Example Usage
 

--- a/docs/resources/project_tag.md
+++ b/docs/resources/project_tag.md
@@ -4,14 +4,14 @@ page_title: "gitlab_project_tag Resource - terraform-provider-gitlab"
 subcategory: ""
 description: |-
   The gitlab_project_tag resource allows to manage the lifecycle of a tag in a project.
-  Upstream API : GitLab API docs https://docs.gitlab.com/ee/api/tags.html
+  Upstream API: GitLab API docs https://docs.gitlab.com/ee/api/tags.html
 ---
 
 # gitlab_project_tag (Resource)
 
 The `gitlab_project_tag` resource allows to manage the lifecycle of a tag in a project.
 
-**Upstream API** : [GitLab API docs](https://docs.gitlab.com/ee/api/tags.html)
+**Upstream API**: [GitLab API docs](https://docs.gitlab.com/ee/api/tags.html)
 
 ## Example Usage
 

--- a/internal/provider/data_source_gitlab_project_issue.go
+++ b/internal/provider/data_source_gitlab_project_issue.go
@@ -12,7 +12,7 @@ var _ = registerDataSource("gitlab_project_issue", func() *schema.Resource {
 	return &schema.Resource{
 		Description: `The ` + "`gitlab_project_issue`" + ` data source allows to retrieve details about an issue in a project.
 
-**Upstream API:** [GitLab API docs](https://docs.gitlab.com/ee/api/issues.html)`,
+**Upstream API**: [GitLab API docs](https://docs.gitlab.com/ee/api/issues.html)`,
 
 		ReadContext: dataSourceGitlabProjectIssueRead,
 		Schema:      datasourceSchemaFromResourceSchema(gitlabProjectIssueGetSchema(), "project", "iid"),

--- a/internal/provider/data_source_gitlab_project_issues.go
+++ b/internal/provider/data_source_gitlab_project_issues.go
@@ -31,7 +31,7 @@ var _ = registerDataSource("gitlab_project_issues", func() *schema.Resource {
 	return &schema.Resource{
 		Description: `The ` + "`gitlab_project_issues`" + ` data source allows to retrieve details about issues in a project.
 
-**Upstream API:** [GitLab API docs](https://docs.gitlab.com/ee/api/issues.html)`,
+**Upstream API**: [GitLab API docs](https://docs.gitlab.com/ee/api/issues.html)`,
 
 		ReadContext: dataSourceGitlabProjectIssuesRead,
 		Schema: map[string]*schema.Schema{

--- a/internal/provider/data_source_gitlab_project_tag.go
+++ b/internal/provider/data_source_gitlab_project_tag.go
@@ -13,7 +13,7 @@ var _ = registerDataSource("gitlab_project_tag", func() *schema.Resource {
 	return &schema.Resource{
 		Description: `The ` + "`gitlab_project_tag`" + ` data source allows details of a project tag to be retrieved by its name.
 
-**Upstream API** : [GitLab API docs](https://docs.gitlab.com/ee/api/tags.html)`,
+**Upstream API**: [GitLab API docs](https://docs.gitlab.com/ee/api/tags.html)`,
 
 		ReadContext: dataSourceGitlabProjectTagRead,
 		Schema: map[string]*schema.Schema{

--- a/internal/provider/resource_gitlab_group.go
+++ b/internal/provider/resource_gitlab_group.go
@@ -17,8 +17,9 @@ import (
 
 var _ = registerResource("gitlab_group", func() *schema.Resource {
 	return &schema.Resource{
-		Description: "This resource allows you to create and manage GitLab groups.\n" +
-			"Note your provider will need to be configured with admin-level access for this resource to work.",
+		Description: "This resource allows you to create and manage GitLab groups.\n\n" +
+			"Note your provider will need to be configured with admin-level access for this resource to work.\n\n" +
+			"**Upstream API**: [GitLab Groups API](https://docs.gitlab.com/ee/api/groups.html)",
 
 		CreateContext: resourceGitlabGroupCreate,
 		ReadContext:   resourceGitlabGroupRead,

--- a/internal/provider/resource_gitlab_project_issue.go
+++ b/internal/provider/resource_gitlab_project_issue.go
@@ -25,7 +25,7 @@ var _ = registerResource("gitlab_project_issue", func() *schema.Resource {
 
 ~> **Experimental**: while the base functionality of this resource works, it may be subject to minor change.
 
-**Upstream API:** [GitLab API docs](https://docs.gitlab.com/ee/api/issues.html)
+**Upstream API**: [GitLab API docs](https://docs.gitlab.com/ee/api/issues.html)
 		`,
 
 		CreateContext: resourceGitlabProjectIssueCreate,

--- a/internal/provider/resource_gitlab_project_tag.go
+++ b/internal/provider/resource_gitlab_project_tag.go
@@ -13,7 +13,7 @@ var _ = registerResource("gitlab_project_tag", func() *schema.Resource {
 	return &schema.Resource{
 		Description: `The ` + "`gitlab_project_tag`" + ` resource allows to manage the lifecycle of a tag in a project.
 
-**Upstream API** : [GitLab API docs](https://docs.gitlab.com/ee/api/tags.html)`,
+**Upstream API**: [GitLab API docs](https://docs.gitlab.com/ee/api/tags.html)`,
 
 		CreateContext: resourceGitlabProjectTagCreate,
 		ReadContext:   resourceGitlabProjectTagRead,

--- a/scripts/lint-custom.sh
+++ b/scripts/lint-custom.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+
+# This script is run during the CI workflow in order to run additional custom checks and validations
+# that do not fit into an existing lint framework.
+#
+# This script uses GitHub workflow commands in order to add contextual error messages:
+#   https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message
+#
+# Usage:
+#   ./scripts/lint-custom.sh
+
+has_failure=''
+
+pattern="^\*\*Upstream API\*\*: \[.*\](.*)$"
+files_without_match="$(grep --recursive --files-without-match "$pattern" ./docs/resources ./docs/data-sources)"
+test -z "$files_without_match" || {
+    has_failure='true'
+    echo "$files_without_match" | xargs -I{} echo "::error file={}::Generated documentation file {} should reference an upstream GitLab API. Expected file to match regex \"$pattern\"."
+}
+
+# ^^^ Add new checks above this line ^^^
+
+test -z "$has_failure"


### PR DESCRIPTION
## Description

<!-- Which issue/s does this PR close? Is there any more context you can give the reviewer? -->

Added a new CI job and make target `make lint-custom` to run a shell script that performs miscellaneous additional linter automation that can't fit into an existing lint framework.

Added one custom linter that greps the generated documentation and outputs an error for any pages that are missing a link to upstream GitLab documentation.

The linter script uses the [::error](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message) command in order to annotate the PR files with the error message.

Here's what the errors look like in a PR:

<img width="1286" alt="Screen Shot 2022-03-08 at 5 06 01 PM" src="https://user-images.githubusercontent.com/9969202/157352494-75709d96-2c27-4def-94b0-303621bfa838.png">


### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
