### PR TITLE
Fix tfplugindocs generate error on M1 macs

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -11,7 +11,8 @@ build: ## Build the provider binary.
 
 generate: tool-tfplugindocs ## Generate files to be checked in.
 	@# Setting empty environment variables to work around issue: https://github.com/hashicorp/terraform-plugin-docs/issues/12
-	GITLAB_TOKEN="" $(GOBIN)/tfplugindocs generate
+	@# Setting the PATH so that tfplugindocs uses the same terraform binary as other targets here, and to resolve a "Error: Incompatible provider version" error on M1 macs.
+	GITLAB_TOKEN="" PATH="$(GOBIN):$(PATH)" $(GOBIN)/tfplugindocs generate
 
 ifdef RUN
 TESTARGS += -test.run $(RUN)


### PR DESCRIPTION
## Description

<!-- Which issue/s does this PR close? Is there any more context you can give the reviewer? -->

Fixes this error since upgrading to tfproviderdocs 0.7.0, which changed how the terraform binary is loaded. (I have an M1 mac, which I assume is the cause. It's always the cause. 😓 I tried upgrading to the latest Terraform for my local version, and that didn't help.)

```
make generate                                                                                                protected-environment-multi
GITLAB_TOKEN="" /Users/adam/repos/terraform-provider-gitlab/bin/tfplugindocs generate
rendering website for provider "terraform-provider-gitlab"
copying any existing content to tmp dir
exporting schema from Terraform
compiling provider "gitlab"
using Terraform CLI binary from PATH if available, otherwise downloading latest Terraform CLI binary
running terraform init
Error executing command: unable to generate website: exit status 1

Error: Incompatible provider version

Provider registry.terraform.io/hashicorp/gitlab v0.0.1 does not have a
package available for your current platform, darwin_amd64.

Provider releases are separate from Terraform CLI releases, so not all
providers are available for all platforms. Other versions of this provider
may have different platforms supported.



make: *** [generate] Error 1
```

### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
