### PR TITLE
resource/gitlab_pipeline_trigger: Mark `token` attribute as sensitive

### DIFF
--- a/docs/resources/pipeline_trigger.md
+++ b/docs/resources/pipeline_trigger.md
@@ -36,7 +36,7 @@ resource "gitlab_pipeline_trigger" "example" {
 
 ### Read-Only
 
-- `token` (String) The pipeline trigger token.
+- `token` (String, Sensitive) The pipeline trigger token.
 
 ## Import
 

--- a/internal/provider/resource_gitlab_pipeline_trigger.go
+++ b/internal/provider/resource_gitlab_pipeline_trigger.go
@@ -41,6 +41,7 @@ var _ = registerResource("gitlab_pipeline_trigger", func() *schema.Resource {
 				Description: "The pipeline trigger token.",
 				Type:        schema.TypeString,
 				Computed:    true,
+				Sensitive:   true,
 			},
 		},
 	}


### PR DESCRIPTION
The `gitlab_pipeline_trigger` `token` attribute is actually a sensitive value. I think it's okay to mark it as sensitive in a minor release.