### PR TITLE
resource/gitlab_repository_file: Add execute_filemode attribute

### DIFF
--- a/docs/data-sources/repository_file.md
+++ b/docs/data-sources/repository_file.md
@@ -43,6 +43,7 @@ data "gitlab_repository_file" "example" {
 - `content` (String) File content. If the content is not yet base64 encoded, it will be encoded automatically. No other encoding is currently supported, because of a [GitLab API bug](https://gitlab.com/gitlab-org/gitlab/-/issues/342430).
 - `content_sha256` (String) File content sha256 digest.
 - `encoding` (String) The file content encoding.
+- `execute_filemode` (Boolean) Enables or disables the execute flag on the file. **Note**: requires GitLab 14.10 or newer.
 - `file_name` (String) The filename.
 - `last_commit_id` (String) The last known commit id.
 - `size` (Number) The file size.

--- a/docs/resources/repository_file.md
+++ b/docs/resources/repository_file.md
@@ -75,6 +75,7 @@ resource "gitlab_repository_file" "readme" {
 
 - `author_email` (String) Email of the commit author.
 - `author_name` (String) Name of the commit author.
+- `execute_filemode` (Boolean) Enables or disables the execute flag on the file. **Note**: requires GitLab 14.10 or newer.
 - `id` (String) The ID of this resource.
 - `start_branch` (String) Name of the branch to start the new commit from.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))

--- a/go.mod
+++ b/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.14.0
 	github.com/mitchellh/hashstructure v1.1.0
 	github.com/onsi/gomega v1.19.0
-	github.com/xanzy/go-gitlab v0.63.0
+	github.com/xanzy/go-gitlab v0.64.0
 	golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
-	golang.org/x/net v0.0.0-20220412020605-290c469a71a5 // indirect
+	golang.org/x/net v0.0.0-20220421235706-1d1ef9303861 // indirect
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 // indirect
 	golang.org/x/time v0.0.0-20220411224347-583f2d630306 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -311,6 +311,8 @@ github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37w
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/xanzy/go-gitlab v0.63.0 h1:a9fXpKWykUS6dowapFej/2Wjf4aOAEFC1q2ZIcz4IpI=
 github.com/xanzy/go-gitlab v0.63.0/go.mod h1:F0QEXwmqiBUxCgJm8fE9S+1veX4XC9Z4cfaAbqwk4YM=
+github.com/xanzy/go-gitlab v0.64.0 h1:rMgQdW9S1w3qvNAH2LYpFd2xh7KNLk+JWJd7sorNuTc=
+github.com/xanzy/go-gitlab v0.64.0/go.mod h1:F0QEXwmqiBUxCgJm8fE9S+1veX4XC9Z4cfaAbqwk4YM=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -413,6 +415,8 @@ golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220412020605-290c469a71a5 h1:bRb386wvrE+oBNdF1d/Xh9mQrfQ4ecYhW5qJ5GvTGT4=
 golang.org/x/net v0.0.0-20220412020605-290c469a71a5/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
+golang.org/x/net v0.0.0-20220421235706-1d1ef9303861 h1:yssD99+7tqHWO5Gwh81phT+67hg+KttniBr6UnEXOY8=
+golang.org/x/net v0.0.0-20220421235706-1d1ef9303861/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/internal/provider/data_source_gitlab_repository_file_test.go
+++ b/internal/provider/data_source_gitlab_repository_file_test.go
@@ -40,6 +40,7 @@ func testAccDataSourceGitlabRepositoryFile(src, n string) resource.TestCheckFunc
 			"size",
 			"encoding",
 			"content",
+			"execute_filemode",
 			"ref",
 			"blob_id",
 			"commit_id",
@@ -64,6 +65,7 @@ resource "gitlab_repository_file" "foo" {
 	branch = "main"
 	content = base64encode("Meow goes the cat")
 	commit_message = "feat: Meow"
+	execute_filemode = true
 }
 
 data "gitlab_repository_file" "foo" {

--- a/internal/provider/resource_gitlab_repository_file.go
+++ b/internal/provider/resource_gitlab_repository_file.go
@@ -126,6 +126,9 @@ func resourceGitlabRepositoryFileCreate(ctx context.Context, d *schema.ResourceD
 	if startBranch, ok := d.GetOk("start_branch"); ok {
 		options.StartBranch = gitlab.String(startBranch.(string))
 	}
+	if executeFilemode, ok := d.GetOk("execute_filemode"); ok {
+		options.ExecuteFilemode = gitlab.Bool(executeFilemode.(bool))
+	}
 
 	err := resource.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
 		repositoryFile, _, err := client.RepositoryFiles.CreateFile(project, filePath, options, gitlab.WithContext(ctx))
@@ -226,6 +229,9 @@ func resourceGitlabRepositoryFileUpdate(ctx context.Context, d *schema.ResourceD
 	}
 	if startBranch, ok := d.GetOk("start_branch"); ok {
 		updateOptions.StartBranch = gitlab.String(startBranch.(string))
+	}
+	if executeFilemode, ok := d.GetOk("execute_filemode"); ok {
+		updateOptions.ExecuteFilemode = gitlab.Bool(executeFilemode.(bool))
 	}
 
 	err = resource.RetryContext(ctx, d.Timeout(schema.TimeoutUpdate), func() *resource.RetryError {

--- a/internal/provider/resource_gitlab_repository_file_test.go
+++ b/internal/provider/resource_gitlab_repository_file_test.go
@@ -366,6 +366,7 @@ resource "gitlab_repository_file" "this" {
   author_email = "meow@catnip.com"
   author_name = "Meow Meowington"
   commit_message = "feature: change launch codes"
+  execute_filemode = true
 }
 	`, projectID)
 }

--- a/internal/provider/schema_gitlab_repository_file.go
+++ b/internal/provider/schema_gitlab_repository_file.go
@@ -49,6 +49,11 @@ func gitlabRepositoryFileGetSchema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Computed:    true,
 		},
+		"execute_filemode": {
+			Description: "Enables or disables the execute flag on the file. **Note**: requires GitLab 14.10 or newer.",
+			Type:        schema.TypeBool,
+			Optional:    true,
+		},
 		"blob_id": {
 			Description: "The blob id.",
 			Type:        schema.TypeString,
@@ -76,6 +81,7 @@ func gitlabRepositoryFileToStateMap(project string, repositoryFile *gitlab.File)
 	stateMap["encoding"] = repositoryFile.Encoding
 	stateMap["content"] = repositoryFile.Content
 	stateMap["content_sha256"] = repositoryFile.SHA256
+	stateMap["execute_filemode"] = repositoryFile.ExecuteFilemode
 	stateMap["ref"] = repositoryFile.Ref
 	stateMap["blob_id"] = repositoryFile.BlobID
 	stateMap["commit_id"] = repositoryFile.CommitID


### PR DESCRIPTION
I've recently implemented the `execute_filemode` flag to the Repository
Files API. This change set makes it available in the provider, too :)

Blocked by:

- https://github.com/xanzy/go-gitlab/pull/1453
- GitLab 14.10 release and integration into the provider

Closes #981
