### PR TITLE
Update managed_license resources to deprecate existing values and add GitLab 15+ values

### DIFF
--- a/docs/resources/managed_license.md
+++ b/docs/resources/managed_license.md
@@ -28,7 +28,7 @@ resource "gitlab_project" "foo" {
 resource "gitlab_managed_license" "mit" {
   project         = gitlab_project.foo.id
   name            = "MIT license"
-  approval_status = "approved"
+  approval_status = "allowed"
 }
 ```
 
@@ -37,7 +37,9 @@ resource "gitlab_managed_license" "mit" {
 
 ### Required
 
-- **approval_status** (String) Whether the license is approved or not. Only 'approved' or 'blacklisted' allowed.
+- **approval_status** (String) The approval status of the license. Valid values are: `approved`, `blacklisted`, `allowed`, `denied`. "approved" and "blacklisted" 
+				have been deprecated in favor of "allowed" and "denied"; use "allowed" and "denied" for GitLab versions 15.0 and higher. 
+				Prior to version 15.0 and after 14.6, the values are equivalent.
 - **name** (String) The name of the managed license (I.e., 'Apache License 2.0' or 'MIT license')
 - **project** (String) The ID of the project under which the managed license will be created.
 

--- a/examples/resources/gitlab_managed_license/resource.tf
+++ b/examples/resources/gitlab_managed_license/resource.tf
@@ -7,5 +7,5 @@ resource "gitlab_project" "foo" {
 resource "gitlab_managed_license" "mit" {
   project         = gitlab_project.foo.id
   name            = "MIT license"
-  approval_status = "approved"
+  approval_status = "allowed"
 }

--- a/internal/provider/helper_test.go
+++ b/internal/provider/helper_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/xanzy/go-gitlab"
 )
 
+type SkipFunc = func() (bool, error)
+
 func init() {
 	// We are using the gomega package for its matchers only, but it requires us to register a handler anyway.
 	gomega.RegisterFailHandler(func(_ string, _ ...int) {
@@ -68,6 +70,22 @@ func testAccCheck(t *testing.T) {
 
 	if os.Getenv(resource.EnvTfAcc) == "" {
 		t.Skip(fmt.Sprintf("Acceptance tests skipped unless env '%s' set", resource.EnvTfAcc))
+	}
+}
+
+// orSkipFunc accepts many skipFunc and returns "true" if any returns true.
+func orSkipFunc(input ...SkipFunc) SkipFunc {
+	return func() (bool, error) {
+		for _, item := range input {
+			result, err := item()
+			if err != nil {
+				return false, err
+			}
+			if result {
+				return result, nil
+			}
+		}
+		return false, nil
 	}
 }
 


### PR DESCRIPTION
## Description

Closes #951

### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
