### PR TITLE
resource/gitlab_project_protected_environment: Allow multiple deploy_access_levels

### DIFF
--- a/docs/resources/project_protected_environment.md
+++ b/docs/resources/project_protected_environment.md
@@ -16,26 +16,15 @@ The `gitlab_project_protected_environment` resource allows to manage the lifecyc
 ## Example Usage
 
 ```terraform
-resource "gitlab_group" "this" {
-  name        = "example"
-  path        = "example"
-  description = "An example group"
-}
-
-resource "gitlab_project" "this" {
-  name                   = "example"
-  namespace_id           = gitlab_group.this.id
-  initialize_with_readme = true
-}
-
 resource "gitlab_project_environment" "this" {
-  project      = gitlab_project.this.id
+  project      = 123
   name         = "example"
   external_url = "www.example.com"
 }
 
-resource "gitlab_project_protected_environment" "this" {
-  project     = gitlab_project.this.id
+# Example with access level
+resource "gitlab_project_protected_environment" "example_with_access_level" {
+  project     = gitlab_project_environment.this.project
   environment = gitlab_project_environment.this.name
 
   deploy_access_levels {
@@ -43,23 +32,42 @@ resource "gitlab_project_protected_environment" "this" {
   }
 }
 
-resource "gitlab_project_protected_environment" "this" {
-  project     = gitlab_project.this.id
+# Example with group
+resource "gitlab_project_protected_environment" "example_with_group" {
+  project     = gitlab_project_environment.this.project
   environment = gitlab_project_environment.this.name
 
   deploy_access_levels {
-    group_id = gitlab_group.test.id
+    group_id = 456
   }
 }
 
-resource "gitlab_project_protected_environment" "this" {
-  project     = gitlab_project.this.id
+# Example with user
+resource "gitlab_project_protected_environment" "example_with_user" {
+  project     = gitlab_project_environment.this.project
   environment = gitlab_project_environment.this.name
 
   deploy_access_levels {
-    user_id = gitlab_user.test.id
+    user_id = 789
+  }
+}
+
+# Example with multiple access levels
+resource "gitlab_project_protected_environment" "example_with_multiple" {
+  project     = gitlab_project_environment.this.project
+  environment = gitlab_project_environment.this.name
+
+  deploy_access_levels {
+    access_level = "developer"
   }
 
+  deploy_access_levels {
+    group_id = 456
+  }
+
+  deploy_access_levels {
+    user_id = 789
+  }
 }
 ```
 
@@ -68,7 +76,7 @@ resource "gitlab_project_protected_environment" "this" {
 
 ### Required
 
-- `deploy_access_levels` (Block List, Min: 1, Max: 1) Array of access levels allowed to deploy, with each described by a hash. (see [below for nested schema](#nestedblock--deploy_access_levels))
+- `deploy_access_levels` (Block List, Min: 1) Array of access levels allowed to deploy, with each described by a hash. (see [below for nested schema](#nestedblock--deploy_access_levels))
 - `environment` (String) The name of the environment.
 - `project` (String) The ID or full path of the project which the protected environment is created against.
 

--- a/examples/resources/gitlab_project_protected_environment/resource.tf
+++ b/examples/resources/gitlab_project_protected_environment/resource.tf
@@ -1,23 +1,12 @@
-resource "gitlab_group" "this" {
-  name        = "example"
-  path        = "example"
-  description = "An example group"
-}
-
-resource "gitlab_project" "this" {
-  name                   = "example"
-  namespace_id           = gitlab_group.this.id
-  initialize_with_readme = true
-}
-
 resource "gitlab_project_environment" "this" {
-  project      = gitlab_project.this.id
+  project      = 123
   name         = "example"
   external_url = "www.example.com"
 }
 
-resource "gitlab_project_protected_environment" "this" {
-  project     = gitlab_project.this.id
+# Example with access level
+resource "gitlab_project_protected_environment" "example_with_access_level" {
+  project     = gitlab_project_environment.this.project
   environment = gitlab_project_environment.this.name
 
   deploy_access_levels {
@@ -25,21 +14,40 @@ resource "gitlab_project_protected_environment" "this" {
   }
 }
 
-resource "gitlab_project_protected_environment" "this" {
-  project     = gitlab_project.this.id
+# Example with group
+resource "gitlab_project_protected_environment" "example_with_group" {
+  project     = gitlab_project_environment.this.project
   environment = gitlab_project_environment.this.name
 
   deploy_access_levels {
-    group_id = gitlab_group.test.id
+    group_id = 456
   }
 }
 
-resource "gitlab_project_protected_environment" "this" {
-  project     = gitlab_project.this.id
+# Example with user
+resource "gitlab_project_protected_environment" "example_with_user" {
+  project     = gitlab_project_environment.this.project
   environment = gitlab_project_environment.this.name
 
   deploy_access_levels {
-    user_id = gitlab_user.test.id
+    user_id = 789
+  }
+}
+
+# Example with multiple access levels
+resource "gitlab_project_protected_environment" "example_with_multiple" {
+  project     = gitlab_project_environment.this.project
+  environment = gitlab_project_environment.this.name
+
+  deploy_access_levels {
+    access_level = "developer"
   }
 
+  deploy_access_levels {
+    group_id = 456
+  }
+
+  deploy_access_levels {
+    user_id = 789
+  }
 }

--- a/internal/provider/resource_gitlab_project_protected_environment.go
+++ b/internal/provider/resource_gitlab_project_protected_environment.go
@@ -40,16 +40,13 @@ var _ = registerResource("gitlab_project_protected_environment", func() *schema.
 			},
 			// Uncomment and validate after 14.9 is released, update acceptance tests
 			// 	"required_approval_count": {
-			// 		Description:  "The number of approvals required to deploy to this environment. This is part of Deployment Approvals, which isn't yet available for use.",
-			// 		Type:         schema.TypeString,
+			// 		Description:  "The number of approvals required to deploy to this environment.",
+			// 		Type:         schema.TypeInt,
 			// 		ForceNew:     true,
-			// 		Required:     false,
-			// 		ValidateFunc: validation.StringIsNotEmpty,
 			// },
 			"deploy_access_levels": {
 				Description: "Array of access levels allowed to deploy, with each described by a hash.",
 				Type:        schema.TypeList,
-				MaxItems:    1,
 				ForceNew:    true,
 				Required:    true,
 				Elem: &schema.Resource{
@@ -59,7 +56,7 @@ var _ = registerResource("gitlab_project_protected_environment", func() *schema.
 							Type:         schema.TypeString,
 							ForceNew:     true,
 							Optional:     true,
-							Computed:     true,
+							Computed:     true, // When user_id or group_id is specified, the GitLab API still returns an access_level in the response.
 							ValidateFunc: validation.StringInSlice(validProtectedEnvironmentDeploymentLevelNames, false),
 						},
 						"access_level_description": {
@@ -89,7 +86,11 @@ var _ = registerResource("gitlab_project_protected_environment", func() *schema.
 })
 
 func resourceGitlabProjectProtectedEnvironmentCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	deployAccessLevels := expandDeployAccessLevels(d.Get("deploy_access_levels").([]interface{}))
+	deployAccessLevels, err := expandDeployAccessLevels(d.Get("deploy_access_levels").([]interface{}))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
 	options := &gitlab.ProtectRepositoryEnvironmentsOptions{
 		Name:               gitlab.String(d.Get("environment").(string)),
 		DeployAccessLevels: &deployAccessLevels,
@@ -162,33 +163,50 @@ func resourceGitlabProjectProtectedEnvironmentDelete(ctx context.Context, d *sch
 	return nil
 }
 
-func expandDeployAccessLevels(vs []interface{}) []*gitlab.EnvironmentAccessOptions {
-	result := make([]*gitlab.EnvironmentAccessOptions, 0)
+func expandDeployAccessLevels(vs []interface{}) ([]*gitlab.EnvironmentAccessOptions, error) {
+	result := make([]*gitlab.EnvironmentAccessOptions, len(vs))
 
-	for _, v := range vs {
+	for i, v := range vs {
 		opts := v.(map[string]interface{})
 		option := &gitlab.EnvironmentAccessOptions{}
+		count := 0
+
 		if accessLevel, ok := opts["access_level"]; ok && accessLevel != "" {
 			option.AccessLevel = gitlab.AccessLevel(accessLevelNameToValue[accessLevel.(string)])
-		} else if userID, ok := opts["user_id"]; ok && userID != 0 {
-			option.UserID = gitlab.Int(userID.(int))
-		} else if groupID, ok := opts["group_id"]; ok && groupID != 0 {
-			option.GroupID = gitlab.Int(groupID.(int))
+			count++
 		}
-		result = append(result, option)
+
+		if userID, ok := opts["user_id"]; ok && userID != 0 {
+			option.UserID = gitlab.Int(userID.(int))
+			count++
+		}
+
+		if groupID, ok := opts["group_id"]; ok && groupID != 0 {
+			option.GroupID = gitlab.Int(groupID.(int))
+			count++
+		}
+
+		// This is a manual "ExactlyOneOf" schema check, since this cannot be validated at the
+		// schema-level inside of a list.
+		// See: https://github.com/hashicorp/terraform-plugin-sdk/blob/0f834ffb1619ce1ef8d3f5255911108ede086ef9/helper/schema/schema.go#L278
+		if count != 1 {
+			return nil, fmt.Errorf(`illegal deploy_access_levels.%d: exactly one of "access_level", "user_id", or "group_id" must be specified (got %d)`, i, count)
+		}
+
+		result[i] = option
 	}
 
-	return result
+	return result, nil
 }
 
 func flattenDeployAccessLevels(accessDescriptions []*gitlab.EnvironmentAccessDescription) []map[string]interface{} {
-	result := make([]map[string]interface{}, 0)
+	result := make([]map[string]interface{}, len(accessDescriptions))
 
-	for _, accessDescription := range accessDescriptions {
+	for i, accessDescription := range accessDescriptions {
 		v := make(map[string]interface{})
+		v["access_level_description"] = accessDescription.AccessLevelDescription
 		if accessDescription.AccessLevel != 0 {
 			v["access_level"] = accessLevelValueToName[accessDescription.AccessLevel]
-			v["access_level_description"] = accessDescription.AccessLevelDescription
 		}
 		if accessDescription.UserID != 0 {
 			v["user_id"] = accessDescription.UserID
@@ -196,7 +214,7 @@ func flattenDeployAccessLevels(accessDescriptions []*gitlab.EnvironmentAccessDes
 		if accessDescription.GroupID != 0 {
 			v["group_id"] = accessDescription.GroupID
 		}
-		result = append(result, v)
+		result[i] = v
 	}
 
 	return result


### PR DESCRIPTION
## Description

<!-- Which issue/s does this PR close? Is there any more context you can give the reviewer? -->

Closes #1000 

The functional change is simply the removal of the `MaxItems: 1` field from the schema.

I decided to rewrite the tests because of how they were organized by access level type. To reduce duplication with my new test case, it made the most sense to combine them into a single test.

### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
