### PR TITLE
resource/gitlab_project: Only execute custom `default_branch` logic for GitLab < 14.10

### DIFF
--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -20,11 +20,11 @@ The `gitlab_project` resource allows to manage the lifecycle of a project.
 
 A project can either be created in a group or user namespace.
 
--> **Default Branch Protection Workaround** Projects are created with default branch protection. 
-Since this default branch protection is not currently managed via Terraform, to workaround this limitation, 
+-> **Default Branch Protection Workaround** Projects are created with default branch protection.
+Since this default branch protection is not currently managed via Terraform, to workaround this limitation,
 you can remove the default branch protection via the API and create your desired Terraform managed branch protection.
-In the `gitlab_project` resource, define a `local-exec` provisioner which invokes 
-the `/projects/:id/protected_branches/:name` API via curl to delete the branch protection on the default 
+In the `gitlab_project` resource, define a `local-exec` provisioner which invokes
+the `/projects/:id/protected_branches/:name` API via curl to delete the branch protection on the default
 branch using a `DELETE` request. Then define the desired branch protection using the `gitlab_branch_protection` resource.
 
 **Upstream API**: [GitLab REST API docs](https://docs.gitlab.com/ce/api/projects.html)


### PR DESCRIPTION
GitLab 14.10 released with a bugfix for the `default_branch` field in
the Projects REST API so that our custom logic is no longer required.

see https://gitlab.com/gitlab-org/gitlab/-/issues/333426

Once GitLab 15.1 is out I suggest to remove that code entirely.