### PR TITLE
Clarify documentation on `gitlab_group_share_group` resource

### DIFF
--- a/docs/resources/group_share_group.md
+++ b/docs/resources/group_share_group.md
@@ -30,8 +30,8 @@ resource "gitlab_group_share_group" "test" {
 ### Required
 
 - `group_access` (String) The access level to grant the group. Valid values are: `no one`, `minimal`, `guest`, `reporter`, `developer`, `maintainer`, `owner`, `master`
-- `group_id` (String) The id of the main group.
-- `share_group_id` (Number) The id of an additional group which will be shared with the main group.
+- `group_id` (String) The id of the main group to be shared.
+- `share_group_id` (Number) The id of the additional group with which the main group will be shared.
 
 ### Optional
 

--- a/internal/provider/resource_gitlab_group_share_group.go
+++ b/internal/provider/resource_gitlab_group_share_group.go
@@ -28,13 +28,13 @@ var _ = registerResource("gitlab_group_share_group", func() *schema.Resource {
 		},
 		Schema: map[string]*schema.Schema{
 			"group_id": {
-				Description: "The id of the main group.",
+				Description: "The id of the main group to be shared.",
 				Type:        schema.TypeString,
 				ForceNew:    true,
 				Required:    true,
 			},
 			"share_group_id": {
-				Description: "The id of an additional group which will be shared with the main group.",
+				Description: "The id of the additional group with which the main group will be shared.",
 				Type:        schema.TypeInt,
 				ForceNew:    true,
 				Required:    true,


### PR DESCRIPTION
## Description

The documentation for the `group_id` and `group_share_id` currently 
suggests that this resource works the other way round than it actually does.

### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)

(none apply)
