### PR TITLE
Use context for all GitLab API calls

### DIFF
--- a/internal/provider/config.go
+++ b/internal/provider/config.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"io/ioutil"
@@ -22,7 +23,7 @@ type Config struct {
 }
 
 // Client returns a *gitlab.Client to interact with the configured gitlab instance
-func (c *Config) Client() (*gitlab.Client, error) {
+func (c *Config) Client(ctx context.Context) (*gitlab.Client, error) {
 	// Configure TLS/SSL
 	tlsConfig := &tls.Config{}
 
@@ -78,7 +79,7 @@ func (c *Config) Client() (*gitlab.Client, error) {
 
 	// Test the credentials by checking we can get information about the authenticated user.
 	if c.EarlyAuthFail {
-		_, _, err = client.Users.CurrentUser()
+		_, _, err = client.Users.CurrentUser(gitlab.WithContext(ctx))
 	}
 
 	return client, err

--- a/internal/provider/data_source_gitlab_group_membership.go
+++ b/internal/provider/data_source_gitlab_group_membership.go
@@ -118,7 +118,7 @@ func dataSourceGitlabGroupMembershipRead(ctx context.Context, d *schema.Resource
 		}
 	} else if fullPathOk {
 		// Get group by full path
-		group, _, err = client.Groups.GetGroup(fullPathData.(string), nil)
+		group, _, err = client.Groups.GetGroup(fullPathData.(string), nil, gitlab.WithContext(ctx))
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/internal/provider/data_source_gitlab_project_issues.go
+++ b/internal/provider/data_source_gitlab_project_issues.go
@@ -348,7 +348,7 @@ func dataSourceGitlabProjectIssuesRead(ctx context.Context, d *schema.ResourceDa
 
 	var issues []*gitlab.Issue
 	for options.Page != 0 {
-		paginatedIssues, resp, err := client.Issues.ListProjectIssues(project, &options)
+		paginatedIssues, resp, err := client.Issues.ListProjectIssues(project, &options, gitlab.WithContext(ctx))
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -105,7 +105,7 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 			EarlyAuthFail: d.Get("early_auth_check").(bool),
 		}
 
-		client, err := config.Client()
+		client, err := config.Client(ctx)
 		if err != nil {
 			return nil, diag.FromErr(err)
 		}

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -35,7 +36,7 @@ var testGitlabClient *gitlab.Client
 
 func init() {
 	if os.Getenv(resource.EnvTfAcc) != "" {
-		client, err := testGitlabConfig.Client()
+		client, err := testGitlabConfig.Client(context.Background())
 		if err != nil {
 			panic("failed to create test client: " + err.Error()) // lintignore: R009 // TODO: Resolve this tfproviderlint issue
 		}

--- a/internal/provider/resource_gitlab_group_label.go
+++ b/internal/provider/resource_gitlab_group_label.go
@@ -138,7 +138,7 @@ func resourceGitlabGroupLabelImporter(ctx context.Context, d *schema.ResourceDat
 	}
 
 	d.SetId(parts[1])
-	group, _, err := client.Groups.GetGroup(parts[0], nil)
+	group, _, err := client.Groups.GetGroup(parts[0], nil, gitlab.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/resource_gitlab_label.go
+++ b/internal/provider/resource_gitlab_label.go
@@ -147,7 +147,7 @@ func resourceGitlabLabelImporter(ctx context.Context, d *schema.ResourceData, me
 	}
 
 	d.SetId(parts[1])
-	project, _, err := client.Projects.GetProject(parts[0], nil)
+	project, _, err := client.Projects.GetProject(parts[0], nil, gitlab.WithContext(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/resource_gitlab_managed_license_test.go
+++ b/internal/provider/resource_gitlab_managed_license_test.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"testing"
@@ -60,7 +61,7 @@ func TestAccGitlabManagedLicense_deprecatedConfigValues(t *testing.T) {
 				// Create a managed license with an "approved" state
 				SkipFunc: orSkipFunc(
 					isRunningInCE,
-					isGitLabVersionLessThan(testGitlabClient, "15.0"),
+					isGitLabVersionLessThan(context.Background(), testGitlabClient, "15.0"),
 				),
 				Config: testManagedLicenseConfig(rInt, "approved"),
 				Check: resource.ComposeTestCheckFunc(
@@ -71,7 +72,7 @@ func TestAccGitlabManagedLicense_deprecatedConfigValues(t *testing.T) {
 				// Update the managed license to have a blacklisted state
 				SkipFunc: orSkipFunc(
 					isRunningInCE,
-					isGitLabVersionLessThan(testGitlabClient, "15.0"),
+					isGitLabVersionLessThan(context.Background(), testGitlabClient, "15.0"),
 				),
 				Config: testManagedLicenseConfig(rInt, "blacklisted"),
 				Check: resource.ComposeTestCheckFunc(
@@ -81,7 +82,7 @@ func TestAccGitlabManagedLicense_deprecatedConfigValues(t *testing.T) {
 			{
 				SkipFunc: orSkipFunc(
 					isRunningInCE,
-					isGitLabVersionLessThan(testGitlabClient, "15.0"),
+					isGitLabVersionLessThan(context.Background(), testGitlabClient, "15.0"),
 				),
 				ResourceName:      "gitlab_managed_license.fixme",
 				ImportState:       true,

--- a/internal/provider/resource_gitlab_project.go
+++ b/internal/provider/resource_gitlab_project.go
@@ -663,7 +663,7 @@ A project can either be created in a group or user namespace.
 	}
 })
 
-func resourceGitlabProjectSetToState(client *gitlab.Client, d *schema.ResourceData, project *gitlab.Project) error {
+func resourceGitlabProjectSetToState(ctx context.Context, client *gitlab.Client, d *schema.ResourceData, project *gitlab.Project) error {
 	d.SetId(fmt.Sprintf("%d", project.ID))
 	d.Set("name", project.Name)
 	d.Set("path", project.Path)
@@ -694,7 +694,7 @@ func resourceGitlabProjectSetToState(client *gitlab.Client, d *schema.ResourceDa
 		return err
 	}
 	d.Set("archived", project.Archived)
-	if supportsSquashOption, err := isGitLabVersionAtLeast(client, "14.1")(); err != nil {
+	if supportsSquashOption, err := isGitLabVersionAtLeast(ctx, client, "14.1")(); err != nil {
 		return err
 	} else if supportsSquashOption {
 		d.Set("squash_option", project.SquashOption)
@@ -938,7 +938,7 @@ func resourceGitlabProjectCreate(ctx context.Context, d *schema.ResourceData, me
 		options.MergeCommitTemplate = gitlab.String(v.(string))
 	}
 
-	if supportsSquashOption, err := isGitLabVersionAtLeast(client, "14.1")(); err != nil {
+	if supportsSquashOption, err := isGitLabVersionAtLeast(ctx, client, "14.1")(); err != nil {
 		return diag.FromErr(err)
 	} else if supportsSquashOption {
 		if v, ok := d.GetOk("squash_option"); ok {
@@ -1153,7 +1153,7 @@ func resourceGitlabProjectRead(ctx context.Context, d *schema.ResourceData, meta
 		return nil
 	}
 
-	if err := resourceGitlabProjectSetToState(client, d, project); err != nil {
+	if err := resourceGitlabProjectSetToState(ctx, client, d, project); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -1262,7 +1262,7 @@ func resourceGitlabProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 		options.LFSEnabled = gitlab.Bool(d.Get("lfs_enabled").(bool))
 	}
 
-	if supportsSquashOption, err := isGitLabVersionAtLeast(client, "14.1")(); err != nil {
+	if supportsSquashOption, err := isGitLabVersionAtLeast(ctx, client, "14.1")(); err != nil {
 		return diag.FromErr(err)
 	} else if supportsSquashOption && d.HasChange("squash_option") {
 		options.SquashOption = stringToSquashOptionValue(d.Get("squash_option").(string))

--- a/internal/provider/resource_gitlab_project_test.go
+++ b/internal/provider/resource_gitlab_project_test.go
@@ -3,6 +3,7 @@
 package provider
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"regexp"
@@ -1192,11 +1193,11 @@ func testAccCheckAggregateGitlabProject(expected, received *gitlab.Project) reso
 				}
 			}
 
-			if err := resourceGitlabProjectSetToState(testGitlabClient, expectedData, expected); err != nil {
+			if err := resourceGitlabProjectSetToState(context.Background(), testGitlabClient, expectedData, expected); err != nil {
 				return err
 			}
 
-			if err := resourceGitlabProjectSetToState(testGitlabClient, receivedData, received); err != nil {
+			if err := resourceGitlabProjectSetToState(context.Background(), testGitlabClient, receivedData, received); err != nil {
 				return err
 			}
 

--- a/internal/provider/resource_gitlab_project_variable_test.go
+++ b/internal/provider/resource_gitlab_project_variable_test.go
@@ -180,7 +180,7 @@ func TestAccGitlabProjectVariable_scoped(t *testing.T) {
 		CheckDestroy: func(state *terraform.State) error {
 			// Destroy behavior is nondeterministic for variables with scopes in GitLab versions prior to 13.4
 			// ref: https://gitlab.com/gitlab-org/gitlab/-/merge_requests/39209
-			if isAtLeast134, err := isGitLabVersionAtLeast(testGitlabClient, "13.4")(); err != nil {
+			if isAtLeast134, err := isGitLabVersionAtLeast(context.Background(), testGitlabClient, "13.4")(); err != nil {
 				return err
 			} else if isAtLeast134 {
 				return testAccGitlabProjectVariableCheckAllVariablesDestroyed(ctx)(state)
@@ -246,7 +246,7 @@ resource "gitlab_project_variable" "bar" {
 			// Update an attribute on one of the variables.
 			// Updating a variable with a non-unique key only works reliably on GitLab v13.4+.
 			{
-				SkipFunc: isGitLabVersionLessThan(testGitlabClient, "13.4"),
+				SkipFunc: isGitLabVersionLessThan(context.Background(), testGitlabClient, "13.4"),
 				Config: fmt.Sprintf(`
 resource "gitlab_project_variable" "foo" {
   project = %[1]d
@@ -270,7 +270,7 @@ resource "gitlab_project_variable" "bar" {
 			// Try to have two variables with the same keys and scopes.
 			// On versions of GitLab < 13.4 this can sometimes result in an inconsistent state instead of an error.
 			{
-				SkipFunc: isGitLabVersionLessThan(testGitlabClient, "13.4"),
+				SkipFunc: isGitLabVersionLessThan(context.Background(), testGitlabClient, "13.4"),
 				Config: fmt.Sprintf(`
 resource "gitlab_project_variable" "foo" {
   project = %[1]d

--- a/internal/provider/resource_gitlab_repository_file.go
+++ b/internal/provider/resource_gitlab_repository_file.go
@@ -287,7 +287,7 @@ func resourceGitlabRepositoryFileDelete(ctx context.Context, d *schema.ResourceD
 		}
 
 		deleteOptions.LastCommitID = gitlab.String(existingRepositoryFile.LastCommitID)
-		resp, err := client.RepositoryFiles.DeleteFile(project, filePath, deleteOptions)
+		resp, err := client.RepositoryFiles.DeleteFile(project, filePath, deleteOptions, gitlab.WithContext(ctx))
 		if err != nil {
 			if isRefreshError(err) {
 				return resource.RetryableError(err)

--- a/internal/provider/resource_gitlab_topic.go
+++ b/internal/provider/resource_gitlab_topic.go
@@ -185,7 +185,7 @@ func resourceGitlabTopicDelete(ctx context.Context, d *schema.ResourceData, meta
 	}
 	softDestroy := d.Get("soft_destroy").(bool)
 
-	deleteNotSupported, err := isGitLabVersionLessThan(client, "14.9")()
+	deleteNotSupported, err := isGitLabVersionLessThan(ctx, client, "14.9")()
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/provider/resource_gitlab_user.go
+++ b/internal/provider/resource_gitlab_user.go
@@ -156,13 +156,13 @@ func resourceGitlabUserCreate(ctx context.Context, d *schema.ResourceData, meta 
 	d.SetId(fmt.Sprintf("%d", user.ID))
 
 	if d.Get("state") == "blocked" {
-		err := client.Users.BlockUser(user.ID)
+		err := client.Users.BlockUser(user.ID, gitlab.WithContext(ctx))
 
 		if err != nil {
 			return diag.FromErr(err)
 		}
 	} else if d.Get("state") == "deactivated" {
-		err := client.Users.DeactivateUser(user.ID)
+		err := client.Users.DeactivateUser(user.ID, gitlab.WithContext(ctx))
 
 		if err != nil {
 			return diag.FromErr(err)
@@ -245,24 +245,24 @@ func resourceGitlabUserUpdate(ctx context.Context, d *schema.ResourceData, meta 
 		// NOTE: yes, this can be written much more consice, however, for the sake of understanding the behavior,
 		//       of the API and the allowed state transitions of GitLab, let's keep it as-is and enjoy the readability.
 		if newState == "active" && oldState == "blocked" {
-			err = client.Users.UnblockUser(id)
+			err = client.Users.UnblockUser(id, gitlab.WithContext(ctx))
 		} else if newState == "active" && oldState == "deactivated" {
-			err = client.Users.ActivateUser(id)
+			err = client.Users.ActivateUser(id, gitlab.WithContext(ctx))
 		} else if newState == "blocked" && oldState == "active" {
-			err = client.Users.BlockUser(id)
+			err = client.Users.BlockUser(id, gitlab.WithContext(ctx))
 		} else if newState == "blocked" && oldState == "deactivated" {
-			err = client.Users.BlockUser(id)
+			err = client.Users.BlockUser(id, gitlab.WithContext(ctx))
 		} else if newState == "deactivated" && oldState == "active" {
-			err = client.Users.DeactivateUser(id)
+			err = client.Users.DeactivateUser(id, gitlab.WithContext(ctx))
 		} else if newState == "deactivated" && oldState == "blocked" {
 			// a blocked user cannot be deactivated, GitLab will return an error, like:
 			// `403 Forbidden - A blocked user cannot be deactivated by the API`
 			// we have to unblock the user first
-			err = client.Users.UnblockUser(id)
+			err = client.Users.UnblockUser(id, gitlab.WithContext(ctx))
 			if err != nil {
 				return diag.FromErr(err)
 			}
-			err = client.Users.DeactivateUser(id)
+			err = client.Users.DeactivateUser(id, gitlab.WithContext(ctx))
 		}
 
 		if err != nil {

--- a/internal/provider/util.go
+++ b/internal/provider/util.go
@@ -225,23 +225,23 @@ func intSetToIntSlice(intSet *schema.Set) *[]int {
 
 // isGitLabVersionLessThan is a SkipFunc that returns true if the provided version is lower then
 // the current version of GitLab. It only checks the major and minor version numbers, not the patch.
-func isGitLabVersionLessThan(client *gitlab.Client, version string) func() (bool, error) {
+func isGitLabVersionLessThan(ctx context.Context, client *gitlab.Client, version string) func() (bool, error) {
 	return func() (bool, error) {
-		isAtLeast, err := isGitLabVersionAtLeast(client, version)()
+		isAtLeast, err := isGitLabVersionAtLeast(ctx, client, version)()
 		return !isAtLeast, err
 	}
 }
 
 // isGitLabVersionAtLeast is a SkipFunc that checks that the version of GitLab is at least the
 // provided wantVersion. It only checks the major and minor version numbers, not the patch.
-func isGitLabVersionAtLeast(client *gitlab.Client, wantVersion string) func() (bool, error) {
+func isGitLabVersionAtLeast(ctx context.Context, client *gitlab.Client, wantVersion string) func() (bool, error) {
 	return func() (bool, error) {
 		wantMajor, wantMinor, err := parseVersionMajorMinor(wantVersion)
 		if err != nil {
 			return false, fmt.Errorf("failed to parse wanted version %q: %w", wantVersion, err)
 		}
 
-		actualVersion, _, err := client.Version.GetVersion()
+		actualVersion, _, err := client.Version.GetVersion(gitlab.WithContext(ctx))
 		if err != nil {
 			return false, err
 		}


### PR DESCRIPTION
This change set uses the context for all GitLab API calls.

Required:

* https://github.com/xanzy/go-gitlab/pull/1419

