### PR TITLE
resource/gitlab_project_mirror: Support deletion on destroy

### DIFF
--- a/docs/resources/project_mirror.md
+++ b/docs/resources/project_mirror.md
@@ -6,6 +6,9 @@ description: |-
   The gitlab_project_mirror resource allows to manage the lifecycle of a project mirror.
   This is for pushing changes to a remote repository. Pull Mirroring can be configured using a combination of the
   importurl, mirror, and mirrortriggerbuilds properties on the gitlabproject resource.
+  -> Destroy Behavior GitLab 14.10 introduced an API endpoint to delete a project mirror.
+     Therefore, for GitLab 14.10 and newer the project mirror will be destroyed when the resource is destroyed.
+     For older versions, the mirror will be disabled and the resource will be destroyed.
   Upstream API: GitLab REST API docs https://docs.gitlab.com/ee/api/remote_mirrors.html
 ---
 
@@ -15,6 +18,10 @@ The `gitlab_project_mirror` resource allows to manage the lifecycle of a project
 
 This is for *pushing* changes to a remote repository. *Pull Mirroring* can be configured using a combination of the
 import_url, mirror, and mirror_trigger_builds properties on the gitlab_project resource.
+
+-> **Destroy Behavior** GitLab 14.10 introduced an API endpoint to delete a project mirror.
+   Therefore, for GitLab 14.10 and newer the project mirror will be destroyed when the resource is destroyed.
+   For older versions, the mirror will be disabled and the resource will be destroyed.
 
 **Upstream API**: [GitLab REST API docs](https://docs.gitlab.com/ee/api/remote_mirrors.html)
 

--- a/go.sum
+++ b/go.sum
@@ -309,8 +309,6 @@ github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvC
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-github.com/xanzy/go-gitlab v0.63.0 h1:a9fXpKWykUS6dowapFej/2Wjf4aOAEFC1q2ZIcz4IpI=
-github.com/xanzy/go-gitlab v0.63.0/go.mod h1:F0QEXwmqiBUxCgJm8fE9S+1veX4XC9Z4cfaAbqwk4YM=
 github.com/xanzy/go-gitlab v0.64.0 h1:rMgQdW9S1w3qvNAH2LYpFd2xh7KNLk+JWJd7sorNuTc=
 github.com/xanzy/go-gitlab v0.64.0/go.mod h1:F0QEXwmqiBUxCgJm8fE9S+1veX4XC9Z4cfaAbqwk4YM=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
@@ -413,8 +411,6 @@ golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
-golang.org/x/net v0.0.0-20220412020605-290c469a71a5 h1:bRb386wvrE+oBNdF1d/Xh9mQrfQ4ecYhW5qJ5GvTGT4=
-golang.org/x/net v0.0.0-20220412020605-290c469a71a5/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220421235706-1d1ef9303861 h1:yssD99+7tqHWO5Gwh81phT+67hg+KttniBr6UnEXOY8=
 golang.org/x/net v0.0.0-20220421235706-1d1ef9303861/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=


### PR DESCRIPTION
This change set add support for deletion on a destroy. It also switched to the new `GET` endpoint to retrieve a single project mirror instead of finding the proper one in the list `GET` endpoint.

It's currently blocked by:

* GitLab 14.10 release
* https://github.com/xanzy/go-gitlab/pull/1432 is merged
