### PR TITLE
Support Gitlab 15.0

### DIFF
--- a/.github/workflows/pr-acceptance-ce.yml
+++ b/.github/workflows/pr-acceptance-ce.yml
@@ -12,7 +12,7 @@ on:
       - 'CHANGELOG.md'
       - 'CONTRIBUTING.md'
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
@@ -31,6 +31,10 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     needs: [go-version]
+    strategy:
+      fail-fast: false
+      matrix:
+        gitlab-version: ["14.9.4-ce.0", "14.10.3-ce.0", "15.0.0-ce.0"]
     steps:
       - uses: actions/setup-go@v3
         with:
@@ -41,5 +45,5 @@ jobs:
         with:
           path: ~/go/pkg/mod
           key: ${{ github.job }}-${{ runner.os }}-go${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum', 'GNUMakefile') }}
-      - run: make testacc-up
+      - run: make testacc-up GITLAB_CE_VERSION=${{ matrix.gitlab-version }}
       - run: make testacc

--- a/.github/workflows/pr-acceptance-ee.yml
+++ b/.github/workflows/pr-acceptance-ee.yml
@@ -26,7 +26,7 @@ on:
 # Disable permissions on the GITHUB_TOKEN for all scopes.
 permissions: {}
 
-concurrency: 
+concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
@@ -65,6 +65,10 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     needs: [go-version, license-encryption-password]
+    strategy:
+      fail-fast: false
+      matrix:
+        gitlab-version: ["14.9.4-ee.0", "14.10.3-ee.0", "15.0.0-ee.0"]
     steps:
       - uses: actions/setup-go@v3
         with:
@@ -79,7 +83,7 @@ jobs:
         run: |
           openssl version
           openssl enc -d -aes-256-cbc -pbkdf2 -iter 20000 -in Gitlab-license.encrypted -out Gitlab-license.txt -pass "pass:${{ secrets.LICENSE_ENCRYPTION_PASSWORD }}"
-      - run: make testacc-up SERVICE=gitlab-ee
+      - run: make testacc-up SERVICE=gitlab-ee GITLAB_EE_VERSION=${{ matrix.gitlab-version }}
       # Check out the pull request code (as opposed to the target project).
       # This overwrites the entire directory and deleted the unencrypted GitLab license file. The
       # service has already started and continues using the license even though the file is deleted.
@@ -96,4 +100,3 @@ jobs:
       # This is made safe because we have already cleaned up the unencrypted GitLab license file,
       # we have no other secrets, and we are not using GitHub tokens.
       - run: make testacc
-

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -94,6 +94,10 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     needs: [go-version]
+    strategy:
+      fail-fast: false
+      matrix:
+        gitlab-version: ["14.9.4-ce.0", "14.10.3-ce.0", "15.0.0-ce.0"]
     steps:
       - uses: actions/setup-go@v3
         with:
@@ -104,7 +108,7 @@ jobs:
         with:
           path: ~/go/pkg/mod
           key: ${{ github.job }}-${{ runner.os }}-go${{ env.GO_VERSION }}-${{ hashFiles('**/go.sum', 'GNUMakefile') }}
-      - run: make testacc-up
+      - run: make testacc-up GITLAB_CE_VERSION=${{ matrix.gitlab-version }}
       - run: make testacc
 
   acceptance-ee:
@@ -114,6 +118,10 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     needs: [go-version, license-encryption-password]
+    strategy:
+      fail-fast: false
+      matrix:
+        gitlab-version: ["14.9.4-ee.0", "14.10.3-ee.0", "15.0.0-ee.0"]
     steps:
       - uses: actions/setup-go@v3
         with:
@@ -129,5 +137,5 @@ jobs:
           openssl version
           openssl enc -d -aes-256-cbc -pbkdf2 -iter 20000 -in Gitlab-license.encrypted -out Gitlab-license.txt -pass "pass:${{ secrets.LICENSE_ENCRYPTION_PASSWORD }}"
       # Note we specifically launch the gitlab-ee service.
-      - run: make testacc-up SERVICE=gitlab-ee
+      - run: make testacc-up SERVICE=gitlab-ee GITLAB_EE_VERSION=${{ matrix.gitlab-version }}
       - run: make testacc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,6 +108,8 @@ Your workspace will automatically open the repository and branch that you select
 
 The acceptance tests can run against a Gitlab instance where you have a token with administrator permissions (likely not gitlab.com).
 
+The GitHub Actions test against the three latest GitLab releases.
+
 #### Option 1: Run tests against a local Gitlab container with docker-compose
 
 This option is the easiest and requires [docker-compose](https://docs.docker.com/compose/install/) (version 1.13+) to be installed on your machine.
@@ -160,6 +162,14 @@ $ make testacc GITLAB_TOKEN=example123 GITLAB_BASE_URL=https://example.com/api/v
 
   ```sh
   $ make testacc-up SERVICE=gitlab-ee
+  ```
+
+* **Run tests against specific GitLab version:**
+
+  Specify the GitLab release in the `GITLAB_CE_VERSION` or `GITLAB_EE_VERSION`, e.g.:
+
+  ```sh
+  $ make testacc-up GITLAB_CE_VERSION=15.0.0-ce.0
   ```
 
 * **Run a single test:**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ version: '3'
 # Only one of these services should be run at a time.
 services:
   gitlab-ce:
-    image: gitlab/gitlab-ce
+    image: gitlab/gitlab-ce:${GITLAB_CE_VERSION:-latest}
     restart: always
     ports:
       - 8080:80
@@ -25,7 +25,7 @@ services:
       timeout: 2m
 
   gitlab-ee:
-    image: gitlab/gitlab-ee
+    image: gitlab/gitlab-ee:${GITLAB_EE_VERSION:-latest}
     restart: always
     ports:
       - 8080:80

--- a/docs/resources/managed_license.md
+++ b/docs/resources/managed_license.md
@@ -37,8 +37,8 @@ resource "gitlab_managed_license" "mit" {
 
 ### Required
 
-- `approval_status` (String) The approval status of the license. Valid values are: `approved`, `blacklisted`, `allowed`, `denied`. "approved" and "blacklisted" 
-				have been deprecated in favor of "allowed" and "denied"; use "allowed" and "denied" for GitLab versions 15.0 and higher. 
+- `approval_status` (String) The approval status of the license. Valid values are: `approved`, `blacklisted`, `allowed`, `denied`. "approved" and "blacklisted"
+				have been deprecated in favor of "allowed" and "denied"; use "allowed" and "denied" for GitLab versions 15.0 and higher.
 				Prior to version 15.0 and after 14.6, the values are equivalent.
 - `name` (String) The name of the managed license (I.e., 'Apache License 2.0' or 'MIT license')
 - `project` (String) The ID of the project under which the managed license will be created.

--- a/docs/resources/topic.md
+++ b/docs/resources/topic.md
@@ -23,7 +23,8 @@ The `gitlab_topic` resource allows to manage the lifecycle of topics that are th
 
 ```terraform
 resource "gitlab_topic" "functional_programming" {
-  name        = "Functional Programming"
+  name        = "functional-programming"
+  title       = "Functional Programming"
   description = "In computer science, functional programming is a programming paradigm where programs are constructed by applying and composing functions."
   avatar      = "${path.module}/avatar.png"
   avatar_hash = filesha256("${path.module}/avatar.png")
@@ -43,6 +44,7 @@ resource "gitlab_topic" "functional_programming" {
 - `avatar_hash` (String) The hash of the avatar image. Use `filesha256("path/to/avatar.png")` whenever possible. **Note**: this is used to trigger an update of the avatar. If it's not given, but an avatar is given, the avatar will be updated each time.
 - `description` (String) A text describing the topic.
 - `soft_destroy` (Boolean, Deprecated) Empty the topics fields instead of deleting it.
+- `title` (String) The topic's description. Requires at least GitLab 15.0 for which it's a required argument.
 
 ### Read-Only
 

--- a/examples/resources/gitlab_topic/resource.tf
+++ b/examples/resources/gitlab_topic/resource.tf
@@ -1,5 +1,6 @@
 resource "gitlab_topic" "functional_programming" {
-  name        = "Functional Programming"
+  name        = "functional-programming"
+  title       = "Functional Programming"
   description = "In computer science, functional programming is a programming paradigm where programs are constructed by applying and composing functions."
   avatar      = "${path.module}/avatar.png"
   avatar_hash = filesha256("${path.module}/avatar.png")

--- a/internal/provider/data_source_gitlab_repository_file_test.go
+++ b/internal/provider/data_source_gitlab_repository_file_test.go
@@ -66,7 +66,6 @@ resource "gitlab_repository_file" "foo" {
 	branch = "main"
 	content = base64encode("Meow goes the cat")
 	commit_message = "feat: Meow"
-	execute_filemode = true
 }
 
 data "gitlab_repository_file" "foo" {

--- a/internal/provider/helper_test.go
+++ b/internal/provider/helper_test.go
@@ -68,22 +68,6 @@ func isRunningInCE() (bool, error) {
 	return !isEE, err
 }
 
-// orSkipFunc accepts many skipFunc and returns "true" if any returns true.
-func orSkipFunc(input ...SkipFunc) SkipFunc {
-	return func() (bool, error) {
-		for _, item := range input {
-			result, err := item()
-			if err != nil {
-				return false, err
-			}
-			if result {
-				return result, nil
-			}
-		}
-		return false, nil
-	}
-}
-
 // testAccCheckEE is a test helper that skips the current test if the GitLab version is not GitLab Enterprise.
 // This is useful when the version needs to be checked during setup, before the Terraform acceptance test starts.
 func testAccCheckEE(t *testing.T) {

--- a/internal/provider/helper_test.go
+++ b/internal/provider/helper_test.go
@@ -4,6 +4,7 @@
 package provider
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -96,6 +97,37 @@ func testAccCheckEE(t *testing.T) {
 	if !strings.HasSuffix(version.Version, "-ee") {
 		t.Skipf("Test is skipped for non-Enterprise version of GitLab (was %q)", version.String())
 	}
+}
+
+func testAccRequiresLessThan(t *testing.T, requiredMaxVersion string) {
+	isLessThan, err := isGitLabVersionLessThan(context.TODO(), testGitlabClient, requiredMaxVersion)()
+	if err != nil {
+		t.Fatalf("Failed to fetch GitLab version: %+v", err)
+	}
+
+	if !isLessThan {
+		t.Skipf("This test is only valid for GitLab versions less than %s", requiredMaxVersion)
+	}
+}
+
+func testAccRequiresAtLeast(t *testing.T, requiredMinVersion string) {
+	isAtLeast, err := isGitLabVersionAtLeast(context.TODO(), testGitlabClient, requiredMinVersion)()
+	if err != nil {
+		t.Fatalf("Failed to fetch GitLab version: %+v", err)
+	}
+
+	if !isAtLeast {
+		t.Skipf("This test is only valid for GitLab versions newer than %s", requiredMinVersion)
+	}
+}
+
+func testAccIsRunningAtLeast(t *testing.T, requiredMinVersion string) bool {
+	isAtLeast, err := isGitLabVersionAtLeast(context.TODO(), testGitlabClient, requiredMinVersion)()
+	if err != nil {
+		t.Fatalf("Failed to fetch GitLab version: %+v", err)
+	}
+
+	return isAtLeast
 }
 
 // testAccCurrentUser is a test helper for getting the current user of the provided client.

--- a/internal/provider/resource_gitlab_group_cluster_test.go
+++ b/internal/provider/resource_gitlab_group_cluster_test.go
@@ -18,6 +18,7 @@ func TestAccGitlabGroupCluster_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccRequiresLessThan(t, "15.0") },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabGroupClusterDestroy,
 		Steps: []resource.TestStep{
@@ -105,6 +106,7 @@ func TestAccGitlabGroupCluster_import(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccRequiresLessThan(t, "15.0") },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabGroupClusterDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_instance_cluster_test.go
+++ b/internal/provider/resource_gitlab_instance_cluster_test.go
@@ -19,6 +19,7 @@ func TestAccGitlabInstanceCluster_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccRequiresLessThan(t, "15.0") },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabInstanceClusterDestroy,
 		Steps: []resource.TestStep{
@@ -107,6 +108,7 @@ func TestAccGitlabInstanceCluster_import(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccRequiresLessThan(t, "15.0") },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabInstanceClusterDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_cluster_test.go
+++ b/internal/provider/resource_gitlab_project_cluster_test.go
@@ -18,6 +18,7 @@ func TestAccGitlabProjectCluster_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccRequiresLessThan(t, "15.0") },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectClusterDestroy,
 		Steps: []resource.TestStep{
@@ -107,6 +108,7 @@ func TestAccGitlabProjectCluster_import(t *testing.T) {
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccRequiresLessThan(t, "15.0") },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectClusterDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_test.go
+++ b/internal/provider/resource_gitlab_project_test.go
@@ -1131,7 +1131,7 @@ func TestAccGitlabProject_DeprecatedBuildCoverageRegex(t *testing.T) {
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
 			{
-				SkipFunc: isGitLabVersionLessThan(context.Background(), testGitlabClient, "15.0"),
+				SkipFunc: isGitLabVersionAtLeast(context.Background(), testGitlabClient, "15.0"),
 				Config: fmt.Sprintf(`
 					resource "gitlab_project" "this" {
 						name = "foo-%d"
@@ -1144,7 +1144,7 @@ func TestAccGitlabProject_DeprecatedBuildCoverageRegex(t *testing.T) {
 				),
 			},
 			{
-				SkipFunc:          isGitLabVersionLessThan(context.Background(), testGitlabClient, "15.0"),
+				SkipFunc:          isGitLabVersionAtLeast(context.Background(), testGitlabClient, "15.0"),
 				ResourceName:      "gitlab_project.this",
 				ImportState:       true,
 				ImportStateVerify: true,

--- a/internal/provider/resource_gitlab_project_test.go
+++ b/internal/provider/resource_gitlab_project_test.go
@@ -855,6 +855,7 @@ func TestAccGitlabProject_CreateProjectInUserNamespace(t *testing.T) {
 	user := testAccCreateUsers(t, 1)[0]
 
 	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccRequiresAtLeast(t, "14.10") },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_repository_file_test.go
+++ b/internal/provider/resource_gitlab_repository_file_test.go
@@ -239,6 +239,60 @@ func TestAccGitlabRepositoryFile_base64EncodingWithTextContent(t *testing.T) {
 	})
 }
 
+func TestAccGitlabRepositoryFile_createWithExecuteFilemode(t *testing.T) {
+	testProject := testAccCreateProject(t)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccRequiresAtLeast(t, "14.10") },
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckGitlabRepositoryFileDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					resource "gitlab_repository_file" "this" {
+						project = %d
+						file_path = "meow.txt"
+						branch = "main"
+						content = "bWVvdyBtZW93IG1lb3cgbWVvdyBtZW93Cg=="
+						author_email = "meow@catnip.com"
+						author_name = "Meow Meowington"
+						commit_message = "feature: change launch codes"
+						execute_filemode = false
+					}
+				`, testProject.ID),
+			},
+			// Verify Import
+			{
+				ResourceName:            "gitlab_repository_file.this",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"author_email", "author_name", "commit_message"},
+			},
+			{
+				Config: fmt.Sprintf(`
+					resource "gitlab_repository_file" "this" {
+						project = %d
+						file_path = "meow.txt"
+						branch = "main"
+						content = "bWVvdyBtZW93IG1lb3cgbWVvdyBtZW93Cg=="
+						author_email = "meow@catnip.com"
+						author_name = "Meow Meowington"
+						commit_message = "feature: change launch codes"
+						execute_filemode = true
+					}
+				`, testProject.ID),
+			},
+			// Verify Import
+			{
+				ResourceName:            "gitlab_repository_file.this",
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"author_email", "author_name", "commit_message"},
+			},
+		},
+	})
+}
+
 func testAccCheckGitlabRepositoryFileExists(n string, file *gitlab.File) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
@@ -354,7 +408,6 @@ resource "gitlab_repository_file" "this" {
   author_email = "meow@catnip.com"
   author_name = "Meow Meowington"
   commit_message = "feature: change launch codes"
-  execute_filemode = true
 }
 	`, projectID)
 }


### PR DESCRIPTION
GitLab 15.0 has been released today 🎉 

This change set makes the provider compatible. We've missed a few things:

* The old K8s cluster integration was removed, therefore I've disabled the tests for GitLab 15.0 and onwards
* The `gitlab_managed_license` resource wasn't ready regarding the new `approval_status` values

@PatrickRice-KSC can you please verify the changes I did in the managed license resource? Did I miss something?

@PatrickRice-KSC @armsnyder @nagyv I've also changed the workflows to test the last three GitLab releases. WDYT? 🏓 