### PR TITLE
Remove test boilerplate by adding build tag

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -28,7 +28,6 @@ jobs:
       matrix:
         target:
           - lint-golangci
-          - lint-tfprovider
           - lint-examples-tf
           - lint-examples-sh
           - lint-generated

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -40,7 +40,6 @@ jobs:
       matrix:
         target:
           - lint-golangci
-          - lint-tfprovider
           - lint-examples-tf
           - lint-examples-sh
           - lint-generated

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,11 @@ run:
   timeout: 3m
 
 linters-settings:
+  custom:
+    tfproviderlint:
+      path: ./bin/tfproviderlint-plugin.so
+      description: "Terraform Provider Lint Tool"
+      original-url: https://github.com/bflad/tfproviderlint
   errcheck:
     exclude: errcheck_excludes.txt
 
@@ -11,3 +16,4 @@ linters:
   enable:
     - gofmt
     - govet
+    - tfproviderlint

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,8 @@
 {
-  "go.testEnvVars": {
-    "TF_ACC": "1",
-    "GITLAB_TOKEN": "ACCTEST1234567890123",
-    "GITLAB_BASE_URL": "http://127.0.0.1:8080"
-  },
-  "go.testFlags": ["-count=1", "-v", "-timeout=30m"]
+    "go.testEnvVars": {
+        "TF_ACC": "1",
+        "GITLAB_TOKEN": "ACCTEST1234567890123",
+        "GITLAB_BASE_URL": "http://127.0.0.1:8080"
+    },
+    "go.testFlags": ["-count=1", "-v", "-tags=acceptance", "-tags=acceptance"]
 }

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -73,7 +73,7 @@ testacc-down: ## Teardown a GitLab instance.
 	docker-compose down --volumes
 
 testacc: ## Run acceptance tests against a GitLab instance.
-	TF_ACC=1 GITLAB_TOKEN=$(GITLAB_TOKEN) GITLAB_BASE_URL=$(GITLAB_BASE_URL) go test -v $(PROVIDER_SRC_DIR) $(TESTARGS) -timeout 40m
+	TF_ACC=1 GITLAB_TOKEN=$(GITLAB_TOKEN) GITLAB_BASE_URL=$(GITLAB_BASE_URL) go test -v $(PROVIDER_SRC_DIR) $(TESTARGS) -timeout 40m -tags acceptance
 
 certs: ## Generate certs for the GitLab container registry
 	mkdir -p certs

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -23,12 +23,12 @@ test: ## Run unit tests.
 
 fmt: tool-golangci-lint tool-terraform tool-shfmt tfproviderlint-plugin ## Format files and fix issues.
 	gofmt -w -s .
-	$(GOBIN)/golangci-lint run --fix
+	$(GOBIN)/golangci-lint run --build-tags acceptance --fix
 	$(GOBIN)/terraform fmt -recursive -list ./examples
 	$(GOBIN)/shfmt -l -s -w ./examples
 
 lint-golangci: tool-golangci-lint tfproviderlint-plugin ## Run golangci-lint linter (same as fmt but without modifying files).
-	$(GOBIN)/golangci-lint run
+	$(GOBIN)/golangci-lint run --build-tags acceptance
 
 lint-examples-tf: tool-terraform ## Run terraform linter on examples (same as fmt but without modifying files).
 	$(GOBIN)/terraform fmt -recursive -check ./examples

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -67,7 +67,7 @@ testacc-down: ## Teardown a GitLab instance.
 	docker-compose down --volumes
 
 testacc: ## Run acceptance tests against a GitLab instance.
-	TF_ACC=1 GITLAB_TOKEN=$(GITLAB_TOKEN) GITLAB_BASE_URL=$(GITLAB_BASE_URL) go test -v $(PROVIDER_SRC_DIR) $(TESTARGS) -timeout 40m
+	TF_ACC=1 GITLAB_TOKEN=$(GITLAB_TOKEN) GITLAB_BASE_URL=$(GITLAB_BASE_URL) go test --tags acceptance -v $(PROVIDER_SRC_DIR) $(TESTARGS) -timeout 40m
 
 certs: ## Generate certs for the GitLab container registry
 	mkdir -p certs

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -21,20 +21,14 @@ endif
 test: ## Run unit tests.
 	go test $(TESTARGS) $(PROVIDER_SRC_DIR)
 
-TFPROVIDERLINTX_CHECKS = -XAT001=false -XR003=false -XS002=false
-
-fmt: tool-golangci-lint tool-tfproviderlintx tool-terraform tool-shfmt ## Format files and fix issues.
+fmt: tool-golangci-lint tool-terraform tool-shfmt tfproviderlint-plugin ## Format files and fix issues.
 	gofmt -w -s .
 	$(GOBIN)/golangci-lint run --fix
-	$(GOBIN)/tfproviderlintx $(TFPROVIDERLINTX_CHECKS) --fix ./...
 	$(GOBIN)/terraform fmt -recursive -list ./examples
 	$(GOBIN)/shfmt -l -s -w ./examples
 
-lint-golangci: tool-golangci-lint ## Run golangci-lint linter (same as fmt but without modifying files).
+lint-golangci: tool-golangci-lint tfproviderlint-plugin ## Run golangci-lint linter (same as fmt but without modifying files).
 	$(GOBIN)/golangci-lint run
-
-lint-tfprovider: tool-tfproviderlintx ## Run tfproviderlintx linter (same as fmt but without modifying files).
-	$(GOBIN)/tfproviderlintx $(TFPROVIDERLINTX_CHECKS) ./...
 
 lint-examples-tf: tool-terraform ## Run terraform linter on examples (same as fmt but without modifying files).
 	$(GOBIN)/terraform fmt -recursive -check ./examples
@@ -73,7 +67,7 @@ testacc-down: ## Teardown a GitLab instance.
 	docker-compose down --volumes
 
 testacc: ## Run acceptance tests against a GitLab instance.
-	TF_ACC=1 GITLAB_TOKEN=$(GITLAB_TOKEN) GITLAB_BASE_URL=$(GITLAB_BASE_URL) go test -v $(PROVIDER_SRC_DIR) $(TESTARGS) -timeout 40m -tags acceptance
+	TF_ACC=1 GITLAB_TOKEN=$(GITLAB_TOKEN) GITLAB_BASE_URL=$(GITLAB_BASE_URL) go test -v $(PROVIDER_SRC_DIR) $(TESTARGS) -timeout 40m
 
 certs: ## Generate certs for the GitLab container registry
 	mkdir -p certs
@@ -84,9 +78,6 @@ certs: ## Generate certs for the GitLab container registry
 
 tool-golangci-lint:
 	@$(call install-tool, github.com/golangci/golangci-lint/cmd/golangci-lint)
-
-tool-tfproviderlintx:
-	@$(call install-tool, github.com/bflad/tfproviderlint/cmd/tfproviderlintx)
 
 tool-tfplugindocs:
 	@$(call install-tool, github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs)
@@ -111,3 +102,6 @@ tool-terraform:
 
 clean: testacc-down
 	@rm -rf certs/
+
+tfproviderlint-plugin:
+	@cd tools && go build -buildmode=plugin -o $(GOBIN)/tfproviderlint-plugin.so ./cmd/tfproviderlint-plugin

--- a/internal/provider/data_source_gitlab_branch_test.go
+++ b/internal/provider/data_source_gitlab_branch_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/data_source_gitlab_branch_test.go
+++ b/internal/provider/data_source_gitlab_branch_test.go
@@ -14,10 +14,8 @@ import (
 
 func TestAccDataGitlabBranch_basic(t *testing.T) {
 	rInt := acctest.RandInt()
-	testAccCheck(t)
 	project := testAccCreateProject(t)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_group_membership_test.go
+++ b/internal/provider/data_source_gitlab_group_membership_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/data_source_gitlab_group_membership_test.go
+++ b/internal/provider/data_source_gitlab_group_membership_test.go
@@ -15,7 +15,6 @@ func TestAccDataSourceGitlabMembership_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			// Create the group and one member
@@ -48,8 +47,6 @@ func TestAccDataSourceGitlabMembership_basic(t *testing.T) {
 }
 
 func TestAccDataSourceGitlabMembership_pagination(t *testing.T) {
-	testAccCheck(t)
-
 	userCount := 21
 
 	group := testAccCreateGroups(t, 1)[0]
@@ -57,7 +54,6 @@ func TestAccDataSourceGitlabMembership_pagination(t *testing.T) {
 	testAccAddGroupMembers(t, group.ID, users)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_group_test.go
+++ b/internal/provider/data_source_gitlab_group_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/data_source_gitlab_group_test.go
+++ b/internal/provider/data_source_gitlab_group_test.go
@@ -16,7 +16,6 @@ func TestAccDataSourceGitlabGroup_basic(t *testing.T) {
 	rString := fmt.Sprintf("%s", acctest.RandString(5)) // nolint // TODO: Resolve this golangci-lint issue: S1025: the argument is already a string, there's no need to use fmt.Sprintf (gosimple)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			// Get group using its ID

--- a/internal/provider/data_source_gitlab_group_variable_test.go
+++ b/internal/provider/data_source_gitlab_group_variable_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/data_source_gitlab_group_variable_test.go
+++ b/internal/provider/data_source_gitlab_group_variable_test.go
@@ -12,12 +12,9 @@ import (
 )
 
 func TestAccDataSourceGitlabGroupVariable_basic(t *testing.T) {
-	testAccCheck(t)
-
 	testGroup := testAccCreateGroups(t, 1)[0]
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_group_variables_test.go
+++ b/internal/provider/data_source_gitlab_group_variables_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/data_source_gitlab_group_variables_test.go
+++ b/internal/provider/data_source_gitlab_group_variables_test.go
@@ -12,8 +12,6 @@ import (
 )
 
 func TestAccDataSourceGitlabGroupVariables_basic(t *testing.T) {
-	testAccCheck(t)
-
 	testGroup := testAccCreateGroups(t, 1)[0]
 	testVariables := make([]*gitlab.GroupVariable, 0)
 	for i := 0; i < 25; i++ {
@@ -21,7 +19,6 @@ func TestAccDataSourceGitlabGroupVariables_basic(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_instance_deploy_keys_test.go
+++ b/internal/provider/data_source_gitlab_instance_deploy_keys_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/data_source_gitlab_instance_deploy_keys_test.go
+++ b/internal/provider/data_source_gitlab_instance_deploy_keys_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestAccDataSourceGitlabInstanceDeployKeys_basic(t *testing.T) {
-	testAccCheck(t)
 	testKey := "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCi+ErxScCKIVqg2ZRJ6Mx2Yd/RTsh2DGyhUR8z8Iey4rpi1YOBlpTgjxxnSLy26J++Un/iWYDP8wMvEjXElkWz3z4I+Z3mfF3dv039FTCu+O17Mw20Ek4DJxdrKvOgul040sUG/ABVHo6DjqjokjoVJwzUrUmoOtbeMMD8hFN9bWdEVyTj18XQO8nvEe/VkbhCRhAlZC1l60fM07/7Tw83SV5UNAnBtOB+nfa3b24baO+Ijc4+PqYcBuUAF6DvhXW2gZPqf5wjDBJqlDlRTYDdHarMXZAKBpWfWj0gntbtEOM+Fnp6hS1HajaeveNSs6yQwgQEDN2boQnDuvXJ8Y7zW3YQKZp8z0uqWYJSIrYRKVEVYL7gDWL9NvdRV52d/RKPnE/BlL2chiAWBRCT8buQdjVtEPPoYbA1667PXZg6PI9yhCGEIjCj71XzPssA6VL/R7yUafsmNLsirWz9Uyh3HJWCcgNuO9mglP5nfFHIXSHQVhEUEYMfzv1iX5FrenU= test"
 	testKey2 := "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDStVqW58VZ5afXFphIvu2JahndXslJZMkgWsNiYCNdk/NvrEbc4i7yZVoDPFQsbS9I6Ty1RMW7qy3KxJalMsVHcw8arCQFDxs/ka1NHGCUPl68t5ZxUOl900KRQ0lOzGnDQMqG/UUZdPw4CCmigTr6Z9ZBcD1fXAiUwbXR4tWrr5z9KWXC2HgF4WkIJUTIct7ilY1m9W0y79dI/+K8bZrurn3q2QK83pxqqWkLwvUsCxtlhMpwuyflyzyuz8xPZl2GlZgxeIpr68gsPHIzzWizibwFfbRYKCZO4wD0r7JCDOYs9KjcIPpCG6d3HUqijClgdQSBnLwHTdE04ZtdzO8akvy0hMzRCooI5TSc8IAHos53Gp9aaW92sPA8za+WRP6OSH6UsOW4N+iQc4jyl7/fckMSgIZlJouNqqV+P8iqIFJGs70Tj5L8G/m+P2lc3kcE4Vjmj+Fc0xG5+I/PsSOpcc6DfDfZdVDRe8yklYd/qC1jI89OCeqjxu3XcUGHj9s= test"
 	testProjectTwoKeys := testAccCreateProject(t)
@@ -32,7 +31,6 @@ func TestAccDataSourceGitlabInstanceDeployKeys_basic(t *testing.T) {
 	testAccCreateDeployKey(t, testProjectOneKey.ID, &canPushDeployKeyOptions)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_instance_variable_test.go
+++ b/internal/provider/data_source_gitlab_instance_variable_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/data_source_gitlab_instance_variable_test.go
+++ b/internal/provider/data_source_gitlab_instance_variable_test.go
@@ -13,7 +13,6 @@ import (
 
 func TestAccDataSourceGitlabInstanceVariable_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_instance_variables_test.go
+++ b/internal/provider/data_source_gitlab_instance_variables_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/data_source_gitlab_instance_variables_test.go
+++ b/internal/provider/data_source_gitlab_instance_variables_test.go
@@ -12,15 +12,12 @@ import (
 )
 
 func TestAccDataSourceGitlabInstanceVariables_basic(t *testing.T) {
-	testAccCheck(t)
-
 	testVariables := make([]*gitlab.InstanceVariable, 0)
 	for i := 0; i < 25; i++ {
 		testVariables = append(testVariables, testAccCreateInstanceVariable(t))
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_project_issue_test.go
+++ b/internal/provider/data_source_gitlab_project_issue_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/data_source_gitlab_project_issue_test.go
+++ b/internal/provider/data_source_gitlab_project_issue_test.go
@@ -12,12 +12,9 @@ import (
 )
 
 func TestAccDataSourceGitlabProjectIssue_basic(t *testing.T) {
-	testAccCheck(t)
-
 	testProject := testAccCreateProject(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_project_issues_test.go
+++ b/internal/provider/data_source_gitlab_project_issues_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/data_source_gitlab_project_issues_test.go
+++ b/internal/provider/data_source_gitlab_project_issues_test.go
@@ -11,13 +11,10 @@ import (
 )
 
 func TestAccDataSourceGitlabProjectIssues_basic(t *testing.T) {
-	testAccCheck(t)
-
 	testProject := testAccCreateProject(t)
 	testIssues := testAccCreateProjectIssues(t, testProject.ID, 25)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_project_protected_branch_test.go
+++ b/internal/provider/data_source_gitlab_project_protected_branch_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/data_source_gitlab_project_protected_branch_test.go
+++ b/internal/provider/data_source_gitlab_project_protected_branch_test.go
@@ -15,7 +15,6 @@ func TestAccDataGitlabProjectProtectedBranch_search(t *testing.T) {
 	projectName := fmt.Sprintf("tf-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_project_protected_branches_test.go
+++ b/internal/provider/data_source_gitlab_project_protected_branches_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/data_source_gitlab_project_protected_branches_test.go
+++ b/internal/provider/data_source_gitlab_project_protected_branches_test.go
@@ -15,7 +15,6 @@ func TestAccDataGitlabProjectProtectedBranches_search(t *testing.T) {
 	projectName := fmt.Sprintf("tf-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_project_tag_test.go
+++ b/internal/provider/data_source_gitlab_project_tag_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/data_source_gitlab_project_tag_test.go
+++ b/internal/provider/data_source_gitlab_project_tag_test.go
@@ -13,12 +13,10 @@ import (
 )
 
 func TestAccDataGitlabProjectTag_basic(t *testing.T) {
-	testAccCheck(t)
 	rInt := acctest.RandInt()
 	project := testAccCreateProject(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_project_tags_test.go
+++ b/internal/provider/data_source_gitlab_project_tags_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/data_source_gitlab_project_tags_test.go
+++ b/internal/provider/data_source_gitlab_project_tags_test.go
@@ -12,12 +12,10 @@ import (
 )
 
 func TestAccDataGitlabProjectTags_basic(t *testing.T) {
-	testAccCheck(t)
 	countTags := 3
 	project := testAccCreateProject(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_project_test.go
+++ b/internal/provider/data_source_gitlab_project_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/data_source_gitlab_project_test.go
+++ b/internal/provider/data_source_gitlab_project_test.go
@@ -16,7 +16,6 @@ func TestAccDataGitlabProject_basic(t *testing.T) {
 	projectname := fmt.Sprintf("tf-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_project_variable_test.go
+++ b/internal/provider/data_source_gitlab_project_variable_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/data_source_gitlab_project_variable_test.go
+++ b/internal/provider/data_source_gitlab_project_variable_test.go
@@ -12,12 +12,9 @@ import (
 )
 
 func TestAccDataSourceGitlabProjectVariable_basic(t *testing.T) {
-	testAccCheck(t)
-
 	testProject := testAccCreateProject(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_project_variables_test.go
+++ b/internal/provider/data_source_gitlab_project_variables_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/data_source_gitlab_project_variables_test.go
+++ b/internal/provider/data_source_gitlab_project_variables_test.go
@@ -12,8 +12,6 @@ import (
 )
 
 func TestAccDataSourceGitlabProjectVariables_basic(t *testing.T) {
-	testAccCheck(t)
-
 	testProject := testAccCreateProject(t)
 	testVariables := make([]*gitlab.ProjectVariable, 0)
 	for i := 0; i < 25; i++ {
@@ -21,7 +19,6 @@ func TestAccDataSourceGitlabProjectVariables_basic(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_projects_test.go
+++ b/internal/provider/data_source_gitlab_projects_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/data_source_gitlab_projects_test.go
+++ b/internal/provider/data_source_gitlab_projects_test.go
@@ -19,7 +19,6 @@ func TestAccDataGitlabProjects_search(t *testing.T) {
 	projectName := fmt.Sprintf("tf-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
@@ -64,7 +63,6 @@ func TestAccDataGitlabProjects_groups(t *testing.T) {
 	subGroupProjectName2 := fmt.Sprintf("tf-%s", acctest.RandString(5))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
@@ -102,7 +100,6 @@ func TestAccDataGitlabProjects_searchArchivedRepository(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_repository_file_test.go
+++ b/internal/provider/data_source_gitlab_repository_file_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/data_source_gitlab_repository_file_test.go
+++ b/internal/provider/data_source_gitlab_repository_file_test.go
@@ -12,10 +12,8 @@ import (
 )
 
 func TestAccDataGitlabRepositoryFile_basic(t *testing.T) {
-	testAccCheck(t)
 	project := testAccCreateProject(t)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_user_test.go
+++ b/internal/provider/data_source_gitlab_user_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/data_source_gitlab_user_test.go
+++ b/internal/provider/data_source_gitlab_user_test.go
@@ -16,7 +16,6 @@ func TestAccDataSourceGitlabUser_basic(t *testing.T) {
 	rString := fmt.Sprintf("%s", acctest.RandString(5)) // nolint // TODO: Resolve this golangci-lint issue: S1025: the argument is already a string, there's no need to use fmt.Sprintf (gosimple)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			// Get user using its email

--- a/internal/provider/data_source_gitlab_users_test.go
+++ b/internal/provider/data_source_gitlab_users_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/data_source_gitlab_users_test.go
+++ b/internal/provider/data_source_gitlab_users_test.go
@@ -17,7 +17,6 @@ func TestAccDataSourceGitlabUsers_basic(t *testing.T) {
 	user2 := fmt.Sprintf("user%d@test.test", rInt2)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/helper_test.go
+++ b/internal/provider/helper_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/helper_test.go
+++ b/internal/provider/helper_test.go
@@ -67,15 +67,6 @@ func isRunningInCE() (bool, error) {
 	return !isEE, err
 }
 
-// testAccCheck is a test helper that skips the current test if it is not an acceptance test.
-func testAccCheck(t *testing.T) {
-	t.Helper()
-
-	if os.Getenv(resource.EnvTfAcc) == "" {
-		t.Skipf("Acceptance tests skipped unless env '%s' set", resource.EnvTfAcc)
-	}
-}
-
 // orSkipFunc accepts many skipFunc and returns "true" if any returns true.
 func orSkipFunc(input ...SkipFunc) SkipFunc {
 	return func() (bool, error) {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -8,12 +8,7 @@ import (
 	"os"
 	"testing"
 
-	// "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-
-	// "github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/xanzy/go-gitlab"
 )
 
@@ -39,13 +34,11 @@ var testGitlabConfig = Config{
 var testGitlabClient *gitlab.Client
 
 func init() {
-	if os.Getenv(resource.EnvTfAcc) != "" {
-		client, err := testGitlabConfig.Client(context.Background())
-		if err != nil {
-			panic("failed to create test client: " + err.Error()) // lintignore: R009 // TODO: Resolve this tfproviderlint issue
-		}
-		testGitlabClient = client
+	client, err := testGitlabConfig.Client(context.Background())
+	if err != nil {
+		panic("failed to create test client: " + err.Error()) // lintignore: R009 // TODO: Resolve this tfproviderlint issue
 	}
+	testGitlabClient = client
 }
 
 func TestProvider(t *testing.T) {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (
@@ -6,6 +9,7 @@ import (
 	"testing"
 
 	// "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
@@ -52,10 +56,4 @@ func TestProvider(t *testing.T) {
 
 func TestProvider_impl(t *testing.T) {
 	var _ *schema.Provider = New("dev")()
-}
-
-func testAccPreCheck(t *testing.T) {
-	if v := os.Getenv("GITLAB_TOKEN"); v == "" {
-		t.Fatal("GITLAB_TOKEN must be set for acceptance tests")
-	}
 }

--- a/internal/provider/resource_gitlab_branch_protection_test.go
+++ b/internal/provider/resource_gitlab_branch_protection_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_branch_protection_test.go
+++ b/internal/provider/resource_gitlab_branch_protection_test.go
@@ -21,7 +21,6 @@ func TestAccGitlabBranchProtection_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabBranchProtectionDestroy,
 		Steps: []resource.TestStep{
@@ -166,7 +165,6 @@ func TestAccGitlabBranchProtection_createWithCodeOwnerApproval(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabBranchProtectionDestroy,
 		Steps: []resource.TestStep{
@@ -241,7 +239,6 @@ func TestAccGitlabBranchProtection_createWithAllowForcePush(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabBranchProtectionDestroy,
 		Steps: []resource.TestStep{
@@ -297,7 +294,6 @@ func TestAccGitlabBranchProtection_createWithUnprotectAccessLevel(t *testing.T) 
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabBranchProtectionDestroy,
 		Steps: []resource.TestStep{
@@ -338,7 +334,6 @@ func TestAccGitlabBranchProtection_createWithMultipleAccessLevels(t *testing.T) 
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabBranchProtectionDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_branch_test.go
+++ b/internal/provider/resource_gitlab_branch_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_branch_test.go
+++ b/internal/provider/resource_gitlab_branch_test.go
@@ -6,11 +6,12 @@ package provider
 import (
 	"errors"
 	"fmt"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	gitlab "github.com/xanzy/go-gitlab"
-	"testing"
 )
 
 func TestAccGitlabBranch_basic(t *testing.T) {
@@ -18,12 +19,10 @@ func TestAccGitlabBranch_basic(t *testing.T) {
 	var branch2 gitlab.Branch
 	rInt := acctest.RandInt()
 	rInt2 := acctest.RandInt()
-	testAccCheck(t)
 	project := testAccCreateProject(t)
 	fooBranchName := fmt.Sprintf("testbranch-%d", rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabBranchDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_deploy_key_enable_test.go
+++ b/internal/provider/resource_gitlab_deploy_key_enable_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_deploy_key_enable_test.go
+++ b/internal/provider/resource_gitlab_deploy_key_enable_test.go
@@ -13,8 +13,6 @@ import (
 )
 
 func TestAccGitlabDeployKeyEnable_basic(t *testing.T) {
-	testAccCheck(t)
-
 	testProjectParent := testAccCreateProject(t)
 	testProjectKeyShared := testAccCreateProject(t)
 
@@ -29,7 +27,6 @@ func TestAccGitlabDeployKeyEnable_basic(t *testing.T) {
 	parentProjectDeployKey := testAccCreateDeployKey(t, testProjectParent.ID, &canPushDeployKeyOptions)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabDeployKeyEnableDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_deploy_key_test.go
+++ b/internal/provider/resource_gitlab_deploy_key_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_deploy_key_test.go
+++ b/internal/provider/resource_gitlab_deploy_key_test.go
@@ -14,13 +14,10 @@ import (
 )
 
 func TestAccGitlabDeployKey_basic(t *testing.T) {
-	testAccCheck(t)
-
 	testProject := testAccCreateProject(t)
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabDeployKeyDestroy,
 		Steps: []resource.TestStep{
@@ -62,12 +59,10 @@ func TestAccGitlabDeployKey_basic(t *testing.T) {
 }
 
 func TestAccGitlabDeployKey_suppressTrailingSpace(t *testing.T) {
-	testAccCheck(t)
 	testProject := testAccCreateProject(t)
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabDeployKeyDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_deploy_token_test.go
+++ b/internal/provider/resource_gitlab_deploy_token_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_deploy_token_test.go
+++ b/internal/provider/resource_gitlab_deploy_token_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestAccGitlabDeployToken_basic(t *testing.T) {
-	testAccCheck(t)
-
 	var projectDeployToken gitlab.DeployToken
 	var groupDeployToken gitlab.DeployToken
 
@@ -23,7 +21,6 @@ func TestAccGitlabDeployToken_basic(t *testing.T) {
 	testGroup := testAccCreateGroups(t, 1)[0]
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabDeployTokenDestroy,
 		Steps: []resource.TestStep{
@@ -55,13 +52,10 @@ func TestAccGitlabDeployToken_basic(t *testing.T) {
 	})
 }
 func TestAccGitlabDeployToken_pagination(t *testing.T) {
-	testAccCheck(t)
-
 	testGroup := testAccCreateGroups(t, 1)[0]
 	testProject := testAccCreateProject(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabDeployTokenDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_group_access_token_test.go
+++ b/internal/provider/resource_gitlab_group_access_token_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_group_access_token_test.go
+++ b/internal/provider/resource_gitlab_group_access_token_test.go
@@ -17,11 +17,9 @@ func TestAccGitlabGroupAccessToken_basic(t *testing.T) {
 	var gat testAccGitlabGroupAccessTokenWrapper
 	var groupVariable gitlab.GroupVariable
 
-	testAccCheck(t)
 	testGroup := testAccCreateGroups(t, 1)[0]
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabGroupAccessTokenDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_group_badge_test.go
+++ b/internal/provider/resource_gitlab_group_badge_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_group_badge_test.go
+++ b/internal/provider/resource_gitlab_group_badge_test.go
@@ -20,7 +20,6 @@ func TestAccGitlabGroupBadge_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabGroupBadgeDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_group_cluster_test.go
+++ b/internal/provider/resource_gitlab_group_cluster_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_group_cluster_test.go
+++ b/internal/provider/resource_gitlab_group_cluster_test.go
@@ -18,7 +18,6 @@ func TestAccGitlabGroupCluster_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabGroupClusterDestroy,
 		Steps: []resource.TestStep{
@@ -106,7 +105,6 @@ func TestAccGitlabGroupCluster_import(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabGroupClusterDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_group_custom_attribute_test.go
+++ b/internal/provider/resource_gitlab_group_custom_attribute_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_group_custom_attribute_test.go
+++ b/internal/provider/resource_gitlab_group_custom_attribute_test.go
@@ -19,7 +19,6 @@ func TestAccGitlabGroupCustomAttribute_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabGroupDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_group_label_test.go
+++ b/internal/provider/resource_gitlab_group_label_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_group_label_test.go
+++ b/internal/provider/resource_gitlab_group_label_test.go
@@ -18,7 +18,6 @@ func TestAccGitlabGroupLabel_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabGroupLabelDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_group_ldap_link_test.go
+++ b/internal/provider/resource_gitlab_group_ldap_link_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_group_membership_test.go
+++ b/internal/provider/resource_gitlab_group_membership_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_group_membership_test.go
+++ b/internal/provider/resource_gitlab_group_membership_test.go
@@ -18,7 +18,7 @@ func TestAccGitlabGroupMembership_basic(t *testing.T) {
 	var groupMember gitlab.GroupMember
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{PreCheck: func() { testAccPreCheck(t) },
+	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabGroupMembershipDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_group_project_file_template_test.go
+++ b/internal/provider/resource_gitlab_group_project_file_template_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_group_project_file_template_test.go
+++ b/internal/provider/resource_gitlab_group_project_file_template_test.go
@@ -5,22 +5,21 @@ package provider
 
 import (
 	"fmt"
+	"strconv"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/xanzy/go-gitlab"
-	"strconv"
-	"testing"
 )
 
 func TestAccGitlabGroupProjectFileTemplate_basic(t *testing.T) {
 	// Since we do some manual setup in this test, we need to handle the test skip first.
-	testAccCheck(t)
 	baseGroup := testAccCreateGroups(t, 1)[0]
 	firstProject := testAccCreateProjectWithNamespace(t, baseGroup.ID)
 	secondProject := testAccCreateProjectWithNamespace(t, baseGroup.ID)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckProjectFileTemplateDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_group_share_group_test.go
+++ b/internal/provider/resource_gitlab_group_share_group_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_group_share_group_test.go
+++ b/internal/provider/resource_gitlab_group_share_group_test.go
@@ -13,13 +13,10 @@ import (
 )
 
 func TestAccGitlabGroupShareGroup_basic(t *testing.T) {
-	testAccCheck(t)
-
 	mainGroup := testAccCreateGroups(t, 1)[0]
 	sharedGroup := testAccCreateGroups(t, 1)[0]
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabShareGroupDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_group_test.go
+++ b/internal/provider/resource_gitlab_group_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_group_test.go
+++ b/internal/provider/resource_gitlab_group_test.go
@@ -19,7 +19,6 @@ func TestAccGitlabGroup_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabGroupDestroy,
 		Steps: []resource.TestStep{
@@ -116,7 +115,6 @@ func TestAccGitlabGroup_import(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabGroupDestroy,
 		Steps: []resource.TestStep{
@@ -139,7 +137,6 @@ func TestAccGitlabGroup_nested(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabGroupDestroy,
 		Steps: []resource.TestStep{
@@ -232,7 +229,6 @@ func TestAccGitlabGroup_disappears(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabGroupDestroy,
 		Steps: []resource.TestStep{
@@ -253,7 +249,6 @@ func TestAccGitlabGroup_PreventForkingOutsideGroup(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabGroupDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_group_variable_test.go
+++ b/internal/provider/resource_gitlab_group_variable_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_group_variable_test.go
+++ b/internal/provider/resource_gitlab_group_variable_test.go
@@ -20,7 +20,6 @@ func TestAccGitlabGroupVariable_basic(t *testing.T) {
 	rString := acctest.RandString(5)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabGroupVariableDestroy,
 		Steps: []resource.TestStep{
@@ -116,7 +115,6 @@ func TestAccGitlabGroupVariable_scope(t *testing.T) {
 	defaultValueA := fmt.Sprintf("value-%s-a", rString)
 	defaultValueB := fmt.Sprintf("value-%s-b", rString)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabGroupVariableDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_instance_cluster_test.go
+++ b/internal/provider/resource_gitlab_instance_cluster_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_instance_cluster_test.go
+++ b/internal/provider/resource_gitlab_instance_cluster_test.go
@@ -19,7 +19,6 @@ func TestAccGitlabInstanceCluster_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabInstanceClusterDestroy,
 		Steps: []resource.TestStep{
@@ -108,7 +107,6 @@ func TestAccGitlabInstanceCluster_import(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabInstanceClusterDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_instance_variable_test.go
+++ b/internal/provider/resource_gitlab_instance_variable_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_instance_variable_test.go
+++ b/internal/provider/resource_gitlab_instance_variable_test.go
@@ -19,7 +19,6 @@ func TestAccGitlabInstanceVariable_basic(t *testing.T) {
 	rString := acctest.RandString(5)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabInstanceVariableDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_label_test.go
+++ b/internal/provider/resource_gitlab_label_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_label_test.go
+++ b/internal/provider/resource_gitlab_label_test.go
@@ -18,7 +18,6 @@ func TestAccGitlabLabel_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabLabelDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_managed_license_test.go
+++ b/internal/provider/resource_gitlab_managed_license_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_managed_license_test.go
+++ b/internal/provider/resource_gitlab_managed_license_test.go
@@ -20,7 +20,6 @@ func TestAccGitlabManagedLicense_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() {},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckManagedLicenseDestroy,
 		Steps: []resource.TestStep{
@@ -56,7 +55,6 @@ func TestAccGitlabManagedLicense_deprecatedConfigValues(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() {},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckManagedLicenseDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_personal_access_tokens_test.go
+++ b/internal/provider/resource_gitlab_personal_access_tokens_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_personal_access_tokens_test.go
+++ b/internal/provider/resource_gitlab_personal_access_tokens_test.go
@@ -15,12 +15,9 @@ import (
 )
 
 func TestAccGitlabPersonalAccessToken_basic(t *testing.T) {
-	testAccCheck(t)
-
 	user := testAccCreateUsers(t, 1)[0]
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabPersonalAccessTokenDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_pipeline_schedule_test.go
+++ b/internal/provider/resource_gitlab_pipeline_schedule_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_pipeline_schedule_test.go
+++ b/internal/provider/resource_gitlab_pipeline_schedule_test.go
@@ -19,7 +19,6 @@ func TestAccGitlabPipelineSchedule_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabPipelineScheduleDestroy,
 		Steps: []resource.TestStep{
@@ -75,7 +74,6 @@ func TestAccGitlabPipelineSchedule_import(t *testing.T) {
 	resourceName := "gitlab_pipeline_schedule.schedule"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabPipelineScheduleDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_pipeline_schedule_variable_test.go
+++ b/internal/provider/resource_gitlab_pipeline_schedule_variable_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_pipeline_schedule_variable_test.go
+++ b/internal/provider/resource_gitlab_pipeline_schedule_variable_test.go
@@ -19,7 +19,6 @@ func TestAccGitlabPipelineScheduleVariable_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -63,7 +62,6 @@ func TestAccGitlabPipelineScheduleVariable_import(t *testing.T) {
 	resourceName := "gitlab_pipeline_schedule_variable.schedule_var"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabPipelineScheduleVariableDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_pipeline_trigger_test.go
+++ b/internal/provider/resource_gitlab_pipeline_trigger_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_pipeline_trigger_test.go
+++ b/internal/provider/resource_gitlab_pipeline_trigger_test.go
@@ -19,7 +19,6 @@ func TestAccGitlabPipelineTrigger_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabPipelineTriggerDestroy,
 		Steps: []resource.TestStep{
@@ -63,7 +62,6 @@ func TestAccGitlabPipelineTrigger_import(t *testing.T) {
 	resourceName := "gitlab_pipeline_trigger.trigger"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabPipelineTriggerDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_access_token_test.go
+++ b/internal/provider/resource_gitlab_project_access_token_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_project_access_token_test.go
+++ b/internal/provider/resource_gitlab_project_access_token_test.go
@@ -13,12 +13,9 @@ import (
 )
 
 func TestAccGitlabProjectAccessToken_basic(t *testing.T) {
-	testAccCheck(t)
-
 	project := testAccCreateProject(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectAccessTokenDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_approval_rule_test.go
+++ b/internal/provider/resource_gitlab_project_approval_rule_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_project_approval_rule_test.go
+++ b/internal/provider/resource_gitlab_project_approval_rule_test.go
@@ -18,7 +18,6 @@ import (
 func TestAccGitLabProjectApprovalRule_Basic(t *testing.T) {
 	// Set up project, groups, users, and branches to use in the test.
 
-	testAccCheck(t)
 	testAccCheckEE(t)
 
 	// Need to get the current user (usually the admin) because they are automatically added as group members, and we
@@ -85,7 +84,6 @@ func TestAccGitLabProjectApprovalRule_Basic(t *testing.T) {
 func TestAccGitLabProjectApprovalRule_AnyApprover(t *testing.T) {
 	// Set up project, groups, users, and branches to use in the test.
 
-	testAccCheck(t)
 	testAccCheckEE(t)
 
 	project := testAccCreateProject(t)

--- a/internal/provider/resource_gitlab_project_badge_test.go
+++ b/internal/provider/resource_gitlab_project_badge_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_project_badge_test.go
+++ b/internal/provider/resource_gitlab_project_badge_test.go
@@ -12,12 +12,9 @@ import (
 )
 
 func TestAccGitlabProjectBadge_basic(t *testing.T) {
-	testAccCheck(t)
-
 	testProject := testAccCreateProject(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectBadgeDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_cluster_test.go
+++ b/internal/provider/resource_gitlab_project_cluster_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_project_cluster_test.go
+++ b/internal/provider/resource_gitlab_project_cluster_test.go
@@ -18,7 +18,6 @@ func TestAccGitlabProjectCluster_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectClusterDestroy,
 		Steps: []resource.TestStep{
@@ -108,7 +107,6 @@ func TestAccGitlabProjectCluster_import(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectClusterDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_custom_attribute_test.go
+++ b/internal/provider/resource_gitlab_project_custom_attribute_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_project_custom_attribute_test.go
+++ b/internal/provider/resource_gitlab_project_custom_attribute_test.go
@@ -19,7 +19,6 @@ func TestAccGitlabProjectCustomAttribute_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_environment_test.go
+++ b/internal/provider/resource_gitlab_project_environment_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_project_environment_test.go
+++ b/internal/provider/resource_gitlab_project_environment_test.go
@@ -17,8 +17,6 @@ import (
 )
 
 func TestAccGitlabProjectEnvironment_basic(t *testing.T) {
-	testAccCheck(t)
-
 	rInt := acctest.RandInt()
 	testProject := testAccCreateProject(t)
 
@@ -32,7 +30,6 @@ func TestAccGitlabProjectEnvironment_basic(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectEnvironmentDestroy,
 		Steps: []resource.TestStep{
@@ -117,13 +114,10 @@ func TestAccGitlabProjectEnvironment_basic(t *testing.T) {
 }
 
 func TestAccGitlabProjectEnvironment_stopBeforeDestroyDisabled(t *testing.T) {
-	testAccCheck(t)
-
 	rInt := acctest.RandInt()
 	testProject := testAccCreateProject(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectEnvironmentDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_freeze_period_test.go
+++ b/internal/provider/resource_gitlab_project_freeze_period_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_project_freeze_period_test.go
+++ b/internal/provider/resource_gitlab_project_freeze_period_test.go
@@ -18,7 +18,6 @@ func TestAccGitlabProjectFreezePeriod_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -67,7 +66,6 @@ func TestAccGitlabProjectFreezePeriod_import(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_hook_test.go
+++ b/internal/provider/resource_gitlab_project_hook_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_project_hook_test.go
+++ b/internal/provider/resource_gitlab_project_hook_test.go
@@ -19,7 +19,6 @@ func TestAccGitlabProjectHook_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectHookDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_issue_test.go
+++ b/internal/provider/resource_gitlab_project_issue_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_project_issue_test.go
+++ b/internal/provider/resource_gitlab_project_issue_test.go
@@ -15,8 +15,6 @@ import (
 )
 
 func TestAccGitlabProjectIssue_basic(t *testing.T) {
-	testAccCheck(t)
-
 	var testIssue gitlab.Issue
 	var updatedTestIssue gitlab.Issue
 
@@ -31,7 +29,6 @@ func TestAccGitlabProjectIssue_basic(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectIssueDestroy,
 		Steps: []resource.TestStep{
@@ -151,7 +148,6 @@ func TestAccGitlabProjectIssue_basic(t *testing.T) {
 }
 
 func TestAccGitlabProjectIssue_basicEE(t *testing.T) {
-	testAccCheck(t)
 	testAccCheckEE(t)
 
 	testProject := testAccCreateProject(t)
@@ -160,7 +156,6 @@ func TestAccGitlabProjectIssue_basicEE(t *testing.T) {
 	testMilestone := testAccAddProjectMilestone(t, testProject.ID)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectIssueDestroy,
 		Steps: []resource.TestStep{
@@ -180,12 +175,9 @@ func TestAccGitlabProjectIssue_basicEE(t *testing.T) {
 }
 
 func TestAccGitlabProjectIssue_deleteOnDestroy(t *testing.T) {
-	testAccCheck(t)
-
 	testProject := testAccCreateProject(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectIssueDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_level_mr_approvals_test.go
+++ b/internal/provider/resource_gitlab_project_level_mr_approvals_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_project_level_mr_approvals_test.go
+++ b/internal/provider/resource_gitlab_project_level_mr_approvals_test.go
@@ -19,7 +19,6 @@ func TestAccGitlabProjectLevelMRApprovals_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectLevelMRApprovalsDestroy,
 		Steps: []resource.TestStep{
@@ -75,7 +74,6 @@ func TestAccGitlabProjectLevelMRApprovals_import(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectLevelMRApprovalsDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_membership_test.go
+++ b/internal/provider/resource_gitlab_project_membership_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_project_membership_test.go
+++ b/internal/provider/resource_gitlab_project_membership_test.go
@@ -18,7 +18,7 @@ func TestAccGitlabProjectMembership_basic(t *testing.T) {
 	var membership gitlab.ProjectMember
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{PreCheck: func() { testAccPreCheck(t) },
+	resource.Test(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectMembershipDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_mirror_test.go
+++ b/internal/provider/resource_gitlab_project_mirror_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_project_mirror_test.go
+++ b/internal/provider/resource_gitlab_project_mirror_test.go
@@ -20,7 +20,6 @@ func TestAccGitlabProjectMirror_basic(t *testing.T) {
 	var miror gitlab.ProjectMirror
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectMirrorDestroy,
 		Steps: []resource.TestStep{
@@ -77,7 +76,6 @@ func TestAccGitlabProjectMirror_withPassword(t *testing.T) {
 	ctx := testAccGitlabProjectStart(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectMirrorDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_protected_environment_test.go
+++ b/internal/provider/resource_gitlab_project_protected_environment_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_project_protected_environment_test.go
+++ b/internal/provider/resource_gitlab_project_protected_environment_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestAccGitlabProjectProtectedEnvironment_basic(t *testing.T) {
-	testAccCheck(t)
 	testAccCheckEE(t)
 
 	// Set up project environment.
@@ -38,7 +37,6 @@ func TestAccGitlabProjectProtectedEnvironment_basic(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectProtectedEnvironmentDestroy(project.ID, environment.Name),
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_runner_enablement_test.go
+++ b/internal/provider/resource_gitlab_project_runner_enablement_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_project_runner_enablement_test.go
+++ b/internal/provider/resource_gitlab_project_runner_enablement_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestAccGitlabProjectRunnerEnablement_basic(t *testing.T) {
-	testAccCheck(t)
 	testGroup := testAccCreateGroups(t, 1)[0]
 	projectA := testAccCreateProjectWithNamespace(t, testGroup.ID)
 	projectB := testAccCreateProjectWithNamespace(t, testGroup.ID)
@@ -32,7 +31,6 @@ func TestAccGitlabProjectRunnerEnablement_basic(t *testing.T) {
 	runner, _, _ := testGitlabClient.Runners.RegisterNewRunner(&opts)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectRunnerEnablementDestroy(projectB.ID, runner.ID),
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_share_group_test.go
+++ b/internal/provider/resource_gitlab_project_share_group_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_project_share_group_test.go
+++ b/internal/provider/resource_gitlab_project_share_group_test.go
@@ -49,7 +49,6 @@ func TestAccGitlabProjectShareGroup_basic(t *testing.T) {
 	randName := acctest.RandomWithPrefix("acctest")
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectShareGroupDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_tag_test.go
+++ b/internal/provider/resource_gitlab_project_tag_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_project_tag_test.go
+++ b/internal/provider/resource_gitlab_project_tag_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestAccGitlabProjectTag_basic(t *testing.T) {
-	testAccCheck(t)
 	var tag gitlab.Tag
 	var tag2 gitlab.Tag
 	rInt, rInt2, rInt3 := acctest.RandInt(), acctest.RandInt(), acctest.RandInt()
@@ -23,7 +22,6 @@ func TestAccGitlabProjectTag_basic(t *testing.T) {
 	branches := testAccCreateBranches(t, project, 1)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectTagDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_test.go
+++ b/internal/provider/resource_gitlab_project_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_project_test.go
+++ b/internal/provider/resource_gitlab_project_test.go
@@ -26,7 +26,6 @@ func TestAccGitlabProject_minimal(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -121,7 +120,6 @@ func TestAccGitlabProject_basic(t *testing.T) {
 	defaultsMainBranch.DefaultBranch = "main"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -416,7 +414,6 @@ func TestAccGitlabProject_initializeWithReadme(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -444,7 +441,6 @@ func TestAccGitlabProject_initializeWithoutReadme(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -473,7 +469,6 @@ func TestAccGitlabProject_archiveOnDestroy(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectArchivedOnDestroy,
 		Steps: []resource.TestStep{
@@ -488,7 +483,6 @@ func TestAccGitlabProject_setSinglePushRuleToDefault(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -510,7 +504,6 @@ func TestAccGitlabProject_groupWithoutDefaultBranchProtection(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -535,7 +528,6 @@ func TestAccGitlabProject_IssueMergeRequestTemplates(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -566,7 +558,6 @@ func TestAccGitlabProject_MergePipelines(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -593,7 +584,6 @@ func TestAccGitlabProject_MergeTrains(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -620,7 +610,6 @@ func TestAccGitlabProject_willErrorOnAPIFailure(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -668,7 +657,6 @@ func TestAccGitlabProject_willErrorOnAPIFailure(t *testing.T) {
 func TestAccGitlabProject_import(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -693,7 +681,6 @@ func TestAccGitlabProject_import(t *testing.T) {
 func TestAccGitlabProject_nestedImport(t *testing.T) {
 	rInt := acctest.RandInt()
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -744,7 +731,6 @@ func TestAccGitlabProject_transfer(t *testing.T) {
 	pathAfterTransfer := fmt.Sprintf("foo2group-%d/foo-%d", rInt, rInt)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -771,8 +757,6 @@ func TestAccGitlabProject_transfer(t *testing.T) {
 
 // lintignore: AT002 // not a Terraform import test
 func TestAccGitlabProject_importURL(t *testing.T) {
-	testAccCheck(t)
-
 	rInt := acctest.RandInt()
 
 	// Create a base project for importing.
@@ -797,7 +781,6 @@ func TestAccGitlabProject_importURL(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -826,7 +809,6 @@ func TestAccGitlabProject_initializeWithReadmeAndCustomDefaultBranch(t *testing.
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -867,15 +849,12 @@ resource "gitlab_project" "foo" {
 }
 
 func TestAccGitlabProject_CreateProjectInUserNamespace(t *testing.T) {
-	testAccCheck(t)
-
 	var project gitlab.Project
 	rInt := acctest.RandInt()
 
 	user := testAccCreateUsers(t, 1)[0]
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -933,8 +912,6 @@ func testAccCheckGitlabProjectMirroredAttributes(project *gitlab.Project, want *
 
 // lintignore: AT002 // not a Terraform import test
 func TestAccGitlabProject_ImportURLMirrored(t *testing.T) {
-	testAccCheck(t)
-
 	var mirror gitlab.Project
 	rInt := acctest.RandInt()
 
@@ -960,7 +937,6 @@ func TestAccGitlabProject_ImportURLMirrored(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -1052,7 +1028,6 @@ func TestAccGitlabProject_templateMutualExclusiveNameAndID(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -1070,7 +1045,6 @@ func TestAccGitlabProject_containerExpirationPolicy(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -1153,7 +1127,6 @@ func TestAccGitlabProject_DeprecatedBuildCoverageRegex(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_variable_test.go
+++ b/internal/provider/resource_gitlab_project_variable_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_project_variable_test.go
+++ b/internal/provider/resource_gitlab_project_variable_test.go
@@ -76,7 +76,6 @@ func TestAccGitlabProjectVariable_basic(t *testing.T) {
 	ctx := testAccGitlabProjectStart(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccGitlabProjectVariableCheckAllVariablesDestroyed(ctx),
 		Steps: []resource.TestStep{
@@ -178,7 +177,6 @@ func TestAccGitlabProjectVariable_scoped(t *testing.T) {
 	ctx := testAccGitlabProjectStart(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			// Destroy behavior is nondeterministic for variables with scopes in GitLab versions prior to 13.4

--- a/internal/provider/resource_gitlab_repository_file_test.go
+++ b/internal/provider/resource_gitlab_repository_file_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_repository_file_test.go
+++ b/internal/provider/resource_gitlab_repository_file_test.go
@@ -13,13 +13,10 @@ import (
 )
 
 func TestAccGitlabRepositoryFile_basic(t *testing.T) {
-	testAccCheck(t)
-
 	var file gitlab.File
 	testProject := testAccCreateProject(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabRepositoryFileDestroy,
 		Steps: []resource.TestStep{
@@ -62,15 +59,12 @@ func TestAccGitlabRepositoryFile_basic(t *testing.T) {
 }
 
 func TestAccGitlabRepositoryFile_createSameFileDifferentRepository(t *testing.T) {
-	testAccCheck(t)
-
 	var fooFile gitlab.File
 	var barFile gitlab.File
 	firstTestProject := testAccCreateProject(t)
 	secondTestProject := testAccCreateProject(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabRepositoryFileDestroy,
 		Steps: []resource.TestStep{
@@ -94,12 +88,9 @@ func TestAccGitlabRepositoryFile_createSameFileDifferentRepository(t *testing.T)
 }
 
 func TestAccGitlabRepositoryFile_concurrentResources(t *testing.T) {
-	testAccCheck(t)
-
 	testProject := testAccCreateProject(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabRepositoryFileDestroy,
 		Steps: []resource.TestStep{
@@ -120,13 +111,10 @@ func TestAccGitlabRepositoryFile_concurrentResources(t *testing.T) {
 }
 
 func TestAccGitlabRepositoryFile_createOnNewBranch(t *testing.T) {
-	testAccCheck(t)
-
 	var file gitlab.File
 	testProject := testAccCreateProject(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabRepositoryFileDestroy,
 		Steps: []resource.TestStep{
@@ -145,13 +133,10 @@ func TestAccGitlabRepositoryFile_createOnNewBranch(t *testing.T) {
 }
 
 func TestAccGitlabRepositoryFile_base64EncodingWithTextContent(t *testing.T) {
-	testAccCheck(t)
-
 	var file gitlab.File
 	testProject := testAccCreateProject(t)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabRepositoryFileDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_runner_test.go
+++ b/internal/provider/resource_gitlab_runner_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_runner_test.go
+++ b/internal/provider/resource_gitlab_runner_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestAccGitlabRunner_basic(t *testing.T) {
-	testAccCheck(t)
-
 	group := testAccCreateGroups(t, 1)[0]
 	//The runner token is not populated on the return from the group create, so re-retrieve it to get the token.
 	group, _, err := testGitlabClient.Groups.GetGroup(group.ID, &gitlab.GetGroupOptions{})
@@ -24,7 +22,6 @@ func TestAccGitlabRunner_basic(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() {},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckRunnerDestroy,
 		Steps: []resource.TestStep{
@@ -67,13 +64,10 @@ func TestAccGitlabRunner_basic(t *testing.T) {
 }
 
 func TestAccGitlabRunner_instance(t *testing.T) {
-	testAccCheck(t)
-
 	// This pulls from the gitlab.rb file, and is set on instance start-up
 	token := "ACCTEST1234567890123_RUNNER_REG_TOKEN"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() {},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckRunnerDestroy,
 		Steps: []resource.TestStep{
@@ -101,8 +95,6 @@ func TestAccGitlabRunner_instance(t *testing.T) {
 }
 
 func TestAccGitlabRunner_comprehensive(t *testing.T) {
-	testAccCheck(t)
-
 	group := testAccCreateGroups(t, 1)[0]
 	//The runner token is not populated on the return from the group create, so re-retrieve it to get the token.
 	group, _, err := testGitlabClient.Groups.GetGroup(group.ID, &gitlab.GetGroupOptions{})
@@ -111,7 +103,6 @@ func TestAccGitlabRunner_comprehensive(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() {},
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckRunnerDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_service_external_wiki_test.go
+++ b/internal/provider/resource_gitlab_service_external_wiki_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_service_external_wiki_test.go
+++ b/internal/provider/resource_gitlab_service_external_wiki_test.go
@@ -14,8 +14,6 @@ import (
 )
 
 func TestAccGitlabServiceExternalWiki_basic(t *testing.T) {
-	testAccCheck(t)
-
 	testProject := testAccCreateProject(t)
 
 	var externalWikiService gitlab.ExternalWikiService
@@ -25,7 +23,6 @@ func TestAccGitlabServiceExternalWiki_basic(t *testing.T) {
 	var externalWikiResourceName = "gitlab_service_external_wiki.this"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabServiceExternalWikiDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_service_github_test.go
+++ b/internal/provider/resource_gitlab_service_github_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_service_github_test.go
+++ b/internal/provider/resource_gitlab_service_github_test.go
@@ -19,7 +19,6 @@ func TestAccGitlabServiceGithub_basic(t *testing.T) {
 	githubResourceName := "gitlab_service_github.github"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabServiceGithubDestroy,
 		Steps: []resource.TestStep{
@@ -63,7 +62,6 @@ func TestAccGitlabServiceGithub_import(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabServiceGithubDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_service_jira_test.go
+++ b/internal/provider/resource_gitlab_service_jira_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_service_jira_test.go
+++ b/internal/provider/resource_gitlab_service_jira_test.go
@@ -19,7 +19,6 @@ func TestAccGitlabServiceJira_basic(t *testing.T) {
 	jiraResourceName := "gitlab_service_jira.jira"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabServiceJiraDestroy,
 		Steps: []resource.TestStep{
@@ -75,7 +74,6 @@ func TestAccGitlabServiceJira_import(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabServiceJiraDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_service_microsoft_teams_test.go
+++ b/internal/provider/resource_gitlab_service_microsoft_teams_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_service_microsoft_teams_test.go
+++ b/internal/provider/resource_gitlab_service_microsoft_teams_test.go
@@ -19,7 +19,6 @@ func TestAccGitlabServiceMicrosoftTeams_basic(t *testing.T) {
 	teamsResourceName := "gitlab_service_microsoft_teams.teams"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabServiceMicrosoftTeamsDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_service_pipelines_email_test.go
+++ b/internal/provider/resource_gitlab_service_pipelines_email_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_service_pipelines_email_test.go
+++ b/internal/provider/resource_gitlab_service_pipelines_email_test.go
@@ -21,7 +21,6 @@ func TestAccGitlabServicePipelinesEmail_basic(t *testing.T) {
 	pipelinesEmailResourceName := "gitlab_service_pipelines_email.email"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabServicePipelinesEmailDestroy,
 		Steps: []resource.TestStep{
@@ -65,7 +64,6 @@ func TestAccGitlabServicePipelinesEmail_import(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabServicePipelinesEmailDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_service_slack_test.go
+++ b/internal/provider/resource_gitlab_service_slack_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_service_slack_test.go
+++ b/internal/provider/resource_gitlab_service_slack_test.go
@@ -19,7 +19,6 @@ func TestAccGitlabServiceSlack_basic(t *testing.T) {
 	slackResourceName := "gitlab_service_slack.slack"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabServiceSlackDestroy,
 		Steps: []resource.TestStep{
@@ -88,7 +87,6 @@ func TestAccGitlabServiceSlack_import(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabServiceSlackDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_system_hook_test.go
+++ b/internal/provider/resource_gitlab_system_hook_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_system_hook_test.go
+++ b/internal/provider/resource_gitlab_system_hook_test.go
@@ -19,7 +19,6 @@ func TestAccGitlabSystemHook_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabSystemHookDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_tag_protection_test.go
+++ b/internal/provider/resource_gitlab_tag_protection_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_tag_protection_test.go
+++ b/internal/provider/resource_gitlab_tag_protection_test.go
@@ -19,7 +19,6 @@ func TestAccGitlabTagProtection_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabTagProtectionDestroy,
 		Steps: []resource.TestStep{
@@ -68,7 +67,6 @@ func TestAccGitlabTagProtection_wildcard(t *testing.T) {
 	wildcard := "-*"
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabTagProtectionDestroy,
 		Steps: []resource.TestStep{
@@ -114,7 +112,6 @@ func TestAccGitlabTagProtection_import(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabTagProtectionDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_topic_test.go
+++ b/internal/provider/resource_gitlab_topic_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_topic_test.go
+++ b/internal/provider/resource_gitlab_topic_test.go
@@ -20,7 +20,6 @@ func TestAccGitlabTopic_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabTopicDestroy,
 		Steps: []resource.TestStep{
@@ -217,7 +216,6 @@ func TestAccGitlabTopic_withoutAvatarHash(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabTopicDestroy,
 		Steps: []resource.TestStep{
@@ -244,7 +242,6 @@ func TestAccGitlabTopic_softDestroy(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabTopicSoftDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_user_custom_attribute_test.go
+++ b/internal/provider/resource_gitlab_user_custom_attribute_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_user_custom_attribute_test.go
+++ b/internal/provider/resource_gitlab_user_custom_attribute_test.go
@@ -19,7 +19,6 @@ func TestAccGitlabUserCustomAttribute_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabUserDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_user_sshkey_test.go
+++ b/internal/provider/resource_gitlab_user_sshkey_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_user_sshkey_test.go
+++ b/internal/provider/resource_gitlab_user_sshkey_test.go
@@ -19,13 +19,10 @@ var updatedRSAPubKey string = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDStVqW58VZ5
 var updatedRSAPubKeyWithoutComment string = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDStVqW58VZ5afXFphIvu2JahndXslJZMkgWsNiYCNdk/NvrEbc4i7yZVoDPFQsbS9I6Ty1RMW7qy3KxJalMsVHcw8arCQFDxs/ka1NHGCUPl68t5ZxUOl900KRQ0lOzGnDQMqG/UUZdPw4CCmigTr6Z9ZBcD1fXAiUwbXR4tWrr5z9KWXC2HgF4WkIJUTIct7ilY1m9W0y79dI/+K8bZrurn3q2QK83pxqqWkLwvUsCxtlhMpwuyflyzyuz8xPZl2GlZgxeIpr68gsPHIzzWizibwFfbRYKCZO4wD0r7JCDOYs9KjcIPpCG6d3HUqijClgdQSBnLwHTdE04ZtdzO8akvy0hMzRCooI5TSc8IAHos53Gp9aaW92sPA8za+WRP6OSH6UsOW4N+iQc4jyl7/fckMSgIZlJouNqqV+P8iqIFJGs70Tj5L8G/m+P2lc3kcE4Vjmj+Fc0xG5+I/PsSOpcc6DfDfZdVDRe8yklYd/qC1jI89OCeqjxu3XcUGHj9s="
 
 func TestAccGitlabUserSSHKey_basic(t *testing.T) {
-	testAccCheck(t)
-
 	var key gitlab.SSHKey
 	testUser := testAccCreateUsers(t, 1)[0]
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabUserSSHKeyDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_user_test.go
+++ b/internal/provider/resource_gitlab_user_test.go
@@ -1,3 +1,6 @@
+//go:build acceptance
+// +build acceptance
+
 package provider
 
 import (

--- a/internal/provider/resource_gitlab_user_test.go
+++ b/internal/provider/resource_gitlab_user_test.go
@@ -20,7 +20,6 @@ func TestAccGitlabUser_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabUserDestroy,
 		Steps: []resource.TestStep{
@@ -332,7 +331,6 @@ func TestAccGitlabUser_password_reset(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { testAccPreCheck(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabGroupDestroy,
 		Steps: []resource.TestStep{

--- a/tools/cmd/tfproviderlint-plugin/main.go
+++ b/tools/cmd/tfproviderlint-plugin/main.go
@@ -1,0 +1,39 @@
+// Program tfproviderlint-plugin is a custom linter plugin for golangci-lint which runs the
+// tfproviderlint analyzers.
+//
+// See: https://golangci-lint.run/contributing/new-linters/#create-a-plugin
+package main
+
+import (
+	"github.com/bflad/tfproviderlint/passes"
+	"github.com/bflad/tfproviderlint/xpasses"
+	"golang.org/x/tools/go/analysis"
+)
+
+var excludes = []string{
+	"XAT001",
+	"XR003",
+	"XS002",
+}
+
+type analyzerPlugin struct{}
+
+func (*analyzerPlugin) GetAnalyzers() []*analysis.Analyzer {
+	excludesSet := make(map[string]struct{}, len(excludes))
+
+	for _, exclude := range excludes {
+		excludesSet[exclude] = struct{}{}
+	}
+
+	var analyzers []*analysis.Analyzer
+
+	for _, analyzer := range append(passes.AllChecks, xpasses.AllChecks...) {
+		if _, isExcluded := excludesSet[analyzer.Name]; !isExcluded {
+			analyzers = append(analyzers, analyzer)
+		}
+	}
+
+	return analyzers
+}
+
+var AnalyzerPlugin analyzerPlugin


### PR DESCRIPTION
## Description

<!-- Which issue/s does this PR close? Is there any more context you can give the reviewer? -->

Relates to #1008

I'm interested in feedback on this. Is this a good change, if contributors now have to be sure to add the `// +build acceptance` header to new tests, or should we instead keep our test-skipping logic as it is?

The goal of this PR is to remove the `testAccCheck(t)` and `PreCheck` boilerplate code from all tests.

I was able to do this by introducing an "acceptance" [build tag](https://mickey.dev/posts/go-build-tags-testing/).

The 4 commits are independent, so you can review them separately.

1. Run acceptance tests with acceptance build tag
    - I added the `// +build acceptance` build tag on all acceptance test files, but NOT unit test files. This allows us to run acceptance tests by specifying `go test -tags acceptance`, and keep the default `go test` command only running unit tests, without the need to check the value of `TF_ACC` in every test.

2. Run tfproviderlint as a golangci-lint plugin
    - I changed the way that we run tfproviderlint so that instead of running the binary, we run it as a plugin of golangci-lint. This was necessary because tfproviderlint does not allow you to specify build tags, so it was not linting acceptance tests anymore. Whereas, golangci-lint does let you specify build tags.

3. Allow linters to lint acceptance tests
    - Runs linters with `--build-tags acceptance` so that acceptance tests are included in linting.

4. Remove skip-test checks and rely on build tags instead
    - Deleted all uses of `testAccCheck` and `PreCheck`. Now that acceptance tests are enabled using an `acceptance` build tag, we do not need to do these runtime checks.

### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
