### PR TITLE
Add default branch protection workaround text to project resource

### DIFF
--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -5,6 +5,12 @@ subcategory: ""
 description: |-
   The gitlab_project resource allows to manage the lifecycle of a project.
   A project can either be created in a group or user namespace.
+  -> Default Branch Protection Workaround Projects are created with default branch protection.
+  Since this default branch protection is not currently managed via Terraform, to workaround this limitation,
+  you can remove the default branch protection via the API and create your desired Terraform managed branch protection.
+  In the gitlab_project resource, define a local-exec provisioner which invokes
+  the /projects/:id/protected_branches/:name API via curl to delete the branch protection on the default
+  branch using a DELETE request. Then define the desired branch protection using the gitlab_branch_protection resource.
   Upstream API: GitLab REST API docs https://docs.gitlab.com/ce/api/projects.html
 ---
 
@@ -13,6 +19,13 @@ description: |-
 The `gitlab_project` resource allows to manage the lifecycle of a project.
 
 A project can either be created in a group or user namespace.
+
+-> **Default Branch Protection Workaround** Projects are created with default branch protection. 
+Since this default branch protection is not currently managed via Terraform, to workaround this limitation, 
+you can remove the default branch protection via the API and create your desired Terraform managed branch protection.
+In the `gitlab_project` resource, define a `local-exec` provisioner which invokes 
+the `/projects/:id/protected_branches/:name` API via curl to delete the branch protection on the default 
+branch using a `DELETE` request. Then define the desired branch protection using the `gitlab_branch_protection` resource.
 
 **Upstream API**: [GitLab REST API docs](https://docs.gitlab.com/ce/api/projects.html)
 

--- a/internal/provider/resource_gitlab_project.go
+++ b/internal/provider/resource_gitlab_project.go
@@ -644,6 +644,13 @@ var _ = registerResource("gitlab_project", func() *schema.Resource {
 
 A project can either be created in a group or user namespace.
 
+-> **Default Branch Protection Workaround** Projects are created with default branch protection. 
+Since this default branch protection is not currently managed via Terraform, to workaround this limitation, 
+you can remove the default branch protection via the API and create your desired Terraform managed branch protection.
+In the ` + "`gitlab_project`" + ` resource, define a ` + "`local-exec`" + ` provisioner which invokes 
+the ` + "`/projects/:id/protected_branches/:name`" + ` API via curl to delete the branch protection on the default 
+branch using a ` + "`DELETE`" + ` request. Then define the desired branch protection using the ` + "`gitlab_branch_protection`" + ` resource.
+
 **Upstream API**: [GitLab REST API docs](https://docs.gitlab.com/ce/api/projects.html)`,
 
 		CreateContext: resourceGitlabProjectCreate,


### PR DESCRIPTION
Added documentation to the `gitlab_project` resource describing a workaround to allow Terraform to manage the default branch protection on a project.

## Description

<!-- Which issue/s does this PR close? Is there any more context you can give the reviewer? -->

### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
