### PR TITLE
Fix `gitlab_service_slack` IDs

### DIFF
--- a/internal/provider/resource_gitlab_service_slack.go
+++ b/internal/provider/resource_gitlab_service_slack.go
@@ -252,7 +252,12 @@ func resourceGitlabServiceSlackCreate(ctx context.Context, d *schema.ResourceDat
 
 func resourceGitlabServiceSlackRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gitlab.Client)
-	project := d.Id()
+	id := d.Id()
+	project := d.Get("project").(string)
+	if id != project && project != "" {
+		d.SetId(project)
+		log.Printf("[WARN] changed gitlab slack service ID from %s to its project ID %s", id, project)
+	}
 
 	log.Printf("[DEBUG] read gitlab slack service for project %s", project)
 

--- a/internal/provider/resource_gitlab_service_slack.go
+++ b/internal/provider/resource_gitlab_service_slack.go
@@ -257,6 +257,8 @@ func resourceGitlabServiceSlackRead(ctx context.Context, d *schema.ResourceData,
 	if id != project && project != "" {
 		d.SetId(project)
 		log.Printf("[WARN] changed gitlab slack service ID from %s to its project ID %s", id, project)
+	} else {
+		project = id
 	}
 
 	log.Printf("[DEBUG] read gitlab slack service for project %s", project)


### PR DESCRIPTION
## Description

<!-- Which issue/s does this PR close? Is there any more context you can give the reviewer? -->
Resolves #1012

Slack service IDs where changed in https://github.com/gitlabhq/terraform-provider-gitlab/pull/821#discussion_r842671210 which breaks all existing `gitlab_service_slack` resources which were created before v3.9.0 of the Gitlab terraform provider.

### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
