### PR TITLE
Setup for required_approval_count in gitlab_project_protected_environment

### DIFF
--- a/docs/resources/project_protected_environment.md
+++ b/docs/resources/project_protected_environment.md
@@ -24,8 +24,9 @@ resource "gitlab_project_environment" "this" {
 
 # Example with access level
 resource "gitlab_project_protected_environment" "example_with_access_level" {
-  project     = gitlab_project_environment.this.project
-  environment = gitlab_project_environment.this.name
+  project                 = gitlab_project_environment.this.project
+  required_approval_count = 1
+  environment             = gitlab_project_environment.this.name
 
   deploy_access_levels {
     access_level = "developer"
@@ -54,8 +55,9 @@ resource "gitlab_project_protected_environment" "example_with_user" {
 
 # Example with multiple access levels
 resource "gitlab_project_protected_environment" "example_with_multiple" {
-  project     = gitlab_project_environment.this.project
-  environment = gitlab_project_environment.this.name
+  project                 = gitlab_project_environment.this.project
+  required_approval_count = 2
+  environment             = gitlab_project_environment.this.name
 
   deploy_access_levels {
     access_level = "developer"
@@ -79,6 +81,10 @@ resource "gitlab_project_protected_environment" "example_with_multiple" {
 - `deploy_access_levels` (Block List, Min: 1) Array of access levels allowed to deploy, with each described by a hash. (see [below for nested schema](#nestedblock--deploy_access_levels))
 - `environment` (String) The name of the environment.
 - `project` (String) The ID or full path of the project which the protected environment is created against.
+
+### Optional
+
+- `required_approval_count` (Number) The number of approvals required to deploy to this environment.
 
 ### Read-Only
 

--- a/examples/resources/gitlab_project_protected_environment/resource.tf
+++ b/examples/resources/gitlab_project_protected_environment/resource.tf
@@ -6,8 +6,9 @@ resource "gitlab_project_environment" "this" {
 
 # Example with access level
 resource "gitlab_project_protected_environment" "example_with_access_level" {
-  project     = gitlab_project_environment.this.project
-  environment = gitlab_project_environment.this.name
+  project                 = gitlab_project_environment.this.project
+  required_approval_count = 1
+  environment             = gitlab_project_environment.this.name
 
   deploy_access_levels {
     access_level = "developer"
@@ -36,8 +37,9 @@ resource "gitlab_project_protected_environment" "example_with_user" {
 
 # Example with multiple access levels
 resource "gitlab_project_protected_environment" "example_with_multiple" {
-  project     = gitlab_project_environment.this.project
-  environment = gitlab_project_environment.this.name
+  project                 = gitlab_project_environment.this.project
+  required_approval_count = 2
+  environment             = gitlab_project_environment.this.name
 
   deploy_access_levels {
     access_level = "developer"

--- a/internal/provider/resource_gitlab_project_protected_environment_test.go
+++ b/internal/provider/resource_gitlab_project_protected_environment_test.go
@@ -65,6 +65,7 @@ func TestAccGitlabProjectProtectedEnvironment_basic(t *testing.T) {
 				resource "gitlab_project_protected_environment" "this" {
 					project     = %d
 					environment = %q
+					required_approval_count = 1
 					deploy_access_levels {
 						access_level = "maintainer"
 					}
@@ -83,6 +84,8 @@ func TestAccGitlabProjectProtectedEnvironment_basic(t *testing.T) {
 					// access_level is computed when not specified.
 					resource.TestCheckResourceAttrSet("gitlab_project_protected_environment.this", "deploy_access_levels.1.access_level"),
 					resource.TestCheckResourceAttrSet("gitlab_project_protected_environment.this", "deploy_access_levels.2.access_level"),
+					// required_approval_count is set.
+					resource.TestCheckResourceAttrSet("gitlab_project_protected_environment.this", "required_approval_count"),
 				),
 			},
 			// Verify upstream attributes with an import.


### PR DESCRIPTION
## Description

Issue Add protected environments required_approval_count
https://github.com/gitlabhq/terraform-provider-gitlab/issues/1096

This is the PR for the dependency package:
https://github.com/xanzy/go-gitlab/pull/1482

### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
