### PR TITLE
Use specific GET API instead of list for labels

### DIFF
--- a/docs/resources/label.md
+++ b/docs/resources/label.md
@@ -46,4 +46,11 @@ resource "gitlab_label" "devops_create" {
 - **description** (String) The description of the label.
 - **id** (String) The ID of this resource.
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+# Gitlab labels can be imported using an id made up of `{project_id}:{group_label_id}`, e.g.
+terraform import gitlab_label.example 12345:fixme
+```

--- a/examples/resources/gitlab_label/import.sh
+++ b/examples/resources/gitlab_label/import.sh
@@ -1,0 +1,2 @@
+# Gitlab labels can be imported using an id made up of `{project_id}:{group_label_id}`, e.g.
+terraform import gitlab_label.example 12345:fixme

--- a/internal/provider/resource_gitlab_group_label_test.go
+++ b/internal/provider/resource_gitlab_group_label_test.go
@@ -53,53 +53,8 @@ func TestAccGitlabGroupLabel_basic(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccGitlabGroupLabelLargeConfig(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabGroupLabelExists("gitlab_group_label.fixme.20", &label),
-					testAccCheckGitlabGroupLabelExists("gitlab_group_label.fixme.30", &label),
-					testAccCheckGitlabGroupLabelExists("gitlab_group_label.fixme.40", &label),
-					testAccCheckGitlabGroupLabelExists("gitlab_group_label.fixme.10", &label),
-					testAccCheckGitlabGroupLabelAttributes(&label, &testAccGitlabGroupLabelExpectedAttributes{
-						Name:        "FIXME11",
-						Color:       "#ffcc00",
-						Description: "fix this test",
-					}),
-				),
-			},
-			{
-				Config: testAccGitlabGroupLabelUpdateLargeConfig(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabGroupLabelExists("gitlab_group_label.fixme.20", &label),
-					testAccCheckGitlabGroupLabelExists("gitlab_group_label.fixme.30", &label),
-					testAccCheckGitlabGroupLabelExists("gitlab_group_label.fixme.40", &label),
-					testAccCheckGitlabGroupLabelExists("gitlab_group_label.fixme.10", &label),
-					testAccCheckGitlabGroupLabelAttributes(&label, &testAccGitlabGroupLabelExpectedAttributes{
-						Name:        "FIXME11",
-						Color:       "#ff0000",
-						Description: "red label",
-					}),
-				),
-			},
-		},
-	})
-}
-
-// lintignore: AT002 // TODO: Resolve this tfproviderlint issue
-func TestAccGitlabGroupLabel_import(t *testing.T) {
-	rInt := acctest.RandInt()
-	resourceName := "gitlab_group_label.fixme"
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: providerFactories,
-		CheckDestroy:      testAccCheckGitlabGroupLabelDestroy,
-		Steps: []resource.TestStep{
-			{
-				Config: testAccGitlabGroupLabelConfig(rInt),
-			},
-			{
-				ResourceName:      resourceName,
-				ImportStateIdFunc: getGroupLabelImportID(resourceName),
+				ResourceName:      "gitlab_group_label.fixme",
+				ImportStateIdFunc: getGroupLabelImportID("gitlab_group_label.fixme"),
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -234,42 +189,4 @@ resource "gitlab_group_label" "fixme" {
   description = "red label"
 }
 	`, rInt, rInt, rInt)
-}
-
-func testAccGitlabGroupLabelLargeConfig(rInt int) string {
-	return fmt.Sprintf(`
-resource "gitlab_group" "foo" {
-  name             = "foo-%d"
-  path             = "foo-%d"
-  description      = "Terraform acceptance tests"
-  visibility_level = "public"
-}
-
-resource "gitlab_group_label" "fixme" {
-  group = "${gitlab_group.foo.id}"
-  name = format("FIXME%%02d", count.index+1)
-  count = 100
-  color = "#ffcc00"
-  description = "fix this test"
-}
-	`, rInt, rInt)
-}
-
-func testAccGitlabGroupLabelUpdateLargeConfig(rInt int) string {
-	return fmt.Sprintf(`
-resource "gitlab_group" "foo" {
-  name             = "foo-%d"
-  path             = "foo-%d"
-  description      = "Terraform acceptance tests"
-  visibility_level = "public"
-}
-
-resource "gitlab_group_label" "fixme" {
-  group = "${gitlab_group.foo.id}"
-  name = format("FIXME%%02d", count.index+1)
-  count = 99
-  color = "#ff0000"
-  description = "red label"
-}
-	`, rInt, rInt)
 }

--- a/internal/provider/resource_gitlab_label.go
+++ b/internal/provider/resource_gitlab_label.go
@@ -2,7 +2,10 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"strconv"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -10,7 +13,6 @@ import (
 )
 
 var _ = registerResource("gitlab_label", func() *schema.Resource {
-	// lintignore: XR002 // TODO: Resolve this tfproviderlint issue
 	return &schema.Resource{
 		Description: `The ` + "`" + `gitlab_label` + "`" + ` resource allows to manage the lifecycle of a project label.
 
@@ -20,6 +22,12 @@ var _ = registerResource("gitlab_label", func() *schema.Resource {
 		ReadContext:   resourceGitlabLabelRead,
 		UpdateContext: resourceGitlabLabelUpdate,
 		DeleteContext: resourceGitlabLabelDelete,
+		// FIXME: this importer sucks a little, but we can't use a passthrough importer, because
+		//        the resource id is flawed and we don't want to break backwards-compatibility.
+		//        We cannot have the same label in two different projects as of now, ...
+		Importer: &schema.ResourceImporter{
+			StateContext: resourceGitlabLabelImporter,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"project": {
@@ -129,4 +137,29 @@ func resourceGitlabLabelDelete(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	return nil
+}
+
+func resourceGitlabLabelImporter(ctx context.Context, d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {
+	client := meta.(*gitlab.Client)
+	parts := strings.SplitN(d.Id(), ":", 2)
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid label id (should be <project ID>.<label name>): %s", d.Id())
+	}
+
+	d.SetId(parts[1])
+	project, _, err := client.Projects.GetProject(parts[0], nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := d.Set("project", strconv.Itoa(project.ID)); err != nil {
+		return nil, err
+	}
+
+	diagnostic := resourceGitlabLabelRead(ctx, d, meta)
+	if diagnostic.HasError() {
+		return nil, fmt.Errorf("failed to read project label %s: %s", d.Id(), diagnostic[0].Summary)
+	}
+
+	return []*schema.ResourceData{d}, nil
 }

--- a/internal/provider/resource_gitlab_label_test.go
+++ b/internal/provider/resource_gitlab_label_test.go
@@ -55,36 +55,6 @@ func TestAccGitlabLabel_basic(t *testing.T) {
 					}),
 				),
 			},
-			// Create a project and lots of labels with default options
-			{
-				Config: testAccGitlabLabelLargeConfig(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabLabelExists("gitlab_label.fixme.20", &label),
-					testAccCheckGitlabLabelExists("gitlab_label.fixme.30", &label),
-					testAccCheckGitlabLabelExists("gitlab_label.fixme.40", &label),
-					testAccCheckGitlabLabelExists("gitlab_label.fixme.10", &label),
-					testAccCheckGitlabLabelAttributes(&label, &testAccGitlabLabelExpectedAttributes{
-						Name:        "FIXME11",
-						Color:       "#ffcc00",
-						Description: "fix this test",
-					}),
-				),
-			},
-			// Update the lots of labels to change the parameters
-			{
-				Config: testAccGitlabLabelUpdateLargeConfig(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabLabelExists("gitlab_label.fixme.20", &label),
-					testAccCheckGitlabLabelExists("gitlab_label.fixme.30", &label),
-					testAccCheckGitlabLabelExists("gitlab_label.fixme.40", &label),
-					testAccCheckGitlabLabelExists("gitlab_label.fixme.10", &label),
-					testAccCheckGitlabLabelAttributes(&label, &testAccGitlabLabelExpectedAttributes{
-						Name:        "FIXME11",
-						Color:       "#ff0000",
-						Description: "red label",
-					}),
-				),
-			},
 		},
 	})
 }
@@ -200,46 +170,4 @@ resource "gitlab_label" "fixme" {
   description = "red label"
 }
 	`, rInt, rInt)
-}
-
-func testAccGitlabLabelLargeConfig(rInt int) string {
-	return fmt.Sprintf(`
-resource "gitlab_project" "foo" {
-  name = "foo-%d"
-  description = "Terraform acceptance tests"
-
-  # So that acceptance tests can be run in a gitlab organization
-  # with no billing
-  visibility_level = "public"
-}
-
-resource "gitlab_label" "fixme" {
-  project = "${gitlab_project.foo.id}"
-  name = format("FIXME%%02d", count.index+1)
-  count = 100
-  color = "#ffcc00"
-  description = "fix this test"
-}
-	`, rInt)
-}
-
-func testAccGitlabLabelUpdateLargeConfig(rInt int) string {
-	return fmt.Sprintf(`
-resource "gitlab_project" "foo" {
-  name = "foo-%d"
-  description = "Terraform acceptance tests"
-
-  # So that acceptance tests can be run in a gitlab organization
-  # with no billing
-  visibility_level = "public"
-}
-
-resource "gitlab_label" "fixme" {
-  project = "${gitlab_project.foo.id}"
-  name = format("FIXME%%02d", count.index+1)
-  count = 99
-  color = "#ff0000"
-  description = "red label"
-}
-	`, rInt)
 }

--- a/internal/provider/resource_gitlab_label_test.go
+++ b/internal/provider/resource_gitlab_label_test.go
@@ -55,8 +55,35 @@ func TestAccGitlabLabel_basic(t *testing.T) {
 					}),
 				),
 			},
+			// Verify Import
+			{
+				ResourceName:      "gitlab_label.fixme",
+				ImportStateIdFunc: getLabelImportID("gitlab_label.fixme"),
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
 		},
 	})
+}
+
+func getLabelImportID(n string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return "", fmt.Errorf("Not Found: %s", n)
+		}
+
+		labelID := rs.Primary.ID
+		if labelID == "" {
+			return "", fmt.Errorf("No label key ID is set")
+		}
+		projectID := rs.Primary.Attributes["project"]
+		if projectID == "" {
+			return "", fmt.Errorf("No project ID is set")
+		}
+
+		return fmt.Sprintf("%s:%s", projectID, labelID), nil
+	}
 }
 
 func testAccCheckGitlabLabelExists(n string, label *gitlab.Label) resource.TestCheckFunc {


### PR DESCRIPTION
Removing some tech debt to use specific resources GET API instead of the list API...

Also implementing the missing `gitlab_label` importer (#36) and removing some unnecessary large testing configurations.