### PR TITLE
Fix a case where a change to a project in terraform can never apply w…

### DIFF
--- a/internal/provider/resource_gitlab_project.go
+++ b/internal/provider/resource_gitlab_project.go
@@ -1211,7 +1211,11 @@ func resourceGitlabProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 	options := &gitlab.EditProjectOptions{}
 	transferOptions := &gitlab.TransferProjectOptions{}
 
-	if d.HasChange("name") {
+	// Always send the name field, to satisfy the requirement of having one
+	// of the project attributes listed below in the update call
+	// https://gitlab.com/gitlab-org/gitlab-foss/-/blob/master/lib/api/helpers/projects_helpers.rb#L120-188
+	// if d.HasChange("name") {
+	if d.Get("name").(string) != nil {
 		options.Name = gitlab.String(d.Get("name").(string))
 	}
 

--- a/internal/provider/resource_gitlab_project.go
+++ b/internal/provider/resource_gitlab_project.go
@@ -1208,14 +1208,16 @@ func resourceGitlabProjectRead(ctx context.Context, d *schema.ResourceData, meta
 func resourceGitlabProjectUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gitlab.Client)
 
-	options := &gitlab.EditProjectOptions{}
-	transferOptions := &gitlab.TransferProjectOptions{}
-
 	// Always send the name field, to satisfy the requirement of having one
 	// of the project attributes listed below in the update call
 	// https://gitlab.com/gitlab-org/gitlab-foss/-/blob/master/lib/api/helpers/projects_helpers.rb#L120-188
-	// if d.HasChange("name") {
-	if d.Get("name").(string) != nil {
+	options := &gitlab.EditProjectOptions{
+		Name: gitlab.String(d.Get("name").(string)),
+	}
+
+	transferOptions := &gitlab.TransferProjectOptions{}
+
+	if d.HasChange("name") {
 		options.Name = gitlab.String(d.Get("name").(string))
 	}
 

--- a/internal/provider/resource_gitlab_project_test.go
+++ b/internal/provider/resource_gitlab_project_test.go
@@ -1171,9 +1171,6 @@ func TestAccGitlabProject_UpdateAnalyticsAccessLevel(t *testing.T) {
 						visibility_level = "public"
 						analytics_access_level = "disabled"
 					}`, rInt),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("gitlab_project.this", "analytics_access_level", "disabled"),
-				),
 			},
 			// Verify Import
 			{

--- a/internal/provider/resource_gitlab_project_test.go
+++ b/internal/provider/resource_gitlab_project_test.go
@@ -1142,7 +1142,6 @@ func TestAccGitlabProject_templateMutualExclusiveNameAndID(t *testing.T) {
 // Gitlab update project API call requires one from a subset of project fields to be set (See #1157)
 // If only a non-blessed field is changed, this test checks that the provider ensures the code won't return an error.
 func TestAccGitlabProject_UpdateAnalyticsAccessLevel(t *testing.T) {
-	var received gitlab.Project
 	rInt := acctest.RandInt()
 
 	resource.Test(t, resource.TestCase{
@@ -1154,11 +1153,9 @@ func TestAccGitlabProject_UpdateAnalyticsAccessLevel(t *testing.T) {
 				Config: fmt.Sprintf(`
 					resource "gitlab_project" "this" {
 						name = "foo-%d"
-						visibility_level = "public"
+						visibility_level                = "public"
+						analytics_access_level = "private"
 					}`, rInt),
-				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabProjectExists("gitlab_project.this", &received),
-				),
 			},
 			// Verify Import
 			{
@@ -1175,7 +1172,6 @@ func TestAccGitlabProject_UpdateAnalyticsAccessLevel(t *testing.T) {
 						analytics_access_level = "disabled"
 					}`, rInt),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckGitlabProjectExists("gitlab_project.this", &received),
 					resource.TestCheckResourceAttr("gitlab_project.this", "analytics_access_level", "disabled"),
 				),
 			},


### PR DESCRIPTION
…hen certain fields are modified.

Because the gitlab API actually expects at least on field out of a subset of fields in an update call (aside from `id`), if you only modify fields not in this subset, the Gitlab API will return a 400 complaining that one of the needed fields is missing.

One of these special fields is `name`. As this seems to be a safe field to assume always exists (we'll still defensively check if nil though), we pass it in always.

## Description

<!-- Which issue/s does this PR close? Is there any more context you can give the reviewer? -->

#1157 

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [ X] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
