### PR TITLE
Deprecate branch coverage

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,6 +1,11 @@
 image: gitpod/workspace-go
 tasks:
-  - init: go get
+# Retrieve our go dependencies. Also inject several vscode settings that are specifically helpful to a GitPod environment and not needed when opening the repo locally.
+# The reason the settings are copied to a temp file and then moved is that applying the jq string directly to settings.json results in a blank file.
+  - init: |
+      go get
+      cat .vscode/settings.json | jq '. + {"terminal.integrated.lineHeight": 1.0,"terminal.integrated.letterSpacing": 1.0,"terminal.integrated.scrollback": 5000}'  > .vscode/temp.json
+      mv .vscode/temp.json .vscode/settings.json
   - name: Start acceptance Test Environment
     command: make testacc-up
     openMode: split-right

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,8 @@
 {
-    "go.testEnvVars": {
-        "TF_ACC": "1",
-        "GITLAB_TOKEN": "ACCTEST1234567890123",
-        "GITLAB_BASE_URL": "http://127.0.0.1:8080"
-    },
-    "go.testFlags": ["-count=1", "-v"]
+  "go.testEnvVars": {
+    "TF_ACC": "1",
+    "GITLAB_TOKEN": "ACCTEST1234567890123",
+    "GITLAB_BASE_URL": "http://127.0.0.1:8080"
+  },
+  "go.testFlags": ["-count=1", "-v", "-timeout=30m"]
 }

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -81,7 +81,7 @@ resource "gitlab_project" "peters_repo" {
 - `auto_devops_deploy_strategy` (String) Auto Deploy strategy. Valid values are `continuous`, `manual`, `timed_incremental`.
 - `auto_devops_enabled` (Boolean) Enable Auto DevOps for this project.
 - `autoclose_referenced_issues` (Boolean) Set whether auto-closing referenced issues on default branch.
-- `build_coverage_regex` (String) Test coverage parsing for the project.
+- `build_coverage_regex` (String, Deprecated) Test coverage parsing for the project. This is deprecated feature in GitLab 15.0.
 - `build_git_strategy` (String) The Git strategy. Defaults to fetch.
 - `build_timeout` (Number) The maximum amount of time, in seconds, that a job can run.
 - `builds_access_level` (String) Set the builds access level. Valid values are `disabled`, `private`, `enabled`.

--- a/internal/provider/resource_gitlab_project_test.go
+++ b/internal/provider/resource_gitlab_project_test.go
@@ -77,7 +77,6 @@ func TestAccGitlabProject_basic(t *testing.T) {
 		PackagesEnabled:                 true,
 		PrintingMergeRequestLinkEnabled: true,
 		PagesAccessLevel:                gitlab.PublicAccessControl,
-		BuildCoverageRegex:              "foo",
 		IssuesTemplate:                  "",
 		MergeRequestsTemplate:           "",
 		CIConfigPath:                    ".gitlab-ci.yml@mynamespace/myproject",
@@ -158,7 +157,6 @@ func TestAccGitlabProject_basic(t *testing.T) {
 						Archived:                       true,
 						PackagesEnabled:                false,
 						PagesAccessLevel:               gitlab.DisabledAccessControl,
-						BuildCoverageRegex:             "bar",
 						CIForwardDeploymentEnabled:     false,
 						ResolveOutdatedDiffDiscussions: false,
 						AnalyticsAccessLevel:           gitlab.DisabledAccessControl,
@@ -736,7 +734,6 @@ func TestAccGitlabProject_transfer(t *testing.T) {
 		PackagesEnabled:                 true,
 		PrintingMergeRequestLinkEnabled: true,
 		PagesAccessLevel:                gitlab.PrivateAccessControl,
-		BuildCoverageRegex:              "foo",
 		CIForwardDeploymentEnabled:      true,
 	}
 
@@ -1148,6 +1145,38 @@ func TestAccGitlabProject_containerExpirationPolicy(t *testing.T) {
 	})
 }
 
+func TestAccGitlabProject_DeprecatedBuildCoverageRegex(t *testing.T) {
+	var received gitlab.Project
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckGitlabProjectDestroy,
+		Steps: []resource.TestStep{
+			{
+				SkipFunc: isGitLabVersionLessThan(testGitlabClient, "15.0"),
+				Config: fmt.Sprintf(`
+					resource "gitlab_project" "this" {
+						name = "foo-%d"
+						visibility_level = "public"
+
+						build_coverage_regex = "helloWorld"
+					}`, rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabProjectExists("gitlab_project.this", &received),
+				),
+			},
+			{
+				SkipFunc:          isGitLabVersionLessThan(testGitlabClient, "15.0"),
+				ResourceName:      "gitlab_project.this",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func testAccCheckGitlabProjectExists(n string, project *gitlab.Project) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		var err error
@@ -1359,7 +1388,6 @@ resource "gitlab_project" "foo" {
   # So that acceptance tests can be run in a gitlab organization
   # with no billing
   visibility_level = "public"
-  build_coverage_regex = "foo"
 }
 	`, rInt, rInt, rInt)
 }
@@ -1415,7 +1443,6 @@ resource "gitlab_project" "foo" {
   # So that acceptance tests can be run in a gitlab organization
   # with no billing
   visibility_level = "public"
-  build_coverage_regex = "foo"
 }
 
 resource "gitlab_project_variable" "foo" {
@@ -1449,7 +1476,6 @@ resource "gitlab_project" "foo" {
   # So that acceptance tests can be run in a gitlab organization
   # with no billing
   visibility_level = "public"
-  build_coverage_regex = "foo"
 }
 
 resource "gitlab_project_variable" "foo" {
@@ -1489,7 +1515,6 @@ resource "gitlab_project" "foo" {
   only_allow_merge_if_all_discussions_are_resolved = true
   squash_option = "default_off"
   pages_access_level = "public"
-  build_coverage_regex = "foo"
   allow_merge_on_skipped_pipeline = false
   ci_config_path = ".gitlab-ci.yml@mynamespace/myproject"
   resolve_outdated_diff_discussions = true
@@ -1589,7 +1614,6 @@ resource "gitlab_project" "foo" {
   archived = true
   packages_enabled = false
   pages_access_level = "disabled"
-  build_coverage_regex = "bar"
   ci_forward_deployment_enabled = false
   merge_pipelines_enabled = false
   merge_trains_enabled = false
@@ -1929,7 +1953,6 @@ resource "gitlab_project" "foo" {
   only_allow_merge_if_all_discussions_are_resolved = true
   squash_option = "default_off"
   pages_access_level = "public"
-  build_coverage_regex = "foo"
   allow_merge_on_skipped_pipeline = false
   ci_config_path = ".gitlab-ci.yml@mynamespace/myproject"
   resolve_outdated_diff_discussions = true

--- a/internal/provider/resource_gitlab_project_test.go
+++ b/internal/provider/resource_gitlab_project_test.go
@@ -1155,7 +1155,7 @@ func TestAccGitlabProject_DeprecatedBuildCoverageRegex(t *testing.T) {
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				SkipFunc: isGitLabVersionLessThan(testGitlabClient, "15.0"),
+				SkipFunc: isGitLabVersionLessThan(context.Background(), testGitlabClient, "15.0"),
 				Config: fmt.Sprintf(`
 					resource "gitlab_project" "this" {
 						name = "foo-%d"
@@ -1168,7 +1168,7 @@ func TestAccGitlabProject_DeprecatedBuildCoverageRegex(t *testing.T) {
 				),
 			},
 			{
-				SkipFunc:          isGitLabVersionLessThan(testGitlabClient, "15.0"),
+				SkipFunc:          isGitLabVersionLessThan(context.Background(), testGitlabClient, "15.0"),
 				ResourceName:      "gitlab_project.this",
 				ImportState:       true,
 				ImportStateVerify: true,


### PR DESCRIPTION
## Description

Adds a GitLab 15.0 check on the `build_coverage_regex` as it's set to be removed in GitLab 15.0. Based on conversations on our backwards compatibility issue, we still need to support the feature, however passing it will likely break the API in 15.0.

Partial Implements #1014

### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [ ] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
