### PR TITLE
Add `owner` as possible value to `access_level` attribute in some project resources

### DIFF
--- a/docs/resources/project_access_token.md
+++ b/docs/resources/project_access_token.md
@@ -43,7 +43,7 @@ resource "gitlab_project_variable" "example" {
 
 ### Optional
 
-- `access_level` (String) The access level for the project access token. Valid values are: `no one`, `minimal`, `guest`, `reporter`, `developer`, `maintainer`, `master`. Default is `maintainer`.
+- `access_level` (String) The access level for the project access token. Valid values are: `no one`, `minimal`, `guest`, `reporter`, `developer`, `maintainer`, `owner`, `master`. Default is `maintainer`.
 - `expires_at` (String) Time the token will expire it, YYYY-MM-DD format. Will not expire per default.
 
 ### Read-Only

--- a/docs/resources/project_membership.md
+++ b/docs/resources/project_membership.md
@@ -38,7 +38,7 @@ resource "gitlab_project_membership" "example" {
 
 ### Required
 
-- `access_level` (String) The access level for the member. Valid values are: `no one`, `minimal`, `guest`, `reporter`, `developer`, `maintainer`, `master`
+- `access_level` (String) The access level for the member. Valid values are: `no one`, `minimal`, `guest`, `reporter`, `developer`, `maintainer`, `owner`, `master`
 - `project_id` (String) The id of the project.
 - `user_id` (Number) The id of the user.
 

--- a/docs/resources/project_share_group.md
+++ b/docs/resources/project_share_group.md
@@ -33,8 +33,8 @@ resource "gitlab_project_share_group" "test" {
 
 ### Optional
 
-- `access_level` (String, Deprecated) The access level to grant the group for the project. Valid values are: `no one`, `minimal`, `guest`, `reporter`, `developer`, `maintainer`, `master`
-- `group_access` (String) The access level to grant the group for the project. Valid values are: `no one`, `minimal`, `guest`, `reporter`, `developer`, `maintainer`, `master`
+- `access_level` (String, Deprecated) The access level to grant the group for the project. Valid values are: `no one`, `minimal`, `guest`, `reporter`, `developer`, `maintainer`, `owner`, `master`
+- `group_access` (String) The access level to grant the group for the project. Valid values are: `no one`, `minimal`, `guest`, `reporter`, `developer`, `maintainer`, `owner`, `master`
 
 ### Read-Only
 

--- a/internal/provider/access_level_helpers.go
+++ b/internal/provider/access_level_helpers.go
@@ -37,6 +37,7 @@ var validProjectAccessLevelNames = []string{
 	"reporter",
 	"developer",
 	"maintainer",
+	"owner",
 
 	// Deprecated and should be removed in v4 of this provider
 	"master",

--- a/internal/provider/resource_gitlab_project_access_token_test.go
+++ b/internal/provider/resource_gitlab_project_access_token_test.go
@@ -75,6 +75,26 @@ func TestAccGitlabProjectAccessToken_basic(t *testing.T) {
 				// The token is only known during creating. We explicitly mention this limitation in the docs.
 				ImportStateVerifyIgnore: []string{"token"},
 			},
+			// Recreate with `owner` access level.
+			{
+				Config: fmt.Sprintf(`
+				resource "gitlab_project_access_token" "foo" {
+					project = %d
+					name    = "foo"
+					scopes  = ["api", "read_api", "read_repository", "write_repository"]
+					access_level = "owner"
+					expires_at = %q
+				}
+				`, project.ID, time.Now().Add(time.Hour*48).Format("2006-01-02")),
+			},
+			// Verify upstream resource with an import.
+			{
+				ResourceName:      "gitlab_project_access_token.foo",
+				ImportState:       true,
+				ImportStateVerify: true,
+				// The token is only known during creating. We explicitly mention this limitation in the docs.
+				ImportStateVerifyIgnore: []string{"token"},
+			},
 		},
 	})
 }


### PR DESCRIPTION
Affected resources:

* `gitlab_project_access_token`
* `gitlab_project_membership`
* `gitlab_project_share_group`

Closes: #1138