### PR TITLE
Implement all missing importers

### DIFF
--- a/docs/resources/deploy_token.md
+++ b/docs/resources/deploy_token.md
@@ -59,6 +59,16 @@ resource "gitlab_deploy_token" "example" {
 
 ### Read-Only
 
-- **token** (String, Sensitive) The secret token. This is only populated when creating a new deploy token.
+- **token** (String, Sensitive) The secret token. This is only populated when creating a new deploy token. **Note**: The token is not available for imported resources.
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+# GitLab deploy tokens can be imported using an id made up of `{type}:{type_id}:{deploy_token_id}`, where type is one of: project, group.
+terraform import gitlab_deploy_token.group_token group:1:3
+terraform import gitlab_deploy_token.project_token project:1:4
+
+# Note: the `token` resource attribute is not available for imported resources as this information cannot be read from the GitLab API.
+```

--- a/docs/resources/project_access_token.md
+++ b/docs/resources/project_access_token.md
@@ -50,7 +50,16 @@ resource "gitlab_project_variable" "example" {
 - **active** (Boolean) True if the token is active.
 - **created_at** (String) Time the token has been created, RFC3339 format.
 - **revoked** (Boolean) True if the token is revoked.
-- **token** (String, Sensitive) The secret token. This is only populated when creating a new project access token.
+- **token** (String, Sensitive) The secret token. **Note**: the token is not available for imported resources.
 - **user_id** (Number) The user_id associated to the token.
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+# A GitLab Project Access Token can be imported using a key composed of `<project-id>:<token-id>`, e.g.
+terraform import gitlab_project_access_token.example "12345:1"
+
+# NOTE: the `token` resource attribute is not available for imported resources as this information cannot be read from the GitLab API.
+```

--- a/docs/resources/project_hook.md
+++ b/docs/resources/project_hook.md
@@ -47,7 +47,16 @@ resource "gitlab_project_hook" "example" {
 - **push_events_branch_filter** (String) Invoke the hook for push events on matching branches only.
 - **releases_events** (Boolean) Invoke the hook for releases events.
 - **tag_push_events** (Boolean) Invoke the hook for tag push events.
-- **token** (String, Sensitive) A token to present when invoking the hook.
+- **token** (String, Sensitive) A token to present when invoking the hook. The token is not available for imported resources.
 - **wiki_page_events** (Boolean) Invoke the hook for wiki page events.
 
+## Import
 
+Import is supported using the following syntax:
+
+```shell
+# A GitLab Project Hook can be imported using a key composed of `<project-id>:<hook-id>`, e.g.
+terraform import gitlab_project_hook.example "12345:1"
+
+# NOTE: the `token` resource attribute is not available for imported resources as this information cannot be read from the GitLab API.
+```

--- a/examples/resources/gitlab_deploy_token/import.sh
+++ b/examples/resources/gitlab_deploy_token/import.sh
@@ -1,0 +1,5 @@
+# GitLab deploy tokens can be imported using an id made up of `{type}:{type_id}:{deploy_token_id}`, where type is one of: project, group.
+terraform import gitlab_deploy_token.group_token group:1:3
+terraform import gitlab_deploy_token.project_token project:1:4
+
+# Note: the `token` resource attribute is not available for imported resources as this information cannot be read from the GitLab API.

--- a/examples/resources/gitlab_project_access_token/import.sh
+++ b/examples/resources/gitlab_project_access_token/import.sh
@@ -1,0 +1,4 @@
+# A GitLab Project Access Token can be imported using a key composed of `<project-id>:<token-id>`, e.g.
+terraform import gitlab_project_access_token.example "12345:1"
+
+# NOTE: the `token` resource attribute is not available for imported resources as this information cannot be read from the GitLab API.

--- a/examples/resources/gitlab_project_hook/import.sh
+++ b/examples/resources/gitlab_project_hook/import.sh
@@ -1,0 +1,4 @@
+# A GitLab Project Hook can be imported using a key composed of `<project-id>:<hook-id>`, e.g.
+terraform import gitlab_project_hook.example "12345:1"
+
+# NOTE: the `token` resource attribute is not available for imported resources as this information cannot be read from the GitLab API.

--- a/internal/provider/resource_gitlab_group_ldap_link.go
+++ b/internal/provider/resource_gitlab_group_ldap_link.go
@@ -13,7 +13,6 @@ import (
 )
 
 var _ = registerResource("gitlab_group_ldap_link", func() *schema.Resource {
-	// lintignore: XR002 // TODO: Resolve this tfproviderlint issue
 	return &schema.Resource{
 		Description: `The ` + "`gitlab_group_ldap_link`" + ` resource allows to manage the lifecycle of an LDAP integration with a group.
 

--- a/internal/provider/resource_gitlab_project_access_token.go
+++ b/internal/provider/resource_gitlab_project_access_token.go
@@ -14,7 +14,6 @@ import (
 )
 
 var _ = registerResource("gitlab_project_access_token", func() *schema.Resource {
-	// lintignore: XR002 // TODO: Resolve this tfproviderlint issue
 	return &schema.Resource{
 		Description: `The ` + "`" + `gitlab_project_access_token` + "`" + ` resource allows to manage the lifecycle of a project access token.
 
@@ -23,6 +22,9 @@ var _ = registerResource("gitlab_project_access_token", func() *schema.Resource 
 		CreateContext: resourceGitlabProjectAccessTokenCreate,
 		ReadContext:   resourceGitlabProjectAccessTokenRead,
 		DeleteContext: resourceGitlabProjectAccessTokenDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
 
 		Schema: map[string]*schema.Schema{
 			"project": {
@@ -63,7 +65,7 @@ var _ = registerResource("gitlab_project_access_token", func() *schema.Resource 
 				ForceNew: true,
 			},
 			"token": {
-				Description: "The secret token. This is only populated when creating a new project access token.",
+				Description: "The secret token. **Note**: the token is not available for imported resources.",
 				Type:        schema.TypeString,
 				Computed:    true,
 				Sensitive:   true,

--- a/internal/provider/resource_gitlab_project_access_token_test.go
+++ b/internal/provider/resource_gitlab_project_access_token_test.go
@@ -73,6 +73,16 @@ func TestAccGitlabProjectAccessToken_basic(t *testing.T) {
 					}),
 				),
 			},
+			// Verify import
+			{
+				ResourceName:      "gitlab_project_access_token.bar",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					// the token is only known during creating. We explicitly mention this limitation in the docs.
+					"token",
+				},
+			},
 			//Destroy Project Access Token
 			{
 				Config: testAccGitlabProjectAccessTokenDestroyToken(rInt),

--- a/internal/provider/resource_gitlab_project_hook_test.go
+++ b/internal/provider/resource_gitlab_project_hook_test.go
@@ -68,6 +68,14 @@ func TestAccGitlabProjectHook_basic(t *testing.T) {
 					}),
 				),
 			},
+			// Verify import
+			{
+				ResourceName:            "gitlab_project_hook.foo",
+				ImportStateIdFunc:       getProjectHookImportID("gitlab_project_hook.foo"),
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"token"},
+			},
 		},
 	})
 }
@@ -201,6 +209,25 @@ func testAccCheckGitlabProjectHookDestroy(s *terraform.State) error {
 		return nil
 	}
 	return nil
+}
+
+func getProjectHookImportID(n string) resource.ImportStateIdFunc {
+	return func(s *terraform.State) (string, error) {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return "", fmt.Errorf("Not Found: %s", n)
+		}
+
+		hookID := rs.Primary.ID
+		if hookID == "" {
+			return "", fmt.Errorf("No hook ID is set")
+		}
+		projectID := rs.Primary.Attributes["project"]
+		if projectID == "" {
+			return "", fmt.Errorf("No project ID is set")
+		}
+		return fmt.Sprintf("%s:%s", projectID, hookID), nil
+	}
 }
 
 func testAccGitlabProjectHookConfig(rInt int) string {


### PR DESCRIPTION
This change set together with (https://github.com/gitlabhq/terraform-provider-gitlab/pull/954) implements all missing importers and therefore closes the long open #36 .

I've focused on the importer themselves and not so much about the underlying ids. 
I'll follow up with an issue describing the current state of resource ids currently in use. I hope that we can streamline those for v4 of the provider ...