### PR TITLE
add "owner" as valid access level for the group_access_token resource

### DIFF
--- a/docs/resources/group_access_token.md
+++ b/docs/resources/group_access_token.md
@@ -46,7 +46,7 @@ resource "gitlab_group_variable" "example" {
 
 ### Optional
 
-- `access_level` (String) The access level for the group access token. Valid values are: `guest`, `reporter`, `developer`, `maintainer`.
+- `access_level` (String) The access level for the group access token. Valid values are: `guest`, `reporter`, `developer`, `maintainer`, `owner`.
 - `expires_at` (String) The token expires at midnight UTC on that date. The date must be in the format YYYY-MM-DD. Default is never.
 - `id` (String) The ID of this resource.
 

--- a/internal/provider/resource_gitlab_group_access_token.go
+++ b/internal/provider/resource_gitlab_group_access_token.go
@@ -27,6 +27,7 @@ var validAccessLevels = []string{
 	"reporter",
 	"developer",
 	"maintainer",
+	"owner",
 }
 
 var _ = registerResource("gitlab_group_access_token", func() *schema.Resource {

--- a/internal/provider/resource_gitlab_group_access_token_test.go
+++ b/internal/provider/resource_gitlab_group_access_token_test.go
@@ -48,6 +48,19 @@ func TestAccGitlabGroupAccessToken_basic(t *testing.T) {
 					}),
 				),
 			},
+			// Update the Group Access Token Access Level to Owner
+			{
+				Config: testAccGitlabGroupAccessTokenUpdateAccessLevel(testGroup.ID),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabGroupAccessTokenExists("gitlab_group_access_token.this", &gat),
+					testAccCheckGitlabGroupAccessTokenAttributes(&gat, &testAccGitlabGroupAccessTokenExpectedAttributes{
+						name:        "my new group token",
+						scopes:      map[string]bool{"read_repository": false, "api": true, "write_repository": false, "read_api": false},
+						expiresAt:   "2099-05-01",
+						accessLevel: gitlab.AccessLevelValue(gitlab.OwnerPermissions),
+					}),
+				),
+			},
 			// Add a CICD variable with Group Access Token value
 			{
 				Config: testAccGitlabGroupAccessTokenUpdateConfigWithCICDvar(testGroup.ID),
@@ -224,6 +237,18 @@ resource "gitlab_group_access_token" "this" {
   group = %d
   expires_at = "2099-05-01"
   access_level = "maintainer"
+  scopes = ["api"]
+}
+	`, groupId)
+}
+
+func testAccGitlabGroupAccessTokenUpdateAccessLevel(groupId int) string {
+	return fmt.Sprintf(`
+resource "gitlab_group_access_token" "this" {
+  name = "my new group token"
+  group = %d
+  expires_at = "2099-05-01"
+  access_level = "owner"
   scopes = ["api"]
 }
 	`, groupId)


### PR DESCRIPTION
## Description

The Gitlab API documentation does not mention the possibility to select access level 50 (=owner), but this option is both working (I verified it manually with an API call) and also exposed in the Gitlab UI:

![image](https://user-images.githubusercontent.com/3579167/161255179-c96caef9-5cdb-498a-b83a-456309b4a668.png)

### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
