### PR TITLE
Moving a subgroup does not force a recreation of the group and no longer deletes the underlying projects

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,16 +2,13 @@ module github.com/gitlabhq/terraform-provider-gitlab
 
 go 1.17
 
-// we are waiting for a new release
-replace github.com/xanzy/go-gitlab => ../go-gitlab
-
 require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-retryablehttp v0.7.1
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.15.0
 	github.com/mitchellh/hashstructure v1.1.0
 	github.com/onsi/gomega v1.19.0
-	github.com/xanzy/go-gitlab v0.64.0
+	github.com/xanzy/go-gitlab v0.65.0
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/gitlabhq/terraform-provider-gitlab
 
 go 1.17
 
+// we are waiting for a new release
+replace github.com/xanzy/go-gitlab => ../go-gitlab
+
 require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-retryablehttp v0.7.1

--- a/go.sum
+++ b/go.sum
@@ -311,8 +311,8 @@ github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvC
 github.com/vmihailenco/msgpack/v4 v4.3.12/go.mod h1:gborTTJjAo/GWTqqRjrLCn9pgNN+NXzzngzBKDPIqw4=
 github.com/vmihailenco/tagparser v0.1.1 h1:quXMXlA39OCbd2wAdTsGDlK9RkOk6Wuw+x37wVyIuWY=
 github.com/vmihailenco/tagparser v0.1.1/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
-github.com/xanzy/go-gitlab v0.64.0 h1:rMgQdW9S1w3qvNAH2LYpFd2xh7KNLk+JWJd7sorNuTc=
-github.com/xanzy/go-gitlab v0.64.0/go.mod h1:F0QEXwmqiBUxCgJm8fE9S+1veX4XC9Z4cfaAbqwk4YM=
+github.com/xanzy/go-gitlab v0.65.0 h1:9xSA9cRVhz3Z54JacIHdvWnNmNAoSz/BDnyMGOf3yIg=
+github.com/xanzy/go-gitlab v0.65.0/go.mod h1:F0QEXwmqiBUxCgJm8fE9S+1veX4XC9Z4cfaAbqwk4YM=
 github.com/xanzy/ssh-agent v0.3.0 h1:wUMzuKtKilRgBAD1sUb8gOwwRr2FGoBVumcjoOACClI=
 github.com/xanzy/ssh-agent v0.3.0/go.mod h1:3s9xbODqPuuhK9JV1R321M/FlMZSBvE5aY6eAcqrDh0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/provider/resource_gitlab_group.go
+++ b/internal/provider/resource_gitlab_group.go
@@ -369,7 +369,7 @@ func resourceGitlabGroupUpdate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if d.HasChange("parent_id") {
-		diagnostic := transferSubGroup(d, client)
+		diagnostic := transferSubGroup(ctx, d, client)
 		if diagnostic.HasError() {
 			return diagnostic
 		}
@@ -378,7 +378,7 @@ func resourceGitlabGroupUpdate(ctx context.Context, d *schema.ResourceData, meta
 	return resourceGitlabGroupRead(ctx, d, meta)
 }
 
-func transferSubGroup(d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+func transferSubGroup(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gitlab.Client)
 	o, n := d.GetChange("parent_id")
 	parentId, ok := n.(int)
@@ -394,7 +394,7 @@ func transferSubGroup(d *schema.ResourceData, meta interface{}) diag.Diagnostics
 		log.Printf("[DEBUG] turn gitlab group %s from %v to a new top-level group", d.Id(), o)
 	}
 
-	_, _, err := client.Groups.TransferSubGroup(d.Id(), opt)
+	_, _, err := client.Groups.TransferSubGroup(d.Id(), opt, gitlab.WithContext(ctx))
 	if err != nil {
 		return diag.Errorf("error transfering group %s to new parent group %v: %s", d.Id(), parentId, err)
 	}

--- a/internal/provider/resource_gitlab_group.go
+++ b/internal/provider/resource_gitlab_group.go
@@ -141,7 +141,6 @@ var _ = registerResource("gitlab_group", func() *schema.Resource {
 				Description: "Id of the parent group (creates a nested group).",
 				Type:        schema.TypeInt,
 				Optional:    true,
-				ForceNew:    true,
 				Default:     0,
 			},
 			"runners_token": {
@@ -369,7 +368,38 @@ func resourceGitlabGroupUpdate(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
+	if d.HasChange("parent_id") {
+		diagnostic := transferSubGroup(d, client)
+		if diagnostic.HasError() {
+			return diagnostic
+		}
+	}
+
 	return resourceGitlabGroupRead(ctx, d, meta)
+}
+
+func transferSubGroup(d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	client := meta.(*gitlab.Client)
+	o, n := d.GetChange("parent_id")
+	parentId, ok := n.(int)
+	if !ok {
+		return diag.Errorf("error converting parent_id %v into an int", n)
+	}
+
+	opt := &gitlab.TransferSubGroupOptions{}
+	if parentId != 0 {
+		log.Printf("[DEBUG] transfer gitlab group %s from %v to new parent group %v", d.Id(), o, n)
+		opt.GroupID = gitlab.Int(parentId)
+	} else {
+		log.Printf("[DEBUG] turn gitlab group %s from %v to a new top-level group", d.Id(), o)
+	}
+
+	_, _, err := client.Groups.TransferSubGroup(d.Id(), opt)
+	if err != nil {
+		return diag.Errorf("error transfering group %s to new parent group %v: %s", d.Id(), parentId, err)
+	}
+
+	return nil
 }
 
 func resourceGitlabGroupDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/internal/provider/resource_gitlab_group.go
+++ b/internal/provider/resource_gitlab_group.go
@@ -378,8 +378,7 @@ func resourceGitlabGroupUpdate(ctx context.Context, d *schema.ResourceData, meta
 	return resourceGitlabGroupRead(ctx, d, meta)
 }
 
-func transferSubGroup(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	client := meta.(*gitlab.Client)
+func transferSubGroup(ctx context.Context, d *schema.ResourceData, client *gitlab.Client) diag.Diagnostics {
 	o, n := d.GetChange("parent_id")
 	parentId, ok := n.(int)
 	if !ok {

--- a/internal/provider/resource_gitlab_group.go
+++ b/internal/provider/resource_gitlab_group.go
@@ -369,20 +369,20 @@ func resourceGitlabGroupUpdate(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	if d.HasChange("parent_id") {
-		diagnostic := transferSubGroup(ctx, d, client)
-		if diagnostic.HasError() {
-			return diagnostic
+		err = transferSubGroup(ctx, d, client)
+		if err != nil {
+			return diag.FromErr(err)
 		}
 	}
 
 	return resourceGitlabGroupRead(ctx, d, meta)
 }
 
-func transferSubGroup(ctx context.Context, d *schema.ResourceData, client *gitlab.Client) diag.Diagnostics {
+func transferSubGroup(ctx context.Context, d *schema.ResourceData, client *gitlab.Client) error {
 	o, n := d.GetChange("parent_id")
 	parentId, ok := n.(int)
 	if !ok {
-		return diag.Errorf("error converting parent_id %v into an int", n)
+		return fmt.Errorf("error converting parent_id %v into an int", n)
 	}
 
 	opt := &gitlab.TransferSubGroupOptions{}
@@ -395,7 +395,7 @@ func transferSubGroup(ctx context.Context, d *schema.ResourceData, client *gitla
 
 	_, _, err := client.Groups.TransferSubGroup(d.Id(), opt, gitlab.WithContext(ctx))
 	if err != nil {
-		return diag.Errorf("error transfering group %s to new parent group %v: %s", d.Id(), parentId, err)
+		return fmt.Errorf("error transfering group %s to new parent group %v: %s", d.Id(), parentId, err)
 	}
 
 	return nil

--- a/internal/provider/resource_gitlab_group_test.go
+++ b/internal/provider/resource_gitlab_group_test.go
@@ -201,27 +201,26 @@ func TestAccGitlabGroup_nested(t *testing.T) {
 					}),
 				),
 			},
-			// TODO In EE version, re-creating on the same path where a previous group was soft-deleted doesn't work.
-			// {
-			// 	Config: testAccGitlabNestedGroupConfig(rInt),
-			// 	Check: resource.ComposeTestCheckFunc(
-			// 		testAccCheckGitlabGroupExists("gitlab_group.foo", &group),
-			// 		testAccCheckGitlabGroupExists("gitlab_group.foo2", &group2),
-			// 		testAccCheckGitlabGroupExists("gitlab_group.nested_foo", &nestedGroup),
-			// 		testAccCheckGitlabGroupAttributes(&nestedGroup, &testAccGitlabGroupExpectedAttributes{
-			// 			Name:        fmt.Sprintf("nfoo-name-%d", rInt),
-			// 			Path:        fmt.Sprintf("nfoo-path-%d", rInt),
-			// 			Description: "Terraform acceptance tests",
-			// 			LFSEnabled:  true,
-			//			Visibility:            "public",     // default value
-			//			ProjectCreationLevel:  "maintainer", // default value
-			//			SubGroupCreationLevel: "owner",      // default value
-			//			TwoFactorGracePeriod:  48,           // default value
-			//			DefaultBranchProtection: 2,          // default value
-			// 			Parent:      &group,
-			// 		}),
-			// 	),
-			// },
+			{
+				Config: testAccGitlabNestedGroupConfig(rInt),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckGitlabGroupExists("gitlab_group.foo", &group),
+					testAccCheckGitlabGroupExists("gitlab_group.foo2", &group2),
+					testAccCheckGitlabGroupExists("gitlab_group.nested_foo", &nestedGroup),
+					testAccCheckGitlabGroupAttributes(&nestedGroup, &testAccGitlabGroupExpectedAttributes{
+						Name:                    fmt.Sprintf("nfoo-name-%d", rInt),
+						Path:                    fmt.Sprintf("nfoo-path-%d", rInt),
+						Description:             "Terraform acceptance tests",
+						LFSEnabled:              true,
+						Visibility:              "public",     // default value
+						ProjectCreationLevel:    "maintainer", // default value
+						SubGroupCreationLevel:   "owner",      // default value
+						TwoFactorGracePeriod:    48,           // default value
+						DefaultBranchProtection: 2,            // default value
+						Parent:                  &group,
+					}),
+				),
+			},
 		},
 	})
 }

--- a/internal/provider/resource_gitlab_group_test.go
+++ b/internal/provider/resource_gitlab_group_test.go
@@ -157,6 +157,7 @@ func TestAccGitlabGroup_nested(t *testing.T) {
 						TwoFactorGracePeriod:    48,           // default value
 						DefaultBranchProtection: 2,            // default value
 						Parent:                  &group,
+						AutoDevopsEnabled:       true,
 					}),
 				),
 			},
@@ -177,6 +178,7 @@ func TestAccGitlabGroup_nested(t *testing.T) {
 						TwoFactorGracePeriod:    48,           // default value
 						DefaultBranchProtection: 2,            // default value
 						Parent:                  &group2,
+						AutoDevopsEnabled:       true,
 					}),
 				),
 			},
@@ -502,6 +504,12 @@ resource "gitlab_group" "nested_foo" {
   # So that acceptance tests can be run in a gitlab organization
   # with no billing
   visibility_level = "public"
+
+  # We set this to a non-default value to check later whether the group was recreated or not
+  auto_devops_enabled = true
+  lifecycle {
+    ignore_changes = [auto_devops_enabled]
+  }
 }
   `, rInt, rInt, rInt, rInt, rInt, rInt)
 }
@@ -567,6 +575,11 @@ resource "gitlab_group" "nested_foo" {
   # So that acceptance tests can be run in a gitlab organization
   # with no billing
   visibility_level = "public"
+
+  # We need to read this value to check if the group is recreated or not
+  lifecycle {
+    ignore_changes = [auto_devops_enabled]
+  }
 }
   `, rInt, rInt, rInt, rInt, rInt, rInt)
 }


### PR DESCRIPTION
## Description

fixes #574 

### PR Checklist Acknowledgement

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)

### Tests

To test that the nested group is not recreated, I misused the AutoDevopsEnabled attribute. It ensures that the value is still true after transferring the nested group. If the group was recreated, it would be false again (default value). Please let me know if you have a better idea how to test this.