### PR TITLE
resource/gitlab_group: Update the allowable values for default_branch_protection

### DIFF
--- a/internal/provider/resource_gitlab_group.go
+++ b/internal/provider/resource_gitlab_group.go
@@ -72,7 +72,7 @@ var _ = registerResource("gitlab_group", func() *schema.Resource {
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Default:      2,
-				ValidateFunc: validation.IntInSlice([]int{0, 1, 2}),
+				ValidateFunc: validation.IntInSlice([]int{0, 1, 2, 3}),
 			},
 			"request_access_enabled": {
 				Description: "Defaults to false. Allow users to request member access.",


### PR DESCRIPTION
## Description

Update the allowable values for default_branch_protection according to the documentation 
https://docs.gitlab.com/ee/api/groups.html#options-for-default_branch_protection


### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
