### PR TITLE
fix resource type in docs for project_approval_rule.md

### DIFF
--- a/docs/resources/project_approval_rule.md
+++ b/docs/resources/project_approval_rule.md
@@ -58,8 +58,8 @@ resource "gitlab_project_approval_rule" "example-three" {
   user_ids           = [for user in data.gitlab_user.users : user.id]
 }
 
-# Example using `approval_rule`
-resource "gitlab_project_approval_rule" "any-approver" {
+# Example using `approval_rule` using `any_approver` as rule type
+resource "gitlab_project_approval_rule" "any_approver" {
   project            = 5
   name               = "Any name"
   rule_type          = "any_approver"

--- a/docs/resources/project_approval_rule.md
+++ b/docs/resources/project_approval_rule.md
@@ -59,7 +59,7 @@ resource "gitlab_project_approval_rule" "example-three" {
 }
 
 # Example using `approval_rule`
-resource "gitlab_branch_protection" "any-approver" {
+resource "gitlab_project_approval_rule" "any-approver" {
   project            = 5
   name               = "Any name"
   rule_type          = "any_approver"

--- a/examples/resources/gitlab_project_approval_rule/resource.tf
+++ b/examples/resources/gitlab_project_approval_rule/resource.tf
@@ -37,8 +37,8 @@ resource "gitlab_project_approval_rule" "example-three" {
   user_ids           = [for user in data.gitlab_user.users : user.id]
 }
 
-# Example using `approval_rule`
-resource "gitlab_branch_protection" "any-approver" {
+# Example using `approval_rule` using `any_approver` as rule type
+resource "gitlab_project_approval_rule" "any_approver" {
   project            = 5
   name               = "Any name"
   rule_type          = "any_approver"


### PR DESCRIPTION
Pretty sure this is what was meant in the example.

## Description

<!-- Which issue/s does this PR close? Is there any more context you can give the reviewer? -->

### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
