### PR TITLE
Add SELinux Z flag to docker bind

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - config-ce:/etc/gitlab
       - logs-ce:/var/log/gitlab
       - data-ce:/var/opt/gitlab
-      - ${PWD}/scripts/healthcheck-and-setup.sh:/healthcheck-and-setup.sh
+      - ${PWD}/scripts/healthcheck-and-setup.sh:/healthcheck-and-setup.sh:Z
     healthcheck:
       test: /healthcheck-and-setup.sh
       interval: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,8 +36,8 @@ services:
       - config-ee:/etc/gitlab
       - logs-ee:/var/log/gitlab
       - data-ee:/var/opt/gitlab
-      - ${PWD}/scripts/healthcheck-and-setup.sh:/healthcheck-and-setup.sh
-      - ${PWD}/Gitlab-license.txt:/Gitlab-license.txt
+      - ${PWD}/scripts/healthcheck-and-setup.sh:/healthcheck-and-setup.sh:Z
+      - ${PWD}/Gitlab-license.txt:/Gitlab-license.txt:Z
     healthcheck:
       test: /healthcheck-and-setup.sh
       interval: 10s


### PR DESCRIPTION
The 'Z' option tells Docker to label the content with a private unshared
label. This fixes running healtcheck-and-setup on SELinux distros
(RedHat, Fedora, CentOS). Without the flag, SELinux prevents any access
to the file.

## Description

<!-- Which issue/s does this PR close? Is there any more context you can give the reviewer? -->

### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
