### PR TITLE
Enable pages

### DIFF
--- a/scripts/gitlab.rb
+++ b/scripts/gitlab.rb
@@ -1,3 +1,8 @@
+pages_external_url 'http://127.0.0.1:5051'
+pages_nginx['redirect_http_to_https'] = false
+pages_nginx['ssl_certificate'] = "/etc/gitlab/ssl/gitlab-registry.pem"
+pages_nginx['ssl_certificate_key'] = "/etc/gitlab/ssl/gitlab-registry.key"
+
 registry_external_url 'http://127.0.0.1:5050'
 registry['enable']                    = true
 registry_nginx['ssl_certificate']     = "/etc/gitlab/ssl/gitlab-registry.pem"


### PR DESCRIPTION
## Description

Enables GitLab Pages. Required for https://github.com/gitlabhq/terraform-provider-gitlab/pull/1026

<!-- Which issue/s does this PR close? Is there any more context you can give the reviewer? -->

### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
