### PR TITLE
resource/gitlab_topic: Add `title` argument support for GitLab 15.0

### DIFF
--- a/docs/resources/topic.md
+++ b/docs/resources/topic.md
@@ -23,7 +23,8 @@ The `gitlab_topic` resource allows to manage the lifecycle of topics that are th
 
 ```terraform
 resource "gitlab_topic" "functional_programming" {
-  name        = "Functional Programming"
+  name        = "functional-programming"
+  title       = "Functional Programming"
   description = "In computer science, functional programming is a programming paradigm where programs are constructed by applying and composing functions."
   avatar      = "${path.module}/avatar.png"
   avatar_hash = filesha256("${path.module}/avatar.png")
@@ -43,6 +44,7 @@ resource "gitlab_topic" "functional_programming" {
 - `avatar_hash` (String) The hash of the avatar image. Use `filesha256("path/to/avatar.png")` whenever possible. **Note**: this is used to trigger an update of the avatar. If it's not given, but an avatar is given, the avatar will be updated each time.
 - `description` (String) A text describing the topic.
 - `soft_destroy` (Boolean, Deprecated) Empty the topics fields instead of deleting it.
+- `title` (String) The topic's description. Requires at least GitLab 15.0 for which it's a required argument.
 
 ### Read-Only
 

--- a/examples/resources/gitlab_topic/resource.tf
+++ b/examples/resources/gitlab_topic/resource.tf
@@ -1,5 +1,6 @@
 resource "gitlab_topic" "functional_programming" {
-  name        = "Functional Programming"
+  name        = "functional-programming"
+  title       = "Functional Programming"
   description = "In computer science, functional programming is a programming paradigm where programs are constructed by applying and composing functions."
   avatar      = "${path.module}/avatar.png"
   avatar_hash = filesha256("${path.module}/avatar.png")


### PR DESCRIPTION
This change set adds support for the newly introduced `title` field in GitLab 15.0 of the Topics API.

To support previous GitLab instances the `title` resource attribute is optional even though in the API it's required.

However, it's an error if the user sets the `title` for GitLab releases prior to 15.0 and if the user doesn't set it for GitLab releases from 15.0 on ...

Once we integrate 15.0 we have to adjust the tests, too to properly support the resource.

It's currently blocked by a new go-gitlab release we require.

Closes: #1043

