### PR TITLE
Start parallelizing most of the acceptance tests

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,6 @@
         "GITLAB_TOKEN": "ACCTEST1234567890123",
         "GITLAB_BASE_URL": "http://127.0.0.1:8080"
     },
-    "go.testFlags": ["-count=1", "-v", "-tags=acceptance"],
+    "go.testFlags": ["-count=1", "-v", "-tags=acceptance", "-parallel=2"],
     "go.buildFlags": ["-tags=acceptance"]
 }

--- a/internal/provider/data_source_gitlab_branch_test.go
+++ b/internal/provider/data_source_gitlab_branch_test.go
@@ -15,7 +15,7 @@ import (
 func TestAccDataGitlabBranch_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 	project := testAccCreateProject(t)
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_cluster_agent_test.go
+++ b/internal/provider/data_source_gitlab_cluster_agent_test.go
@@ -17,7 +17,7 @@ func TestAccDataSourceGitlabClusterAgent_basic(t *testing.T) {
 	testProject := testAccCreateProject(t)
 	testAgent := testAccCreateClusterAgents(t, testProject.ID, 1)[0]
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_cluster_agents_test.go
+++ b/internal/provider/data_source_gitlab_cluster_agents_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceGitlabClusterAgents_basic(t *testing.T) {
 	testProject := testAccCreateProject(t)
 	testClusterAgents := testAccCreateClusterAgents(t, testProject.ID, 25)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_group_membership_test.go
+++ b/internal/provider/data_source_gitlab_group_membership_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccDataSourceGitlabMembership_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			// Create the group and one member

--- a/internal/provider/data_source_gitlab_group_variable_test.go
+++ b/internal/provider/data_source_gitlab_group_variable_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccDataSourceGitlabGroupVariable_basic(t *testing.T) {
 	testGroup := testAccCreateGroups(t, 1)[0]
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_group_variables_test.go
+++ b/internal/provider/data_source_gitlab_group_variables_test.go
@@ -18,7 +18,7 @@ func TestAccDataSourceGitlabGroupVariables_basic(t *testing.T) {
 		testVariables = append(testVariables, testAccCreateGroupVariable(t, testGroup.ID))
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_instance_variable_test.go
+++ b/internal/provider/data_source_gitlab_instance_variable_test.go
@@ -7,25 +7,28 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
 func TestAccDataSourceGitlabInstanceVariable_basic(t *testing.T) {
-	resource.Test(t, resource.TestCase{
+	rInt := acctest.RandInt()
+
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: `
+				Config: fmt.Sprintf(`
 					resource "gitlab_instance_variable" "this" {
-						key               = "any_key"
-					        value             = "any-value"
+						key               = "any_key_%d"
+					    value             = "any-value"
 					}
 
 					data "gitlab_instance_variable" "this" {
 						key               = gitlab_instance_variable.this.key
 					}
-				`,
+				`, rInt),
 				Check: resource.ComposeTestCheckFunc(
 					testAccDataSourceGitlabInstanceVariable("gitlab_instance_variable.this", "data.gitlab_instance_variable.this"),
 				),

--- a/internal/provider/data_source_gitlab_project_issue_test.go
+++ b/internal/provider/data_source_gitlab_project_issue_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccDataSourceGitlabProjectIssue_basic(t *testing.T) {
 	testProject := testAccCreateProject(t)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_project_issues_test.go
+++ b/internal/provider/data_source_gitlab_project_issues_test.go
@@ -14,7 +14,7 @@ func TestAccDataSourceGitlabProjectIssues_basic(t *testing.T) {
 	testProject := testAccCreateProject(t)
 	testIssues := testAccCreateProjectIssues(t, testProject.ID, 25)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_project_milestone_test.go
+++ b/internal/provider/data_source_gitlab_project_milestone_test.go
@@ -15,7 +15,7 @@ func TestAccDataSourceGitlabProjectMilestone_basic(t *testing.T) {
 	testProject := testAccCreateProject(t)
 	testMilestone := testAccAddProjectMilestones(t, testProject, 1)[0]
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_project_milestones_test.go
+++ b/internal/provider/data_source_gitlab_project_milestones_test.go
@@ -15,7 +15,7 @@ func TestAccDataGitlabProjectMilestones_basic(t *testing.T) {
 	testProject := testAccCreateProject(t)
 	testMilestones := testAccAddProjectMilestones(t, testProject, 2)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_project_protected_branch_test.go
+++ b/internal/provider/data_source_gitlab_project_protected_branch_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccDataGitlabProjectProtectedBranch_search(t *testing.T) {
 	projectName := fmt.Sprintf("tf-%s", acctest.RandString(5))
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_project_protected_branches_test.go
+++ b/internal/provider/data_source_gitlab_project_protected_branches_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccDataGitlabProjectProtectedBranches_search(t *testing.T) {
 	projectName := fmt.Sprintf("tf-%s", acctest.RandString(5))
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_project_tag_test.go
+++ b/internal/provider/data_source_gitlab_project_tag_test.go
@@ -16,7 +16,7 @@ func TestAccDataGitlabProjectTag_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 	project := testAccCreateProject(t)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_project_tags_test.go
+++ b/internal/provider/data_source_gitlab_project_tags_test.go
@@ -15,7 +15,7 @@ func TestAccDataGitlabProjectTags_basic(t *testing.T) {
 	countTags := 3
 	project := testAccCreateProject(t)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_project_test.go
+++ b/internal/provider/data_source_gitlab_project_test.go
@@ -15,7 +15,7 @@ import (
 func TestAccDataGitlabProject_basic(t *testing.T) {
 	projectname := fmt.Sprintf("tf-%s", acctest.RandString(5))
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_project_variable_test.go
+++ b/internal/provider/data_source_gitlab_project_variable_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccDataSourceGitlabProjectVariable_basic(t *testing.T) {
 	testProject := testAccCreateProject(t)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_project_variables_test.go
+++ b/internal/provider/data_source_gitlab_project_variables_test.go
@@ -18,7 +18,7 @@ func TestAccDataSourceGitlabProjectVariables_basic(t *testing.T) {
 		testVariables = append(testVariables, testAccCreateProjectVariable(t, testProject.ID))
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_projects_test.go
+++ b/internal/provider/data_source_gitlab_projects_test.go
@@ -18,7 +18,7 @@ import (
 func TestAccDataGitlabProjects_search(t *testing.T) {
 	projectName := fmt.Sprintf("tf-%s", acctest.RandString(5))
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
@@ -62,7 +62,7 @@ func TestAccDataGitlabProjects_groups(t *testing.T) {
 	subGroupProjectName1 := fmt.Sprintf("tf-%s", acctest.RandString(5))
 	subGroupProjectName2 := fmt.Sprintf("tf-%s", acctest.RandString(5))
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_repository_file_test.go
+++ b/internal/provider/data_source_gitlab_repository_file_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestAccDataGitlabRepositoryFile_basic(t *testing.T) {
 	project := testAccCreateProject(t)
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/data_source_gitlab_user_test.go
+++ b/internal/provider/data_source_gitlab_user_test.go
@@ -15,7 +15,7 @@ import (
 func TestAccDataSourceGitlabUser_basic(t *testing.T) {
 	rString := fmt.Sprintf("%s", acctest.RandString(5)) // nolint // TODO: Resolve this golangci-lint issue: S1025: the argument is already a string, there's no need to use fmt.Sprintf (gosimple)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			// Get user using its email

--- a/internal/provider/data_source_gitlab_users_test.go
+++ b/internal/provider/data_source_gitlab_users_test.go
@@ -16,7 +16,7 @@ func TestAccDataSourceGitlabUsers_basic(t *testing.T) {
 	rInt2 := acctest.RandInt()
 	user2 := fmt.Sprintf("user%d@test.test", rInt2)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -42,11 +42,14 @@ func init() {
 }
 
 func TestProvider(t *testing.T) {
+	t.Parallel()
+
 	if err := New("dev")().InternalValidate(); err != nil {
 		t.Fatalf("err: %s", err)
 	}
 }
 
 func TestProvider_impl(t *testing.T) {
+	t.Parallel()
 	var _ *schema.Provider = New("dev")()
 }

--- a/internal/provider/resource_gitlab_branch_protection_test.go
+++ b/internal/provider/resource_gitlab_branch_protection_test.go
@@ -20,7 +20,7 @@ func TestAccGitlabBranchProtection_basic(t *testing.T) {
 	var pb gitlab.ProtectedBranch
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabBranchProtectionDestroy,
 		Steps: []resource.TestStep{
@@ -164,7 +164,7 @@ func TestAccGitlabBranchProtection_createWithCodeOwnerApproval(t *testing.T) {
 	var pb gitlab.ProtectedBranch
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabBranchProtectionDestroy,
 		Steps: []resource.TestStep{
@@ -238,7 +238,7 @@ func TestAccGitlabBranchProtection_createWithAllowForcePush(t *testing.T) {
 	var pb gitlab.ProtectedBranch
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabBranchProtectionDestroy,
 		Steps: []resource.TestStep{
@@ -293,7 +293,7 @@ func TestAccGitlabBranchProtection_createWithUnprotectAccessLevel(t *testing.T) 
 	var pb gitlab.ProtectedBranch
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabBranchProtectionDestroy,
 		Steps: []resource.TestStep{
@@ -333,7 +333,7 @@ func TestAccGitlabBranchProtection_createWithMultipleAccessLevels(t *testing.T) 
 	var pb gitlab.ProtectedBranch
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabBranchProtectionDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_branch_test.go
+++ b/internal/provider/resource_gitlab_branch_test.go
@@ -22,7 +22,7 @@ func TestAccGitlabBranch_basic(t *testing.T) {
 	project := testAccCreateProject(t)
 	fooBranchName := fmt.Sprintf("testbranch-%d", rInt)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabBranchDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_cluster_agent_test.go
+++ b/internal/provider/resource_gitlab_cluster_agent_test.go
@@ -19,7 +19,7 @@ func TestAccGitlabClusterAgent_basic(t *testing.T) {
 	testProject := testAccCreateProject(t)
 	var sutClusterAgent gitlab.Agent
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabClusterAgentDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_deploy_token_test.go
+++ b/internal/provider/resource_gitlab_deploy_token_test.go
@@ -20,7 +20,7 @@ func TestAccGitlabDeployToken_basic(t *testing.T) {
 	testProject := testAccCreateProject(t)
 	testGroup := testAccCreateGroups(t, 1)[0]
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabDeployTokenDestroy,
 		Steps: []resource.TestStep{
@@ -55,7 +55,7 @@ func TestAccGitlabDeployToken_pagination(t *testing.T) {
 	testGroup := testAccCreateGroups(t, 1)[0]
 	testProject := testAccCreateProject(t)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabDeployTokenDestroy,
 		Steps: []resource.TestStep{
@@ -241,6 +241,8 @@ type expiresAtSuppressFuncTest struct {
 }
 
 func TestExpiresAtSuppressFunc(t *testing.T) {
+	t.Parallel()
+
 	testcases := []expiresAtSuppressFuncTest{
 		{
 			description: "same dates without millis",

--- a/internal/provider/resource_gitlab_group_access_token_test.go
+++ b/internal/provider/resource_gitlab_group_access_token_test.go
@@ -19,7 +19,7 @@ func TestAccGitlabGroupAccessToken_basic(t *testing.T) {
 
 	testGroup := testAccCreateGroups(t, 1)[0]
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabGroupAccessTokenDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_group_badge_test.go
+++ b/internal/provider/resource_gitlab_group_badge_test.go
@@ -19,7 +19,7 @@ func TestAccGitlabGroupBadge_basic(t *testing.T) {
 	var badge gitlab.GroupBadge
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabGroupBadgeDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_group_cluster_test.go
+++ b/internal/provider/resource_gitlab_group_cluster_test.go
@@ -17,7 +17,7 @@ func TestAccGitlabGroupCluster_basic(t *testing.T) {
 	var cluster gitlab.GroupCluster
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccRequiresLessThan(t, "15.0") },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabGroupClusterDestroy,

--- a/internal/provider/resource_gitlab_group_custom_attribute_test.go
+++ b/internal/provider/resource_gitlab_group_custom_attribute_test.go
@@ -18,7 +18,7 @@ func TestAccGitlabGroupCustomAttribute_basic(t *testing.T) {
 	var customAttribute gitlab.CustomAttribute
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabGroupDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_group_label_test.go
+++ b/internal/provider/resource_gitlab_group_label_test.go
@@ -17,7 +17,7 @@ func TestAccGitlabGroupLabel_basic(t *testing.T) {
 	var label gitlab.GroupLabel
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabGroupLabelDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_group_ldap_link_test.go
+++ b/internal/provider/resource_gitlab_group_ldap_link_test.go
@@ -25,7 +25,7 @@ func TestAccGitlabGroupLdapLink_basic(t *testing.T) {
 		Provider: "default",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabGroupLdapLinkDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_group_membership_test.go
+++ b/internal/provider/resource_gitlab_group_membership_test.go
@@ -18,7 +18,7 @@ func TestAccGitlabGroupMembership_basic(t *testing.T) {
 	var groupMember gitlab.GroupMember
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabGroupMembershipDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_group_project_file_template_test.go
+++ b/internal/provider/resource_gitlab_group_project_file_template_test.go
@@ -19,7 +19,7 @@ func TestAccGitlabGroupProjectFileTemplate_basic(t *testing.T) {
 	firstProject := testAccCreateProjectWithNamespace(t, baseGroup.ID)
 	secondProject := testAccCreateProjectWithNamespace(t, baseGroup.ID)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckProjectFileTemplateDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_group_share_group_test.go
+++ b/internal/provider/resource_gitlab_group_share_group_test.go
@@ -16,7 +16,7 @@ func TestAccGitlabGroupShareGroup_basic(t *testing.T) {
 	mainGroup := testAccCreateGroups(t, 1)[0]
 	sharedGroup := testAccCreateGroups(t, 1)[0]
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabShareGroupDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_group_test.go
+++ b/internal/provider/resource_gitlab_group_test.go
@@ -18,7 +18,7 @@ func TestAccGitlabGroup_basic(t *testing.T) {
 	var group gitlab.Group
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabGroupDestroy,
 		Steps: []resource.TestStep{
@@ -150,7 +150,7 @@ func TestAccGitlabGroup_nested(t *testing.T) {
 	}
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabGroupDestroy,
 		Steps: []resource.TestStep{
@@ -245,7 +245,7 @@ func TestAccGitlabGroup_disappears(t *testing.T) {
 	var group gitlab.Group
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabGroupDestroy,
 		Steps: []resource.TestStep{
@@ -265,7 +265,7 @@ func TestAccGitlabGroup_PreventForkingOutsideGroup(t *testing.T) {
 	var group gitlab.Group
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabGroupDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_group_variable_test.go
+++ b/internal/provider/resource_gitlab_group_variable_test.go
@@ -19,7 +19,7 @@ func TestAccGitlabGroupVariable_basic(t *testing.T) {
 	var groupVariable gitlab.GroupVariable
 	rString := acctest.RandString(5)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabGroupVariableDestroy,
 		Steps: []resource.TestStep{
@@ -114,7 +114,7 @@ func TestAccGitlabGroupVariable_scope(t *testing.T) {
 
 	defaultValueA := fmt.Sprintf("value-%s-a", rString)
 	defaultValueB := fmt.Sprintf("value-%s-b", rString)
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabGroupVariableDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_instance_cluster_test.go
+++ b/internal/provider/resource_gitlab_instance_cluster_test.go
@@ -18,7 +18,7 @@ func TestAccGitlabInstanceCluster_basic(t *testing.T) {
 	var cluster gitlab.InstanceCluster
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccRequiresLessThan(t, "15.0") },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabInstanceClusterDestroy,

--- a/internal/provider/resource_gitlab_instance_variable_test.go
+++ b/internal/provider/resource_gitlab_instance_variable_test.go
@@ -18,7 +18,7 @@ func TestAccGitlabInstanceVariable_basic(t *testing.T) {
 	var instanceVariable gitlab.InstanceVariable
 	rString := acctest.RandString(5)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabInstanceVariableDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_label_test.go
+++ b/internal/provider/resource_gitlab_label_test.go
@@ -17,7 +17,7 @@ func TestAccGitlabLabel_basic(t *testing.T) {
 	var label gitlab.Label
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabLabelDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_managed_license_test.go
+++ b/internal/provider/resource_gitlab_managed_license_test.go
@@ -19,7 +19,7 @@ func TestAccGitlabManagedLicense_basic(t *testing.T) {
 	var managedLicense gitlab.ManagedLicense
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccCheckEE(t) },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckManagedLicenseDestroy,
@@ -47,7 +47,7 @@ func TestAccGitlabManagedLicense_deprecatedConfigValues(t *testing.T) {
 	var managedLicense gitlab.ManagedLicense
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
 			testAccRequiresLessThan(t, "15.0")
 			testAccCheckEE(t)

--- a/internal/provider/resource_gitlab_personal_access_tokens_test.go
+++ b/internal/provider/resource_gitlab_personal_access_tokens_test.go
@@ -17,7 +17,7 @@ import (
 func TestAccGitlabPersonalAccessToken_basic(t *testing.T) {
 	user := testAccCreateUsers(t, 1)[0]
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabPersonalAccessTokenDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_pipeline_schedule_test.go
+++ b/internal/provider/resource_gitlab_pipeline_schedule_test.go
@@ -18,7 +18,7 @@ func TestAccGitlabPipelineSchedule_basic(t *testing.T) {
 	var schedule gitlab.PipelineSchedule
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabPipelineScheduleDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_pipeline_schedule_variable_test.go
+++ b/internal/provider/resource_gitlab_pipeline_schedule_variable_test.go
@@ -18,7 +18,7 @@ func TestAccGitlabPipelineScheduleVariable_basic(t *testing.T) {
 	var variable gitlab.PipelineVariable
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabPipelineScheduleVariableDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_pipeline_trigger_test.go
+++ b/internal/provider/resource_gitlab_pipeline_trigger_test.go
@@ -18,7 +18,7 @@ func TestAccGitlabPipelineTrigger_basic(t *testing.T) {
 	var trigger gitlab.PipelineTrigger
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabPipelineTriggerDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_access_token_test.go
+++ b/internal/provider/resource_gitlab_project_access_token_test.go
@@ -15,7 +15,7 @@ import (
 func TestAccGitlabProjectAccessToken_basic(t *testing.T) {
 	project := testAccCreateProject(t)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectAccessTokenDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_approval_rule_test.go
+++ b/internal/provider/resource_gitlab_project_approval_rule_test.go
@@ -39,7 +39,7 @@ func TestAccGitLabProjectApprovalRule_Basic(t *testing.T) {
 
 	var projectApprovalRule gitlab.ProjectApprovalRule
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectApprovalRuleDestroy(project.ID),
 		Steps: []resource.TestStep{
@@ -92,7 +92,7 @@ func TestAccGitLabProjectApprovalRule_AnyApprover(t *testing.T) {
 
 	var projectApprovalRule gitlab.ProjectApprovalRule
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectApprovalRuleDestroy(project.ID),
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_badge_test.go
+++ b/internal/provider/resource_gitlab_project_badge_test.go
@@ -14,7 +14,7 @@ import (
 func TestAccGitlabProjectBadge_basic(t *testing.T) {
 	testProject := testAccCreateProject(t)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectBadgeDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_cluster_test.go
+++ b/internal/provider/resource_gitlab_project_cluster_test.go
@@ -17,7 +17,7 @@ func TestAccGitlabProjectCluster_basic(t *testing.T) {
 	var cluster gitlab.ProjectCluster
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccRequiresLessThan(t, "15.0") },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectClusterDestroy,

--- a/internal/provider/resource_gitlab_project_custom_attribute_test.go
+++ b/internal/provider/resource_gitlab_project_custom_attribute_test.go
@@ -18,7 +18,7 @@ func TestAccGitlabProjectCustomAttribute_basic(t *testing.T) {
 	var customAttribute gitlab.CustomAttribute
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_environment_test.go
+++ b/internal/provider/resource_gitlab_project_environment_test.go
@@ -29,7 +29,7 @@ func TestAccGitlabProjectEnvironment_basic(t *testing.T) {
 		ExternalURL: "https://example.com",
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectEnvironmentDestroy,
 		Steps: []resource.TestStep{
@@ -117,7 +117,7 @@ func TestAccGitlabProjectEnvironment_stopBeforeDestroyDisabled(t *testing.T) {
 	rInt := acctest.RandInt()
 	testProject := testAccCreateProject(t)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectEnvironmentDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_freeze_period_test.go
+++ b/internal/provider/resource_gitlab_project_freeze_period_test.go
@@ -17,7 +17,7 @@ func TestAccGitlabProjectFreezePeriod_basic(t *testing.T) {
 	var schedule gitlab.FreezePeriod
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_hook_test.go
+++ b/internal/provider/resource_gitlab_project_hook_test.go
@@ -18,7 +18,7 @@ func TestAccGitlabProjectHook_basic(t *testing.T) {
 	var hook gitlab.ProjectHook
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectHookDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_issue_test.go
+++ b/internal/provider/resource_gitlab_project_issue_test.go
@@ -28,7 +28,7 @@ func TestAccGitlabProjectIssue_basic(t *testing.T) {
 		t.Fatalf("Failed to get current user: %v", err)
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectIssueDestroy,
 		Steps: []resource.TestStep{
@@ -155,7 +155,7 @@ func TestAccGitlabProjectIssue_basicEE(t *testing.T) {
 	testAccAddProjectMembers(t, testProject.ID, []*gitlab.User{testUser})
 	testMilestone := testAccAddProjectMilestones(t, testProject, 1)[0]
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectIssueDestroy,
 		Steps: []resource.TestStep{
@@ -177,7 +177,7 @@ func TestAccGitlabProjectIssue_basicEE(t *testing.T) {
 func TestAccGitlabProjectIssue_deleteOnDestroy(t *testing.T) {
 	testProject := testAccCreateProject(t)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectIssueDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_level_mr_approvals_test.go
+++ b/internal/provider/resource_gitlab_project_level_mr_approvals_test.go
@@ -18,7 +18,7 @@ func TestAccGitlabProjectLevelMRApprovals_basic(t *testing.T) {
 	var projectApprovals gitlab.ProjectApprovals
 	testProject := testAccCreateProject(t)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectLevelMRApprovalsDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_membership_test.go
+++ b/internal/provider/resource_gitlab_project_membership_test.go
@@ -18,7 +18,7 @@ func TestAccGitlabProjectMembership_basic(t *testing.T) {
 	var membership gitlab.ProjectMember
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectMembershipDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_milestone_test.go
+++ b/internal/provider/resource_gitlab_project_milestone_test.go
@@ -18,7 +18,7 @@ func TestAccGitlabProjectMilestone_basic(t *testing.T) {
 	rInt1, rInt2 := acctest.RandInt(), acctest.RandInt()
 	project := testAccCreateProject(t)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectMilestoneDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_mirror_test.go
+++ b/internal/provider/resource_gitlab_project_mirror_test.go
@@ -19,7 +19,7 @@ func TestAccGitlabProjectMirror_basic(t *testing.T) {
 	ctx := testAccGitlabProjectStart(t)
 	var miror gitlab.ProjectMirror
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectMirrorDestroy,
 		Steps: []resource.TestStep{
@@ -75,7 +75,7 @@ func TestAccGitlabProjectMirror_basic(t *testing.T) {
 func TestAccGitlabProjectMirror_withPassword(t *testing.T) {
 	ctx := testAccGitlabProjectStart(t)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectMirrorDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_protected_environment_test.go
+++ b/internal/provider/resource_gitlab_project_protected_environment_test.go
@@ -36,7 +36,7 @@ func TestAccGitlabProjectProtectedEnvironment_basic(t *testing.T) {
 		t.Fatalf("unable to share project %d with group %d", project.ID, group.ID)
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectProtectedEnvironmentDestroy(project.ID, environment.Name),
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_runner_enablement_test.go
+++ b/internal/provider/resource_gitlab_project_runner_enablement_test.go
@@ -30,7 +30,7 @@ func TestAccGitlabProjectRunnerEnablement_basic(t *testing.T) {
 	// Create runner in project A
 	runner, _, _ := testGitlabClient.Runners.RegisterNewRunner(&opts)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectRunnerEnablementDestroy(projectB.ID, runner.ID),
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_share_group_test.go
+++ b/internal/provider/resource_gitlab_project_share_group_test.go
@@ -48,7 +48,7 @@ func TestResourceGitlabProjectShareGroupStateUpgradeV0(t *testing.T) {
 func TestAccGitlabProjectShareGroup_basic(t *testing.T) {
 	randName := acctest.RandomWithPrefix("acctest")
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectShareGroupDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_tag_test.go
+++ b/internal/provider/resource_gitlab_project_tag_test.go
@@ -21,7 +21,7 @@ func TestAccGitlabProjectTag_basic(t *testing.T) {
 	project := testAccCreateProject(t)
 	branches := testAccCreateBranches(t, project, 1)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectTagDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_project_test.go
+++ b/internal/provider/resource_gitlab_project_test.go
@@ -25,7 +25,7 @@ func TestAccGitlabProject_minimal(t *testing.T) {
 	var received gitlab.Project
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -119,7 +119,7 @@ func TestAccGitlabProject_basic(t *testing.T) {
 	defaultsMainBranch = defaults
 	defaultsMainBranch.DefaultBranch = "main"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -413,7 +413,7 @@ func TestAccGitlabProject_initializeWithReadme(t *testing.T) {
 	var project gitlab.Project
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -440,7 +440,7 @@ func TestAccGitlabProject_initializeWithoutReadme(t *testing.T) {
 	var project gitlab.Project
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -468,7 +468,7 @@ func TestAccGitlabProject_initializeWithoutReadme(t *testing.T) {
 func TestAccGitlabProject_archiveOnDestroy(t *testing.T) {
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectArchivedOnDestroy,
 		Steps: []resource.TestStep{
@@ -482,7 +482,7 @@ func TestAccGitlabProject_archiveOnDestroy(t *testing.T) {
 func TestAccGitlabProject_setSinglePushRuleToDefault(t *testing.T) {
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -503,7 +503,7 @@ func TestAccGitlabProject_groupWithoutDefaultBranchProtection(t *testing.T) {
 	var project gitlab.Project
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -527,7 +527,7 @@ func TestAccGitlabProject_IssueMergeRequestTemplates(t *testing.T) {
 	var project gitlab.Project
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -557,7 +557,7 @@ func TestAccGitlabProject_MergePipelines(t *testing.T) {
 	var project gitlab.Project
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -583,7 +583,7 @@ func TestAccGitlabProject_MergeTrains(t *testing.T) {
 	var project gitlab.Project
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -609,7 +609,7 @@ func TestAccGitlabProject_willErrorOnAPIFailure(t *testing.T) {
 	var received gitlab.Project
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -656,7 +656,7 @@ func TestAccGitlabProject_willErrorOnAPIFailure(t *testing.T) {
 // lintignore: AT002 // specialized import test
 func TestAccGitlabProject_import(t *testing.T) {
 	rInt := acctest.RandInt()
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -680,7 +680,7 @@ func TestAccGitlabProject_import(t *testing.T) {
 // lintignore: AT002 // specialized import test
 func TestAccGitlabProject_nestedImport(t *testing.T) {
 	rInt := acctest.RandInt()
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -730,7 +730,7 @@ func TestAccGitlabProject_transfer(t *testing.T) {
 	pathBeforeTransfer := fmt.Sprintf("foogroup-%d/foo-%d", rInt, rInt)
 	pathAfterTransfer := fmt.Sprintf("foo2group-%d/foo-%d", rInt, rInt)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -780,7 +780,7 @@ func TestAccGitlabProject_importURL(t *testing.T) {
 		t.Fatalf("failed to commit file to base project: %v", err)
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -808,7 +808,7 @@ func TestAccGitlabProject_initializeWithReadmeAndCustomDefaultBranch(t *testing.
 	var project gitlab.Project
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,
 		Steps: []resource.TestStep{
@@ -854,7 +854,7 @@ func TestAccGitlabProject_CreateProjectInUserNamespace(t *testing.T) {
 
 	user := testAccCreateUsers(t, 1)[0]
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccRequiresAtLeast(t, "14.10") },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabProjectDestroy,

--- a/internal/provider/resource_gitlab_project_variable_test.go
+++ b/internal/provider/resource_gitlab_project_variable_test.go
@@ -75,7 +75,7 @@ func testAccGitlabProjectVariableCheckAllVariablesDestroyed(ctx testAccGitlabPro
 func TestAccGitlabProjectVariable_basic(t *testing.T) {
 	ctx := testAccGitlabProjectStart(t)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccGitlabProjectVariableCheckAllVariablesDestroyed(ctx),
 		Steps: []resource.TestStep{
@@ -176,7 +176,7 @@ EOF
 func TestAccGitlabProjectVariable_scoped(t *testing.T) {
 	ctx := testAccGitlabProjectStart(t)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			// Destroy behavior is nondeterministic for variables with scopes in GitLab versions prior to 13.4

--- a/internal/provider/resource_gitlab_repository_file_test.go
+++ b/internal/provider/resource_gitlab_repository_file_test.go
@@ -16,7 +16,7 @@ func TestAccGitlabRepositoryFile_basic(t *testing.T) {
 	var file gitlab.File
 	testProject := testAccCreateProject(t)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabRepositoryFileDestroy,
 		Steps: []resource.TestStep{
@@ -64,7 +64,7 @@ func TestAccGitlabRepositoryFile_createSameFileDifferentRepository(t *testing.T)
 	firstTestProject := testAccCreateProject(t)
 	secondTestProject := testAccCreateProject(t)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabRepositoryFileDestroy,
 		Steps: []resource.TestStep{
@@ -90,7 +90,7 @@ func TestAccGitlabRepositoryFile_createSameFileDifferentRepository(t *testing.T)
 func TestAccGitlabRepositoryFile_concurrentResources(t *testing.T) {
 	testProject := testAccCreateProject(t)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabRepositoryFileDestroy,
 		Steps: []resource.TestStep{
@@ -114,7 +114,7 @@ func TestAccGitlabRepositoryFile_createOnNewBranch(t *testing.T) {
 	var file gitlab.File
 	testProject := testAccCreateProject(t)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabRepositoryFileDestroy,
 		Steps: []resource.TestStep{
@@ -136,7 +136,7 @@ func TestAccGitlabRepositoryFile_base64EncodingWithTextContent(t *testing.T) {
 	var file gitlab.File
 	testProject := testAccCreateProject(t)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabRepositoryFileDestroy,
 		Steps: []resource.TestStep{
@@ -242,7 +242,7 @@ func TestAccGitlabRepositoryFile_base64EncodingWithTextContent(t *testing.T) {
 func TestAccGitlabRepositoryFile_createWithExecuteFilemode(t *testing.T) {
 	testProject := testAccCreateProject(t)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		PreCheck:          func() { testAccRequiresAtLeast(t, "14.10") },
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabRepositoryFileDestroy,

--- a/internal/provider/resource_gitlab_runner_test.go
+++ b/internal/provider/resource_gitlab_runner_test.go
@@ -21,7 +21,7 @@ func TestAccGitlabRunner_basic(t *testing.T) {
 		t.Fail()
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckRunnerDestroy,
 		Steps: []resource.TestStep{
@@ -67,7 +67,7 @@ func TestAccGitlabRunner_instance(t *testing.T) {
 	// This pulls from the gitlab.rb file, and is set on instance start-up
 	token := "ACCTEST1234567890123_RUNNER_REG_TOKEN"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckRunnerDestroy,
 		Steps: []resource.TestStep{
@@ -102,7 +102,7 @@ func TestAccGitlabRunner_comprehensive(t *testing.T) {
 		t.Fail()
 	}
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckRunnerDestroy,
 		Steps: []resource.TestStep{
@@ -117,7 +117,7 @@ func TestAccGitlabRunner_comprehensive(t *testing.T) {
 					run_untagged = false
 					tag_list = ["tag_one", "tag_two"]
 					access_level = "ref_protected"
-					maximum_timeout = 3600					
+					maximum_timeout = 3600
 				}
 				`, group.RunnersToken),
 			},

--- a/internal/provider/resource_gitlab_service_external_wiki_test.go
+++ b/internal/provider/resource_gitlab_service_external_wiki_test.go
@@ -22,7 +22,7 @@ func TestAccGitlabServiceExternalWiki_basic(t *testing.T) {
 	var externalWikiURL2 = "http://mynumbertwowiki.com"
 	var externalWikiResourceName = "gitlab_service_external_wiki.this"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabServiceExternalWikiDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_service_github_test.go
+++ b/internal/provider/resource_gitlab_service_github_test.go
@@ -18,7 +18,7 @@ func TestAccGitlabServiceGithub_basic(t *testing.T) {
 	var githubService gitlab.GithubService
 	testProject := testAccCreateProject(t)
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabServiceGithubDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_service_jira_test.go
+++ b/internal/provider/resource_gitlab_service_jira_test.go
@@ -18,7 +18,7 @@ func TestAccGitlabServiceJira_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 	jiraResourceName := "gitlab_service_jira.jira"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabServiceJiraDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_service_microsoft_teams_test.go
+++ b/internal/provider/resource_gitlab_service_microsoft_teams_test.go
@@ -18,7 +18,7 @@ func TestAccGitlabServiceMicrosoftTeams_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 	teamsResourceName := "gitlab_service_microsoft_teams.teams"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabServiceMicrosoftTeamsDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_service_pipelines_email_test.go
+++ b/internal/provider/resource_gitlab_service_pipelines_email_test.go
@@ -20,7 +20,7 @@ func TestAccGitlabServicePipelinesEmail_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 	pipelinesEmailResourceName := "gitlab_service_pipelines_email.email"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabServicePipelinesEmailDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_service_slack_test.go
+++ b/internal/provider/resource_gitlab_service_slack_test.go
@@ -18,7 +18,7 @@ func TestAccGitlabServiceSlack_basic(t *testing.T) {
 	rInt := acctest.RandInt()
 	slackResourceName := "gitlab_service_slack.slack"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabServiceSlackDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_system_hook_test.go
+++ b/internal/provider/resource_gitlab_system_hook_test.go
@@ -18,7 +18,7 @@ func TestAccGitlabSystemHook_basic(t *testing.T) {
 	var hook gitlab.Hook
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabSystemHookDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_tag_protection_test.go
+++ b/internal/provider/resource_gitlab_tag_protection_test.go
@@ -17,7 +17,7 @@ func TestAccGitlabTagProtection_basic(t *testing.T) {
 	var pt gitlab.ProtectedTag
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabTagProtectionDestroy,
 		Steps: []resource.TestStep{
@@ -76,7 +76,7 @@ func TestAccGitlabTagProtection_wildcard(t *testing.T) {
 
 	wildcard := "-*"
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabTagProtectionDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_topic_test.go
+++ b/internal/provider/resource_gitlab_topic_test.go
@@ -21,7 +21,7 @@ func TestAccGitlabTopic_basic(t *testing.T) {
 	var topic gitlab.Topic
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabTopicDestroy,
 		Steps: []resource.TestStep{
@@ -217,7 +217,7 @@ func TestAccGitlabTopic_withoutAvatarHash(t *testing.T) {
 	var topic gitlab.Topic
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabTopicDestroy,
 		Steps: []resource.TestStep{
@@ -243,7 +243,7 @@ func TestAccGitlabTopic_softDestroy(t *testing.T) {
 	var topic gitlab.Topic
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabTopicSoftDestroy,
 		Steps: []resource.TestStep{
@@ -261,7 +261,7 @@ func TestAccGitlabTopic_softDestroy(t *testing.T) {
 func TestAccGitlabTopic_titleSupport(t *testing.T) {
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabTopicDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_user_custom_attribute_test.go
+++ b/internal/provider/resource_gitlab_user_custom_attribute_test.go
@@ -18,7 +18,7 @@ func TestAccGitlabUserCustomAttribute_basic(t *testing.T) {
 	var customAttribute gitlab.CustomAttribute
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabUserDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_user_sshkey_test.go
+++ b/internal/provider/resource_gitlab_user_sshkey_test.go
@@ -22,7 +22,7 @@ func TestAccGitlabUserSSHKey_basic(t *testing.T) {
 	var key gitlab.SSHKey
 	testUser := testAccCreateUsers(t, 1)[0]
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabUserSSHKeyDestroy,
 		Steps: []resource.TestStep{

--- a/internal/provider/resource_gitlab_user_test.go
+++ b/internal/provider/resource_gitlab_user_test.go
@@ -19,7 +19,7 @@ func TestAccGitlabUser_basic(t *testing.T) {
 	var user gitlab.User
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabUserDestroy,
 		Steps: []resource.TestStep{
@@ -330,7 +330,7 @@ func TestAccGitlabUser_password_reset(t *testing.T) {
 	var user gitlab.User
 	rInt := acctest.RandInt()
 
-	resource.Test(t, resource.TestCase{
+	resource.ParallelTest(t, resource.TestCase{
 		ProviderFactories: providerFactories,
 		CheckDestroy:      testAccCheckGitlabGroupDestroy,
 		Steps: []resource.TestStep{


### PR DESCRIPTION
The only ones which are not yet `resource.ParallelTest`s are the deploy key tests
which reuse keys and some instance-based resources / data sources.

It brings down the CI testing time a couple of minutes, but not too drastically. This is mainly because the Ci machines "only" provide 2 CPU cores which is then used by `go test`. Manually increasing it for Ci led to a lot of issues somehow and I wasn't able to debug it yet.

The better news is that on my local machine testing time is down to ~6 minutes, which more than half in my case.

My suggestion would be to merge this for now and improve on follow ups. 

***

Another problem is that because we perform setups outside of the `resource.ParallelTest` it's not parallelized and takes up a lot of time.

Therefore, I've created https://github.com/hashicorp/terraform-plugin-sdk/issues/979 - maybe you can also chime in there if you have any good ideas :)