### PR TITLE
resource/gitlab_project_approval_rule: fix potential accidental destroy of resource if not in first page

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.11.0
 	github.com/mitchellh/hashstructure v1.1.0
 	github.com/onsi/gomega v1.18.1
-	github.com/xanzy/go-gitlab v0.59.0
+	github.com/xanzy/go-gitlab v0.60.0
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/oauth2 v0.0.0-20220309155454-6242fa91716a // indirect

--- a/go.sum
+++ b/go.sum
@@ -310,8 +310,8 @@ github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvC
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-github.com/xanzy/go-gitlab v0.59.0 h1:fAr6rT/YIdfmBavYgI42+Op7yAAex2Y4xOfvbjN9hxQ=
-github.com/xanzy/go-gitlab v0.59.0/go.mod h1:F0QEXwmqiBUxCgJm8fE9S+1veX4XC9Z4cfaAbqwk4YM=
+github.com/xanzy/go-gitlab v0.60.0 h1:HaIlc14k4t9eJjAhY0Gmq2fBHgKd1MthBn3+vzDtsbA=
+github.com/xanzy/go-gitlab v0.60.0/go.mod h1:F0QEXwmqiBUxCgJm8fE9S+1veX4XC9Z4cfaAbqwk4YM=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/provider/data_source_gitlab_project_issues.go
+++ b/internal/provider/data_source_gitlab_project_issues.go
@@ -267,7 +267,7 @@ func dataSourceGitlabProjectIssuesRead(ctx context.Context, d *schema.ResourceDa
 	}
 
 	if v, ok := d.GetOk("assignee_id"); ok {
-		options.AssigneeID = gitlab.Int(v.(int))
+		options.AssigneeID = gitlab.AssigneeID(v.(int))
 	}
 
 	if v, ok := d.GetOk("not_assignee_id"); ok {

--- a/internal/provider/resource_gitlab_project_approval_rule.go
+++ b/internal/provider/resource_gitlab_project_approval_rule.go
@@ -115,21 +115,28 @@ func resourceGitlabProjectApprovalRuleCreate(ctx context.Context, d *schema.Reso
 func resourceGitlabProjectApprovalRuleRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Printf("[DEBUG] read gitlab project-level rule %s", d.Id())
 
-	projectID, _, err := parseTwoPartID(d.Id())
+	projectID, parsedRuleID, err := parseTwoPartID(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	d.Set("project", projectID)
-
-	rule, err := getApprovalRuleByID(ctx, meta.(*gitlab.Client), d.Id())
+	ruleID, err := strconv.Atoi(parsedRuleID)
 	if err != nil {
-		if errors.Is(err, errApprovalRuleNotFound) {
+		return diag.FromErr(err)
+	}
+
+	client := meta.(*gitlab.Client)
+
+	rule, _, err := client.Projects.GetProjectApprovalRule(projectID, ruleID, gitlab.WithContext(ctx))
+	if err != nil {
+		if is404(err) {
+			log.Printf("[DEBUG] no project-level rule %s found, removing from state", d.Id())
 			d.SetId("")
 			return nil
 		}
 		return diag.FromErr(err)
 	}
 
+	d.Set("project", projectID)
 	d.Set("name", rule.Name)
 	d.Set("approvals_required", rule.ApprovalsRequired)
 	d.Set("rule_type", rule.RuleType)
@@ -201,35 +208,6 @@ func resourceGitlabProjectApprovalRuleDelete(ctx context.Context, d *schema.Reso
 	}
 
 	return nil
-}
-
-// getApprovalRuleByID checks the list of rules and finds the one that matches our rule ID.
-func getApprovalRuleByID(ctx context.Context, client *gitlab.Client, id string) (*gitlab.ProjectApprovalRule, error) {
-	projectID, ruleID, err := parseTwoPartID(id)
-	if err != nil {
-		return nil, err
-	}
-
-	ruleIDInt, err := strconv.Atoi(ruleID)
-	if err != nil {
-		return nil, err
-	}
-
-	log.Printf("[DEBUG] read approval rules for project %s", projectID)
-
-	rules, _, err := client.Projects.GetProjectApprovalRules(projectID, gitlab.WithContext(ctx))
-	if err != nil {
-		return nil, err
-	}
-
-	for _, r := range rules {
-		if r.ID == ruleIDInt {
-			log.Printf("[DEBUG] found project-level rule %+v", r)
-			return r, nil
-		}
-	}
-
-	return nil, errApprovalRuleNotFound
 }
 
 // flattenApprovalRuleUserIDs flattens a list of approval user ids into a list

--- a/internal/provider/resource_gitlab_project_approval_rule.go
+++ b/internal/provider/resource_gitlab_project_approval_rule.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"strconv"
@@ -12,9 +11,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	gitlab "github.com/xanzy/go-gitlab"
 )
-
-// https://docs.gitlab.com/ee/api/merge_request_approvals.html#create-project-level-rule
-var errApprovalRuleNotFound = errors.New("approval rule not found")
 
 var _ = registerResource("gitlab_project_approval_rule", func() *schema.Resource {
 	var validRuleTypeValues = []string{


### PR DESCRIPTION
This fixes a potential bug that the resource is marked for destroy after a read,
because it was not found on the first page. Pagination was not implemented.
However, there exist a specific API to get a single project-level approval rule.
I have implemented it in go-gitlab:

* https://github.com/xanzy/go-gitlab/pull/1410

After it is released, we should be able to just rebase and LGTM ;)

Refs: #949 
