### PR TITLE
Suppress diff on the skip_confirmation attribute of gitlab_user

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -55,7 +55,6 @@ resource "gitlab_user" "example" {
 - `projects_limit` (Number) Integer, defaults to 0.  Number of projects user can create.
 - `reset_password` (Boolean) Boolean, defaults to false. Send user password reset link.
 - `skip_confirmation` (Boolean) Boolean, defaults to true. Whether to skip confirmation.
-				
 This field does not import properly, and GitLab does not return the value of this field to verify it was set properly on apply.
 Terraform assumes the field was set properly upon first apply, and will update the field unless other values change.
 - `state` (String) String, defaults to 'active'. The state of the user account. Valid values are `active`, `deactivated`, `blocked`.

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -55,6 +55,9 @@ resource "gitlab_user" "example" {
 - `projects_limit` (Number) Integer, defaults to 0.  Number of projects user can create.
 - `reset_password` (Boolean) Boolean, defaults to false. Send user password reset link.
 - `skip_confirmation` (Boolean) Boolean, defaults to true. Whether to skip confirmation.
+				
+This field does not import properly, and GitLab does not return the value of this field to verify it was set properly on apply.
+Terraform assumes the field was set properly upon first apply, and will update the field unless other values change.
 - `state` (String) String, defaults to 'active'. The state of the user account. Valid values are `active`, `deactivated`, `blocked`.
 
 ### Read-Only

--- a/internal/provider/resource_gitlab_user.go
+++ b/internal/provider/resource_gitlab_user.go
@@ -79,6 +79,10 @@ var _ = registerResource("gitlab_user", func() *schema.Resource {
 				Optional:    true,
 				Default:     true,
 				ForceNew:    true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					// Skip Confirmation doesn't come back from the API, so this will always return a diff unless this skips.
+					return true
+				},
 			},
 			"projects_limit": {
 				Description: "Integer, defaults to 0.  Number of projects user can create.",

--- a/internal/provider/resource_gitlab_user.go
+++ b/internal/provider/resource_gitlab_user.go
@@ -75,7 +75,6 @@ var _ = registerResource("gitlab_user", func() *schema.Resource {
 			},
 			"skip_confirmation": {
 				Description: `Boolean, defaults to true. Whether to skip confirmation.
-				
 This field does not import properly, and GitLab does not return the value of this field to verify it was set properly on apply.
 Terraform assumes the field was set properly upon first apply, and will update the field unless other values change.
 				`,

--- a/internal/provider/resource_gitlab_user.go
+++ b/internal/provider/resource_gitlab_user.go
@@ -82,6 +82,9 @@ Terraform assumes the field was set properly upon first apply, and will update t
 				Optional: true,
 				ForceNew: true,
 				Computed: true,
+				DiffSuppressFunc: func(string, string, string, *schema.ResourceData) bool {
+					return true
+				},
 			},
 			"projects_limit": {
 				Description: "Integer, defaults to 0.  Number of projects user can create.",

--- a/internal/provider/resource_gitlab_user_test.go
+++ b/internal/provider/resource_gitlab_user_test.go
@@ -370,26 +370,44 @@ func TestAccGitlabUser_user_skip_confirmation(t *testing.T) {
 			{
 				Config: fmt.Sprintf(`
 				resource "gitlab_user" "example_user" {
-					name             = "Example User"
-					username         = "exampleuser"
-					email            = "user%d@example.com"
-					is_admin         = true
-					projects_limit   = 0
-					can_create_group = false
-					is_external      = false
-					note             = "Ipsum Lorem."
-					password         = "Dolor Sit Amet"
+					name              = "Example User"
+					username          = "exampleuser"
+					email             = "user%d@example.com"
+					is_admin          = true
+					projects_limit    = 0
+					can_create_group  = false
+					is_external       = false
+					note              = "Ipsum Lorem."
+					password          = "Dolor Sit Amet"
+					skip_confirmation = "true"
 				  }
 				`, rInt),
-				Check: testAccCheckGitlabUserExists("gitlab_user.example_user", &user),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					testAccCheckGitlabUserExists("gitlab_user.example_user", &user),
+
+					// Since this will never import properly, check the value directly.
+					resource.TestCheckResourceAttr("gitlab_user.example_user", "skip_confirmation", "true"),
+				),
 			},
 			{
-				ResourceName:      "gitlab_user.example_user",
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateVerifyIgnore: []string{
-					"password",
-				},
+				Config: fmt.Sprintf(`
+				resource "gitlab_user" "example_user" {
+					name              = "Example User"
+					username          = "exampleuser"
+					email             = "user%d@example.com"
+					is_admin          = true
+					projects_limit    = 0
+					can_create_group  = false
+					is_external       = false
+					note              = "Ipsum Lorem."
+					password          = "Dolor Sit Amet"
+					skip_confirmation = "false"
+				  }
+				`, rInt),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					// Verify false is stored in state after update
+					resource.TestCheckResourceAttr("gitlab_user.example_user", "skip_confirmation", "false"),
+				),
 			},
 		},
 	})

--- a/internal/provider/resource_gitlab_user_test.go
+++ b/internal/provider/resource_gitlab_user_test.go
@@ -358,6 +358,43 @@ func TestAccGitlabUser_password_reset(t *testing.T) {
 	})
 }
 
+// Test that the fix for suppressing skip_confirmation works appropriately.
+func TestAccGitlabUser_user_skip_confirmation(t *testing.T) {
+	var user gitlab.User
+	rInt := acctest.RandInt()
+
+	resource.Test(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckGitlabGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+				resource "gitlab_user" "example_user" {
+					name             = "Example User"
+					username         = "exampleuser"
+					email            = "user%d@example.com"
+					is_admin         = true
+					projects_limit   = 0
+					can_create_group = false
+					is_external      = false
+					note             = "Ipsum Lorem."
+					password         = "Dolor Sit Amet"
+				  }
+				`, rInt),
+				Check: testAccCheckGitlabUserExists("gitlab_user.example_user", &user),
+			},
+			{
+				ResourceName:      "gitlab_user.example_user",
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateVerifyIgnore: []string{
+					"password",
+				},
+			},
+		},
+	})
+}
+
 func testAccCheckGitlabUserExists(n string, user *gitlab.User) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]


### PR DESCRIPTION
## Description

Fix an issue with gitlab_user where the `skip_confirmation` attribute results in a non-empty plan on every run.

Closes #1101

### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
