### PR TITLE
Add access_level to gitlab_project_access_token resource

### DIFF
--- a/docs/resources/project_access_token.md
+++ b/docs/resources/project_access_token.md
@@ -17,9 +17,10 @@ The `gitlab_project_access_token` resource allows to manage the lifecycle of a p
 
 ```terraform
 resource "gitlab_project_access_token" "example" {
-  project    = "25"
-  name       = "Example project access token"
-  expires_at = "2020-03-14"
+  project      = "25"
+  name         = "Example project access token"
+  expires_at   = "2020-03-14"
+  access_level = "reporter"
 
   scopes = ["api"]
 }
@@ -42,6 +43,7 @@ resource "gitlab_project_variable" "example" {
 
 ### Optional
 
+- `access_level` (String) The access level of the associated user_id project membership (cf resource_gitlab_project_membership). Valid values are: `no one`, `minimal`, `guest`, `reporter`, `developer`, `maintainer`, `master`. Default is `maintainer`
 - `expires_at` (String) Time the token will expire it, YYYY-MM-DD format. Will not expire per default.
 - `id` (String) The ID of this resource.
 

--- a/docs/resources/project_access_token.md
+++ b/docs/resources/project_access_token.md
@@ -43,7 +43,7 @@ resource "gitlab_project_variable" "example" {
 
 ### Optional
 
-- `access_level` (String) The access level of the associated user_id project membership (cf resource_gitlab_project_membership). Valid values are: `no one`, `minimal`, `guest`, `reporter`, `developer`, `maintainer`, `master`. Default is `maintainer`
+- `access_level` (String) The access level for the project access token. Valid values are: `no one`, `minimal`, `guest`, `reporter`, `developer`, `maintainer`, `master`. Default is `maintainer`.
 - `expires_at` (String) Time the token will expire it, YYYY-MM-DD format. Will not expire per default.
 - `id` (String) The ID of this resource.
 

--- a/examples/resources/gitlab_project_access_token/resource.tf
+++ b/examples/resources/gitlab_project_access_token/resource.tf
@@ -1,7 +1,8 @@
 resource "gitlab_project_access_token" "example" {
-  project    = "25"
-  name       = "Example project access token"
-  expires_at = "2020-03-14"
+  project      = "25"
+  name         = "Example project access token"
+  expires_at   = "2020-03-14"
+  access_level = "reporter"
 
   scopes = ["api"]
 }

--- a/internal/provider/resource_gitlab_project_access_token.go
+++ b/internal/provider/resource_gitlab_project_access_token.go
@@ -91,7 +91,7 @@ var _ = registerResource("gitlab_project_access_token", func() *schema.Resource 
 				Computed:    true,
 			},
 			"access_level": {
-				Description:      fmt.Sprintf("The access level of the associated user_id membership (cf resource_gitlab_project_membership). Valid values are: %s", renderValueListForDocs(validProjectAccessLevelNames)),
+				Description:      fmt.Sprintf("The access level of the associated user_id project membership (cf resource_gitlab_project_membership). Valid values are: %s. Default is `%s`", renderValueListForDocs(validProjectAccessLevelNames), accessLevelValueToName[gitlab.MaintainerPermissions]),
 				Type:             schema.TypeString,
 				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(validProjectAccessLevelNames, false)),
 				Optional:         true,

--- a/internal/provider/resource_gitlab_project_access_token.go
+++ b/internal/provider/resource_gitlab_project_access_token.go
@@ -91,7 +91,7 @@ var _ = registerResource("gitlab_project_access_token", func() *schema.Resource 
 				Computed:    true,
 			},
 			"access_level": {
-				Description:      fmt.Sprintf("The access level of the associated user_id project membership (cf resource_gitlab_project_membership). Valid values are: %s. Default is `%s`", renderValueListForDocs(validProjectAccessLevelNames), accessLevelValueToName[gitlab.MaintainerPermissions]),
+				Description:      fmt.Sprintf("The access level for the project access token. Valid values are: %s. Default is `%s`.", renderValueListForDocs(validProjectAccessLevelNames), accessLevelValueToName[gitlab.MaintainerPermissions]),
 				Type:             schema.TypeString,
 				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(validProjectAccessLevelNames, false)),
 				Optional:         true,

--- a/internal/provider/resource_gitlab_project_access_token.go
+++ b/internal/provider/resource_gitlab_project_access_token.go
@@ -90,17 +90,27 @@ var _ = registerResource("gitlab_project_access_token", func() *schema.Resource 
 				Type:        schema.TypeInt,
 				Computed:    true,
 			},
+			"access_level": {
+				Description:      fmt.Sprintf("The access level of the associated user_id membership (cf resource_gitlab_project_membership). Valid values are: %s", renderValueListForDocs(validProjectAccessLevelNames)),
+				Type:             schema.TypeString,
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice(validProjectAccessLevelNames, false)),
+				Optional:         true,
+				Default:          accessLevelValueToName[gitlab.MaintainerPermissions],
+				ForceNew:         true,
+			},
 		},
 	}
 })
 
 func resourceGitlabProjectAccessTokenCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gitlab.Client)
-
+	accessLevelId := accessLevelNameToValue[d.Get("access_level").(string)]
 	project := d.Get("project").(string)
+
 	options := &gitlab.CreateProjectAccessTokenOptions{
-		Name:   gitlab.String(d.Get("name").(string)),
-		Scopes: stringSetToStringSlice(d.Get("scopes").(*schema.Set)),
+		Name:        gitlab.String(d.Get("name").(string)),
+		Scopes:      stringSetToStringSlice(d.Get("scopes").(*schema.Set)),
+		AccessLevel: &accessLevelId,
 	}
 
 	log.Printf("[DEBUG] create gitlab ProjectAccessToken %s %s for project ID %s", *options.Name, options.Scopes, project)
@@ -172,6 +182,7 @@ func resourceGitlabProjectAccessTokenRead(ctx context.Context, d *schema.Resourc
 				d.Set("created_at", projectAccessToken.CreatedAt.String())
 				d.Set("revoked", projectAccessToken.Revoked)
 				d.Set("user_id", projectAccessToken.UserID)
+				d.Set("access_level", accessLevelValueToName[projectAccessToken.AccessLevel])
 
 				err = d.Set("scopes", projectAccessToken.Scopes)
 				if err != nil {


### PR DESCRIPTION
## Description

Add `access_level` to `gitlab_project_access_token` resource #994 

### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
