### PR TITLE
gitlab_project_access_token: Test bugfix and destroy improvement

### DIFF
--- a/internal/provider/resource_gitlab_project_access_token.go
+++ b/internal/provider/resource_gitlab_project_access_token.go
@@ -2,12 +2,14 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"strconv"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	gitlab "github.com/xanzy/go-gitlab"
@@ -140,7 +142,6 @@ func resourceGitlabProjectAccessTokenCreate(ctx context.Context, d *schema.Resou
 }
 
 func resourceGitlabProjectAccessTokenRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-
 	project, PATstring, err := parseTwoPartID(d.Id())
 	if err != nil {
 		return diag.Errorf("Error parsing ID: %s", d.Id())
@@ -155,6 +156,73 @@ func resourceGitlabProjectAccessTokenRead(ctx context.Context, d *schema.Resourc
 
 	log.Printf("[DEBUG] read gitlab ProjectAccessToken %d, project ID %s", projectAccessTokenID, project)
 
+	projectAccessToken, err := resourceGitlabProjectAccessTokenFind(ctx, client, project, projectAccessTokenID)
+	if errors.Is(err, errResourceGitlabProjectAccessTokenNotFound) {
+		log.Printf("[DEBUG] failed to read gitlab ProjectAccessToken %d, project ID %s", projectAccessTokenID, project)
+		d.SetId("")
+	}
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.Set("project", project)
+	d.Set("name", projectAccessToken.Name)
+	if projectAccessToken.ExpiresAt != nil {
+		d.Set("expires_at", projectAccessToken.ExpiresAt.String())
+	}
+	d.Set("active", projectAccessToken.Active)
+	d.Set("created_at", projectAccessToken.CreatedAt.String())
+	d.Set("revoked", projectAccessToken.Revoked)
+	d.Set("user_id", projectAccessToken.UserID)
+	d.Set("access_level", accessLevelValueToName[projectAccessToken.AccessLevel])
+	err = d.Set("scopes", projectAccessToken.Scopes)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceGitlabProjectAccessTokenDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	project, patString, err := parseTwoPartID(d.Id())
+	if err != nil {
+		return diag.Errorf("Error parsing ID: %s", d.Id())
+	}
+
+	client := meta.(*gitlab.Client)
+
+	projectAccessTokenID, err := strconv.Atoi(patString)
+	if err != nil {
+		return diag.Errorf("%s cannot be converted to int", patString)
+	}
+
+	log.Printf("[DEBUG] Delete gitlab ProjectAccessToken %s", d.Id())
+	_, err = client.ProjectAccessTokens.DeleteProjectAccessToken(project, projectAccessTokenID, gitlab.WithContext(ctx))
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[DEBUG] Waiting for ProjectAccessToken %s to finish deleting", d.Id())
+
+	err = resource.RetryContext(ctx, 5*time.Minute, func() *resource.RetryError {
+		_, err := resourceGitlabProjectAccessTokenFind(ctx, client, project, projectAccessTokenID)
+		if errors.Is(err, errResourceGitlabProjectAccessTokenNotFound) {
+			return nil
+		}
+		if err != nil {
+			return resource.NonRetryableError(err)
+		}
+		return resource.RetryableError(errors.New("project access token was not deleted"))
+	})
+
+	return diag.FromErr(err)
+}
+
+var errResourceGitlabProjectAccessTokenNotFound = errors.New("project access token not found")
+
+// resourceGitlabProjectAccessTokenFind finds the project access token with the specified tokenID.
+// It returns a errResourceGitlabProjectAccessTokenNotFound error if the token is not found.
+func resourceGitlabProjectAccessTokenFind(ctx context.Context, client *gitlab.Client, project interface{}, projectAccessTokenID int) (*gitlab.ProjectAccessToken, error) {
 	//there is a slight possibility to not find an existing item, for example
 	// 1. item is #101 (ie, in the 2nd page)
 	// 2. I load first page (ie. I don't find my target item)
@@ -167,55 +235,17 @@ func resourceGitlabProjectAccessTokenRead(ctx context.Context, d *schema.Resourc
 	for page != 0 {
 		projectAccessTokens, response, err := client.ProjectAccessTokens.ListProjectAccessTokens(project, &gitlab.ListProjectAccessTokensOptions{Page: page, PerPage: 100}, gitlab.WithContext(ctx))
 		if err != nil {
-			return diag.FromErr(err)
+			return nil, err
 		}
 
 		for _, projectAccessToken := range projectAccessTokens {
 			if projectAccessToken.ID == projectAccessTokenID {
-
-				d.Set("project", project)
-				d.Set("name", projectAccessToken.Name)
-				if projectAccessToken.ExpiresAt != nil {
-					d.Set("expires_at", projectAccessToken.ExpiresAt.String())
-				}
-				d.Set("active", projectAccessToken.Active)
-				d.Set("created_at", projectAccessToken.CreatedAt.String())
-				d.Set("revoked", projectAccessToken.Revoked)
-				d.Set("user_id", projectAccessToken.UserID)
-				d.Set("access_level", accessLevelValueToName[projectAccessToken.AccessLevel])
-
-				err = d.Set("scopes", projectAccessToken.Scopes)
-				if err != nil {
-					return diag.FromErr(err)
-				}
-
-				return nil
+				return projectAccessToken, nil
 			}
 		}
 
 		page = response.NextPage
 	}
 
-	log.Printf("[DEBUG] failed to read gitlab ProjectAccessToken %d, project ID %s", projectAccessTokenID, project)
-	d.SetId("")
-	return nil
-}
-
-func resourceGitlabProjectAccessTokenDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-
-	project, PATstring, err := parseTwoPartID(d.Id())
-	if err != nil {
-		return diag.Errorf("Error parsing ID: %s", d.Id())
-	}
-
-	client := meta.(*gitlab.Client)
-
-	projectAccessTokenID, err := strconv.Atoi(PATstring)
-	if err != nil {
-		return diag.Errorf("%s cannot be converted to int", PATstring)
-	}
-
-	log.Printf("[DEBUG] Delete gitlab ProjectAccessToken %s", d.Id())
-	_, err = client.ProjectAccessTokens.DeleteProjectAccessToken(project, projectAccessTokenID, gitlab.WithContext(ctx))
-	return diag.FromErr(err)
+	return nil, errResourceGitlabProjectAccessTokenNotFound
 }

--- a/internal/provider/resource_gitlab_project_access_token_test.go
+++ b/internal/provider/resource_gitlab_project_access_token_test.go
@@ -2,378 +2,103 @@ package provider
 
 import (
 	"fmt"
-	"strconv"
 	"testing"
 	"time"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/onsi/gomega"
-	gitlab "github.com/xanzy/go-gitlab"
 )
 
 func TestAccGitlabProjectAccessToken_basic(t *testing.T) {
-	var pat testAccGitlabProjectAccessTokenWrapper
-	rInt := acctest.RandInt()
+	testAccCheck(t)
 
-	testAccGitlabProjectStart(t)
+	project := testAccCreateProject(t)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectAccessTokenDestroy,
 		Steps: []resource.TestStep{
-			// Create a project and a Project Access Token
+			// Create a basic access token.
 			{
-				Config: testAccGitlabProjectAccessTokenConfig(rInt),
+				Config: fmt.Sprintf(`
+				resource "gitlab_project_access_token" "foo" {
+					project = %d
+					name    = "foo"
+					scopes  = ["api"]
+				}
+				`, project.ID),
+				// Check computed and default attributes.
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabProjectAccessTokenExists("gitlab_project_access_token.bar", &pat),
-					testAccCheckGitlabProjectAccessTokenAttributes(&pat, &testAccGitlabProjectAccessTokenExpectedAttributes{
-						name:        "my project token",
-						scopes:      map[string]bool{"read_repository": true, "api": true, "write_repository": true, "read_api": true},
-						expiresAt:   "2022-04-01",
-						accessLevel: accessLevelValueToName[gitlab.MaintainerPermissions], // default permission on gitlab side when unspecified
-					}),
+					resource.TestCheckResourceAttr("gitlab_project_access_token.foo", "active", "true"),
+					resource.TestCheckResourceAttr("gitlab_project_access_token.foo", "revoked", "false"),
+					resource.TestCheckResourceAttr("gitlab_project_access_token.foo", "access_level", "maintainer"),
+					resource.TestCheckResourceAttrSet("gitlab_project_access_token.foo", "token"),
+					resource.TestCheckResourceAttrSet("gitlab_project_access_token.foo", "created_at"),
+					resource.TestCheckResourceAttrSet("gitlab_project_access_token.foo", "user_id"),
+					resource.TestCheckNoResourceAttr("gitlab_project_access_token.foo", "expires_at"),
 				),
 			},
-			// Update the Project Access Token to change the parameters
+			// Verify upstream resource with an import.
 			{
-				Config: testAccGitlabProjectAccessTokenUpdateConfig(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabProjectAccessTokenExists("gitlab_project_access_token.bar", &pat),
-					testAccCheckGitlabProjectAccessTokenAttributes(&pat, &testAccGitlabProjectAccessTokenExpectedAttributes{
-						name:      "my new project token",
-						scopes:    map[string]bool{"read_repository": false, "api": true, "write_repository": false, "read_api": false},
-						expiresAt: "2022-05-01",
-					}),
-				),
-			},
-			// Add a CICD variable with Project Access Token value
-			{
-				Config: testAccGitlabProjectAccessTokenUpdateConfigWithCICDvar(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabProjectAccessTokenExists("gitlab_project_access_token.bar", &pat),
-					testAccCheckGitlabProjectVariableExists("gitlab_project_variable.var"),
-					testAccCheckGitlabProjectAccessTokenAttributes(&pat, &testAccGitlabProjectAccessTokenExpectedAttributes{
-						name:      "my new project token",
-						scopes:    map[string]bool{"read_repository": false, "api": true, "write_repository": false, "read_api": false},
-						expiresAt: "2022-05-01",
-					}),
-				),
-			},
-			//Restore Project Access Token initial parameters
-			{
-				Config: testAccGitlabProjectAccessTokenConfig(rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabProjectAccessTokenExists("gitlab_project_access_token.bar", &pat),
-					testAccCheckGitlabProjectAccessTokenAttributes(&pat, &testAccGitlabProjectAccessTokenExpectedAttributes{
-						name:      "my project token",
-						scopes:    map[string]bool{"read_repository": true, "api": true, "write_repository": true, "read_api": true},
-						expiresAt: "2022-04-01",
-					}),
-				),
-			},
-			// Verify import
-			{
-				ResourceName:      "gitlab_project_access_token.bar",
+				ResourceName:      "gitlab_project_access_token.foo",
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					// the token is only known during creating. We explicitly mention this limitation in the docs.
-					"token",
-				},
+				// The token is only known during creating. We explicitly mention this limitation in the docs.
+				ImportStateVerifyIgnore: []string{"token"},
 			},
-			//Destroy Project Access Token
+			// Recreate the access token with updated attributes.
 			{
-				Config: testAccGitlabProjectAccessTokenDestroyToken(rInt),
-				Check:  testAccCheckGitlabProjectAccessTokenDoesNotExist(&pat),
+				Config: fmt.Sprintf(`
+				resource "gitlab_project_access_token" "foo" {
+					project = %d
+					name    = "foo"
+					scopes  = ["api", "read_api", "read_repository", "write_repository"]
+					access_level = "developer"
+					expires_at = %q
+				}
+				`, project.ID, time.Now().Add(time.Hour*48).Format("2006-01-02")),
+				// Check computed and default attributes.
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("gitlab_project_access_token.foo", "active", "true"),
+					resource.TestCheckResourceAttr("gitlab_project_access_token.foo", "revoked", "false"),
+					resource.TestCheckResourceAttrSet("gitlab_project_access_token.foo", "token"),
+					resource.TestCheckResourceAttrSet("gitlab_project_access_token.foo", "created_at"),
+					resource.TestCheckResourceAttrSet("gitlab_project_access_token.foo", "user_id"),
+				),
+			},
+			// Verify upstream resource with an import.
+			{
+				ResourceName:      "gitlab_project_access_token.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+				// The token is only known during creating. We explicitly mention this limitation in the docs.
+				ImportStateVerifyIgnore: []string{"token"},
 			},
 		},
 	})
 }
 
-func TestAccGitlabProjectAccessToken_accessLevel(t *testing.T) {
-	var pat testAccGitlabProjectAccessTokenWrapper
-	rInt := acctest.RandInt()
-
-	testAccGitlabProjectStart(t)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: providerFactories,
-		CheckDestroy:      testAccCheckGitlabProjectAccessTokenDestroy,
-		Steps: []resource.TestStep{
-			// Create a project and a Project Access Token
-			{
-				Config: testAccGitlabProjectAccessTokenConfigWithAccessLevel(rInt, accessLevelValueToName[gitlab.MaintainerPermissions]),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabProjectAccessTokenExists("gitlab_project_access_token.bar", &pat),
-					testAccCheckGitlabProjectAccessTokenAttributes(&pat, &testAccGitlabProjectAccessTokenExpectedAttributes{
-						name:        "my project token",
-						scopes:      map[string]bool{"read_repository": true, "api": true, "write_repository": true, "read_api": true},
-						expiresAt:   "2022-04-01",
-						accessLevel: accessLevelValueToName[gitlab.MaintainerPermissions],
-					}),
-				),
-			},
-			// Update the Project Access Token to change the parameters
-			{
-				Config: testAccGitlabProjectAccessTokenConfigWithAccessLevel(rInt, accessLevelValueToName[gitlab.DeveloperPermissions]),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabProjectAccessTokenExists("gitlab_project_access_token.bar", &pat),
-					testAccCheckGitlabProjectAccessTokenAttributes(&pat, &testAccGitlabProjectAccessTokenExpectedAttributes{
-						name:        "my project token",
-						scopes:      map[string]bool{"read_repository": true, "api": true, "write_repository": true, "read_api": true},
-						expiresAt:   "2022-04-01",
-						accessLevel: accessLevelValueToName[gitlab.DeveloperPermissions],
-					}),
-				),
-			},
-			// Verify import
-			{
-				ResourceName:      "gitlab_project_access_token.bar",
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					// the token is only known during creating. We explicitly mention this limitation in the docs.
-					"token",
-				},
-			},
-		}})
-}
-
-func testAccCheckGitlabProjectAccessTokenDoesNotExist(pat *testAccGitlabProjectAccessTokenWrapper) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		return gomega.InterceptGomegaFailure(func() {
-			gomega.Eventually(func() error {
-				tokens, _, err := testGitlabClient.ProjectAccessTokens.ListProjectAccessTokens(pat.project, nil)
-				if err != nil {
-					return err
-				}
-
-				for _, token := range tokens {
-					if token.ID == pat.pat.ID {
-						return fmt.Errorf("Found token %d for project %s (tokens found: %d)", token.ID, pat.project, len(tokens))
-					}
-				}
-
-				return nil
-			}).WithTimeout(time.Second * 10).WithPolling(time.Second * 2).Should(gomega.Succeed())
-		})
-	}
-}
-
-func testAccCheckGitlabProjectAccessTokenExists(n string, pat *testAccGitlabProjectAccessTokenWrapper) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-		if !ok {
-			return fmt.Errorf("Not Found: %s", n)
+func testAccCheckGitlabProjectAccessTokenDestroy(s *terraform.State) error {
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "gitlab_project_access_token" {
+			continue
 		}
 
-		project, PATstring, err := parseTwoPartID(rs.Primary.ID)
-		if err != nil {
-			return fmt.Errorf("Error parsing ID: %s", rs.Primary.ID)
-		}
-		projectAccessTokenID, err := strconv.Atoi(PATstring)
-		if err != nil {
-			return fmt.Errorf("%s cannot be converted to int", PATstring)
-		}
+		project := rs.Primary.Attributes["project"]
+		name := rs.Primary.Attributes["name"]
 
-		repoName := rs.Primary.Attributes["project"]
-		if repoName == "" {
-			return fmt.Errorf("No project ID is set")
-		}
-		if repoName != project {
-			return fmt.Errorf("Project [%s] in project identifier [%s] it's different from project stored into the state [%s]", project, rs.Primary.ID, repoName)
-		}
-
-		tokens, _, err := testGitlabClient.ProjectAccessTokens.ListProjectAccessTokens(repoName, nil)
+		tokens, _, err := testGitlabClient.ProjectAccessTokens.ListProjectAccessTokens(project, nil)
 		if err != nil {
 			return err
 		}
 
 		for _, token := range tokens {
-			if token.ID == projectAccessTokenID {
-				pat.pat = token
-				pat.project = repoName
-				pat.token = rs.Primary.Attributes["token"]
-				return nil
+			if token.Name == name {
+				return fmt.Errorf("project %q access token with name %q still exists", project, name)
 			}
 		}
-		return fmt.Errorf("Project Access Token does not exist")
 	}
-}
 
-type testAccGitlabProjectAccessTokenExpectedAttributes struct {
-	name        string
-	scopes      map[string]bool
-	expiresAt   string
-	accessLevel string
-}
-
-type testAccGitlabProjectAccessTokenWrapper struct {
-	pat     *gitlab.ProjectAccessToken
-	project string
-	token   string
-}
-
-func testAccCheckGitlabProjectAccessTokenAttributes(patWrap *testAccGitlabProjectAccessTokenWrapper, want *testAccGitlabProjectAccessTokenExpectedAttributes) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		pat := patWrap.pat
-		if pat.Name != want.name {
-			return fmt.Errorf("got Name %q; want %q", pat.Name, want.name)
-		}
-
-		if pat.ExpiresAt.String() != want.expiresAt {
-			return fmt.Errorf("got ExpiresAt %q; want %q", pat.ExpiresAt.String(), want.expiresAt)
-		}
-
-		for _, scope := range pat.Scopes {
-			if !want.scopes[scope] {
-				return fmt.Errorf("got a not wanted Scope %q, received %v", scope, pat.Scopes)
-			}
-			want.scopes[scope] = false
-		}
-		for k, v := range want.scopes {
-			if v {
-				return fmt.Errorf("not got a wanted Scope %q, received %v", k, pat.Scopes)
-			}
-		}
-
-		git, err := gitlab.NewClient(patWrap.token, gitlab.WithBaseURL(testGitlabClient.BaseURL().String()))
-		if err != nil {
-			return fmt.Errorf("Cannot use the token to instantiate a new client %s", err)
-		}
-		_, _, err = git.ProjectMembers.ListAllProjectMembers(patWrap.project, nil)
-		if err != nil {
-			return fmt.Errorf("Cannot use the token to perform an API call %s", err)
-		}
-
-		return nil
-	}
-}
-
-func testAccCheckGitlabProjectAccessTokenDestroy(s *terraform.State) error {
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "gitlab_project" {
-			continue
-		}
-
-		gotRepo, resp, err := testGitlabClient.Projects.GetProject(rs.Primary.ID, nil)
-		if err == nil {
-			if gotRepo != nil && fmt.Sprintf("%d", gotRepo.ID) == rs.Primary.ID {
-				if gotRepo.MarkedForDeletionAt == nil {
-					return fmt.Errorf("Repository still exists")
-				}
-			}
-		}
-		if resp.StatusCode != 404 {
-			return err
-		}
-		return nil
-	}
 	return nil
-}
-
-func testAccGitlabProjectAccessTokenConfig(rInt int) string {
-	return fmt.Sprintf(`
-resource "gitlab_project" "foo" {
-  name = "foo-%d"
-  description = "Terraform acceptance tests"
-
-  # So that acceptance tests can be run in a gitlab organization
-  # with no billing
-  visibility_level = "public"
-}
-
-resource "gitlab_project_access_token" "bar" {
-  name = "my project token"
-  project = gitlab_project.foo.id
-  expires_at = "2022-04-01"
-  scopes = ["read_repository" , "api", "write_repository", "read_api"]
-}
-	`, rInt)
-}
-
-func testAccGitlabProjectAccessTokenDestroyToken(rInt int) string {
-	return fmt.Sprintf(`
-resource "gitlab_project" "foo" {
-  name = "foo-%d"
-  description = "Terraform acceptance tests"
-
-  # So that acceptance tests can be run in a gitlab organization
-  # with no billing
-  visibility_level = "public"
-}
-	`, rInt)
-}
-
-func testAccGitlabProjectAccessTokenUpdateConfig(rInt int) string {
-	return fmt.Sprintf(`
-resource "gitlab_project" "foo" {
-  name = "foo-%d"
-  description = "Terraform acceptance tests"
-
-  # So that acceptance tests can be run in a gitlab organization
-  # with no billing
-  visibility_level = "public"
-}
-
-resource "gitlab_project_access_token" "bar" {
-  name = "my new project token"
-  project = gitlab_project.foo.id
-  expires_at = "2022-05-01"
-  scopes = ["api"]
-}
-	`, rInt)
-}
-
-func testAccGitlabProjectAccessTokenUpdateConfigWithCICDvar(rInt int) string {
-	return fmt.Sprintf(`
-resource "gitlab_project" "foo" {
-  name = "foo-%d"
-  description = "Terraform acceptance tests"
-
-  # So that acceptance tests can be run in a gitlab organization
-  # with no billing
-  visibility_level = "public"
-}
-
-resource "gitlab_project_access_token" "bar" {
-  name = "my new project token"
-  project = gitlab_project.foo.id
-  expires_at = "2022-05-01"
-  scopes = ["api"]
-}
-
-
-resource "gitlab_project_variable" "var" {
-  project   = gitlab_project.foo.id
-  key       = "my_proj_access_token"
-  value     = gitlab_project_access_token.bar.token
- }
-
-	`, rInt)
-}
-
-func testAccGitlabProjectAccessTokenConfigWithAccessLevel(rInt int, level string) string {
-	return fmt.Sprintf(`
-resource "gitlab_project" "foo" {
-  name = "foo-%d"
-  description = "Terraform acceptance tests"
-
-  # So that acceptance tests can be run in a gitlab organization
-  # with no billing
-  visibility_level = "public"
-}
-
-resource "gitlab_project_access_token" "bar" {
-  name = "my project token"
-  project = gitlab_project.foo.id
-  expires_at = "2022-04-01"
-  scopes = ["read_repository" , "api", "write_repository", "read_api"]
-  access_level = "%s"
-}
-	`, rInt, level)
 }


### PR DESCRIPTION
## Description

Fixes #1002 

- Fixed a test bug where a hardcoded expiration date that passed caused failures
- Improved the destroy function to wait for the token to finish deleting

Note the diff to the `resourceGitlabProjectAccessTokenRead` looks large, but actually it is a straight move. I moved the list API calls into a `resourceGitlabProjectAccessTokenFind` function because I had to use it in the destroy logic also.

### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
