### PR TITLE
Option for enforcing personal access token auth

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -80,4 +80,5 @@ resource "gitlab_project" "sample_group_project" {
 - `client_cert` (String) File path to client certificate when GitLab instance is behind company proxy. File must contain PEM encoded data.
 - `client_key` (String) File path to client key when GitLab instance is behind company proxy. File must contain PEM encoded data. Required when `client_cert` is set.
 - `early_auth_check` (Boolean) (Experimental) By default the provider does a dummy request to get the current user in order to verify that the provider configuration is correct and the GitLab API is reachable. Turn it off, to skip this check. This may be useful if the GitLab instance does not yet exist and is created within the same terraform module. This is an experimental feature and may change in the future. Please make sure to always keep backups of your state.
+- `force_pa_token` (Boolean) Force the usage of personal access token instead of bearer authentication. E.g. useful when personal access token has been generated programmatically.
 - `insecure` (Boolean) When set to true this disables SSL verification of the connection to the GitLab instance.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -38,6 +38,12 @@ func New(version string) func() *schema.Provider {
 					DefaultFunc: schema.EnvDefaultFunc("GITLAB_TOKEN", nil),
 					Description: "The OAuth2 Token, Project, Group, Personal Access Token or CI Job Token used to connect to GitLab. The OAuth method is used in this provider for authentication (using Bearer authorization token). See https://docs.gitlab.com/ee/api/#authentication for details. It may be sourced from the `GITLAB_TOKEN` environment variable.",
 				},
+				"force_pa_token": {
+					Type:        schema.TypeBool,
+					Optional:    true,
+					Default:     false,
+					Description: "Force the usage of personal access token instead of bearer authentication. E.g. useful when personal access token has been generated programmatically.",
+				},
 				"base_url": {
 					Type:        schema.TypeString,
 					Optional:    true,
@@ -97,6 +103,7 @@ func configure(version string, p *schema.Provider) func(context.Context, *schema
 	return func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 		config := Config{
 			Token:         d.Get("token").(string),
+			ForcePAToken:  d.Get("force_pa_token").(bool),
 			BaseURL:       d.Get("base_url").(string),
 			CACertFile:    d.Get("cacert_file").(string),
 			Insecure:      d.Get("insecure").(bool),


### PR DESCRIPTION
## Description

Fixes https://github.com/gitlabhq/terraform-provider-gitlab/issues/1017

<!-- Which issue/s does this PR close? Is there any more context you can give the reviewer? -->

### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [X] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
