### PR TITLE
resource/gitlab_project: Mark `topics` attribute as `Computed`

### DIFF
--- a/internal/provider/resource_gitlab_project.go
+++ b/internal/provider/resource_gitlab_project.go
@@ -565,6 +565,7 @@ var resourceGitLabProjectSchema = map[string]*schema.Schema{
 		Set:         schema.HashString,
 		Elem:        &schema.Schema{Type: schema.TypeString},
 		Optional:    true,
+		Computed:    true,
 	},
 	"wiki_access_level": {
 		Description:      fmt.Sprintf("Set the wiki access level. Valid values are %s.", renderValueListForDocs(validProjectAccessLevels)),


### PR DESCRIPTION
This avoids a subsequent non-empty plan to a minial `gitlab_project` configuration:

```
Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the last "terraform apply":

  # gitlab_project.test has changed
  ~ resource "gitlab_project" "test" {
        id                                               = "481"
        name                                             = "Test 3"
        tags                                             = []
      + topics                                           = []
        # (57 unchanged attributes hidden)

        # (2 unchanged blocks hidden)
    }

Unless you have made equivalent changes to your configuration, or ignored the relevant attributes using ignore_changes, the following plan may include actions to undo or respond to these changes.
```

This behavior has not yet been released. See #917
