### PR TITLE
resource/gitlab_project_issue: Remove `Optional` from `Computed`-only attributes

### DIFF
--- a/docs/resources/project_issue.md
+++ b/docs/resources/project_issue.md
@@ -54,8 +54,6 @@ output "welcome_issue_web_url" {
 ### Optional
 
 - `assignee_ids` (Set of Number) The IDs of the users to assign the issue to.
-- `closed_at` (String) When the issue was closed. Date time string, ISO 8601 formatted, for example 2016-03-11T03:45:40Z.
-- `closed_by_user_id` (Number) The ID of the user that closed the issue. Use `gitlab_user` data source to get more information about the user.
 - `confidential` (Boolean) Set an issue to be confidential.
 - `created_at` (String) When the issue was created. Date time string, ISO 8601 formatted, for example 2016-03-11T03:45:40Z. Requires administrator or project/group owner rights.
 - `delete_on_destroy` (Boolean) Whether the issue is deleted instead of closed during destroy.
@@ -65,45 +63,47 @@ output "welcome_issue_web_url" {
 - `due_date` (String) The due date. Date time string in the format YYYY-MM-DD, for example 2016-03-11.
 **Note:** removing a due date is currently not supported, see https://github.com/xanzy/go-gitlab/issues/1384 for details.
 - `epic_issue_id` (Number) The ID of the epic issue.
-- `human_time_estimate` (String) The human-readable time estimate of the issue.
-- `human_total_time_spent` (String) The human-readable total time spent of the issue.
 - `iid` (Number) The internal ID of the project's issue.
 - `issue_type` (String) The type of issue. Valid values are: `issue`, `incident`, `test_case`.
 - `labels` (Set of String) The labels of an issue.
-- `links` (Map of String) The links of the issue.
 - `merge_request_to_resolve_discussions_of` (Number) The IID of a merge request in which to resolve all issues. This fills out the issue with a default description and mark all discussions as resolved. When passing a description or title, these values take precedence over the default values.
 - `milestone_id` (Number) The global ID of a milestone to assign issue. To find the milestone_id associated with a milestone, view an issue with the milestone assigned and use the API to retrieve the issue's details.
-- `references` (Map of String) The references of the issue.
 - `state` (String) The state of the issue. Valid values are: `opened`, `closed`.
-- `task_completion_status` (Block List, Max: 1) The task completion status. It's always a one element list. (see [below for nested schema](#nestedblock--task_completion_status))
-- `time_estimate` (Number) The time estimate of the issue.
-- `total_time_spent` (Number) The total time spent of the issue.
 - `updated_at` (String) When the issue was updated. Date time string, ISO 8601 formatted, for example 2016-03-11T03:45:40Z.
 - `weight` (Number) The weight of the issue. Valid values are greater than or equal to 0.
 
 ### Read-Only
 
 - `author_id` (Number) The ID of the author of the issue. Use `gitlab_user` data source to get more information about the user.
+- `closed_at` (String) When the issue was closed. Date time string, ISO 8601 formatted, for example 2016-03-11T03:45:40Z.
+- `closed_by_user_id` (Number) The ID of the user that closed the issue. Use `gitlab_user` data source to get more information about the user.
 - `downvotes` (Number) The number of downvotes the issue has received.
 - `epic_id` (Number) ID of the epic to add the issue to. Valid values are greater than or equal to 0.
 - `external_id` (String) The external ID of the issue.
+- `human_time_estimate` (String) The human-readable time estimate of the issue.
+- `human_total_time_spent` (String) The human-readable total time spent of the issue.
 - `id` (String) The ID of this resource.
 - `issue_id` (Number) The instance-wide ID of the issue.
 - `issue_link_id` (Number) The ID of the issue link.
+- `links` (Map of String) The links of the issue.
 - `merge_requests_count` (Number) The number of merge requests associated with the issue.
 - `moved_to_id` (Number) The ID of the issue that was moved to.
+- `references` (Map of String) The references of the issue.
 - `subscribed` (Boolean) Whether the authenticated user is subscribed to the issue or not.
+- `task_completion_status` (List of Object) The task completion status. It's always a one element list. (see [below for nested schema](#nestedatt--task_completion_status))
+- `time_estimate` (Number) The time estimate of the issue.
+- `total_time_spent` (Number) The total time spent of the issue.
 - `upvotes` (Number) The number of upvotes the issue has received.
 - `user_notes_count` (Number) The number of user notes on the issue.
 - `web_url` (String) The web URL of the issue.
 
-<a id="nestedblock--task_completion_status"></a>
+<a id="nestedatt--task_completion_status"></a>
 ### Nested Schema for `task_completion_status`
 
-Optional:
+Read-Only:
 
-- `completed_count` (Number) The number of tasks that are completed.
-- `count` (Number) The number of tasks.
+- `completed_count` (Number)
+- `count` (Number)
 
 ## Import
 

--- a/internal/provider/schema_gitlab_project_issue.go
+++ b/internal/provider/schema_gitlab_project_issue.go
@@ -152,7 +152,6 @@ func gitlabProjectIssueGetSchema() map[string]*schema.Schema {
 			Description: "When the issue was closed. Date time string, ISO 8601 formatted, for example 2016-03-11T03:45:40Z.",
 			Type:        schema.TypeString,
 			Computed:    true,
-			Optional:    true,
 		},
 		// NOTE: to keep things simple, users of this resource should use the `gitlab_user` data source to
 		//       get more information about the closer if desired.
@@ -160,7 +159,6 @@ func gitlabProjectIssueGetSchema() map[string]*schema.Schema {
 			Description: "The ID of the user that closed the issue. Use `gitlab_user` data source to get more information about the user.",
 			Type:        schema.TypeInt,
 			Computed:    true,
-			Optional:    true,
 		},
 		"moved_to_id": {
 			Description: "The ID of the issue that was moved to.",
@@ -187,7 +185,6 @@ func gitlabProjectIssueGetSchema() map[string]*schema.Schema {
 			Type:        schema.TypeMap,
 			Elem:        &schema.Schema{Type: schema.TypeString},
 			Computed:    true,
-			Optional:    true,
 		},
 		// NOTE(TF): these are from the `time_stats` field.
 		//           Clarify what to do with nested types.
@@ -195,25 +192,21 @@ func gitlabProjectIssueGetSchema() map[string]*schema.Schema {
 			Description: "The time estimate of the issue.",
 			Type:        schema.TypeInt,
 			Computed:    true,
-			Optional:    true,
 		},
 		"total_time_spent": {
 			Description: "The total time spent of the issue.",
 			Type:        schema.TypeInt,
 			Computed:    true,
-			Optional:    true,
 		},
 		"human_time_estimate": {
 			Description: "The human-readable time estimate of the issue.",
 			Type:        schema.TypeString,
 			Computed:    true,
-			Optional:    true,
 		},
 		"human_total_time_spent": {
 			Description: "The human-readable total time spent of the issue.",
 			Type:        schema.TypeString,
 			Computed:    true,
-			Optional:    true,
 		},
 		// NOTE(TF): end `time_stats`
 		// NOTE: not part of `CREATE`, but part of `UPDATE`
@@ -237,7 +230,6 @@ func gitlabProjectIssueGetSchema() map[string]*schema.Schema {
 			Type:        schema.TypeMap,
 			Elem:        &schema.Schema{Type: schema.TypeString},
 			Computed:    true,
-			Optional:    true,
 		},
 		"issue_link_id": {
 			Description: "The ID of the issue link.",
@@ -258,9 +250,7 @@ func gitlabProjectIssueGetSchema() map[string]*schema.Schema {
 		"task_completion_status": {
 			Description: "The task completion status. It's always a one element list.",
 			Type:        schema.TypeList,
-			MaxItems:    1,
 			Computed:    true,
-			Optional:    true,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"count": {


### PR DESCRIPTION
Some attributes were mistakenly marked as `Optional`, but they are
`Computed`-only.

See #1080
