### PR TITLE
Clean up: date comment & fmt.Sprintf

### DIFF
--- a/internal/provider/resource_gitlab_group_ldap_link_test.go
+++ b/internal/provider/resource_gitlab_group_ldap_link_test.go
@@ -37,7 +37,7 @@ func TestAccGitlabGroupLdapLink_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabGroupLdapLinkExists(resourceName, &ldapLink),
 					testAccCheckGitlabGroupLdapLinkAttributes(&ldapLink, &testAccGitlabGroupLdapLinkExpectedAttributes{
-						accessLevel: fmt.Sprintf("developer"), // nolint // TODO: Resolve this golangci-lint issue: S1039: unnecessary use of fmt.Sprintf (gosimple)
+						accessLevel: "developer",
 					})),
 			},
 
@@ -57,7 +57,7 @@ func TestAccGitlabGroupLdapLink_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckGitlabGroupLdapLinkExists(resourceName, &ldapLink),
 					testAccCheckGitlabGroupLdapLinkAttributes(&ldapLink, &testAccGitlabGroupLdapLinkExpectedAttributes{
-						accessLevel: fmt.Sprintf("maintainer"), // nolint // TODO: Resolve this golangci-lint issue: S1039: unnecessary use of fmt.Sprintf (gosimple)
+						accessLevel: "maintainer",
 					})),
 			},
 		},

--- a/internal/provider/resource_gitlab_group_membership.go
+++ b/internal/provider/resource_gitlab_group_membership.go
@@ -50,7 +50,7 @@ var _ = registerResource("gitlab_group_membership", func() *schema.Resource {
 			},
 			"expires_at": {
 				Description:  "Expiration date for the group membership. Format: `YYYY-MM-DD`",
-				Type:         schema.TypeString, // Format YYYY-MM-DD
+				Type:         schema.TypeString,
 				ValidateFunc: validateDateFunc,
 				Optional:     true,
 			},
@@ -166,6 +166,8 @@ func resourceGitlabGroupMembershipSetToState(d *schema.ResourceData, groupMember
 	d.Set("access_level", accessLevelValueToName[groupMember.AccessLevel])
 	if groupMember.ExpiresAt != nil {
 		d.Set("expires_at", groupMember.ExpiresAt.String())
+	} else {
+		d.Set("expires_at", "")
 	}
 	userId := strconv.Itoa(groupMember.ID)
 	d.SetId(buildTwoPartID(groupId, &userId))

--- a/internal/provider/resource_gitlab_group_membership_test.go
+++ b/internal/provider/resource_gitlab_group_membership_test.go
@@ -27,7 +27,7 @@ func TestAccGitlabGroupMembership_basic(t *testing.T) {
 			{
 				Config: testAccGitlabGroupMembershipConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(testAccCheckGitlabGroupMembershipExists("gitlab_group_membership.foo", &groupMember), testAccCheckGitlabGroupMembershipAttributes(&groupMember, &testAccGitlabGroupMembershipExpectedAttributes{
-					accessLevel: fmt.Sprintf("developer"), // nolint // TODO: Resolve this golangci-lint issue: S1039: unnecessary use of fmt.Sprintf (gosimple)
+					accessLevel: "developer",
 				})),
 			},
 
@@ -35,8 +35,8 @@ func TestAccGitlabGroupMembership_basic(t *testing.T) {
 			{
 				Config: testAccGitlabGroupMembershipUpdateConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(testAccCheckGitlabGroupMembershipExists("gitlab_group_membership.foo", &groupMember), testAccCheckGitlabGroupMembershipAttributes(&groupMember, &testAccGitlabGroupMembershipExpectedAttributes{
-					accessLevel: fmt.Sprintf("guest"),      // nolint // TODO: Resolve this golangci-lint issue: S1039: unnecessary use of fmt.Sprintf (gosimple)
-					expiresAt:   fmt.Sprintf("2099-01-01"), // nolint // TODO: Resolve this golangci-lint issue: S1039: unnecessary use of fmt.Sprintf (gosimple)
+					accessLevel: "guest",
+					expiresAt:   "2099-01-01",
 				})),
 			},
 
@@ -44,7 +44,7 @@ func TestAccGitlabGroupMembership_basic(t *testing.T) {
 			{
 				Config: testAccGitlabGroupMembershipConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(testAccCheckGitlabGroupMembershipExists("gitlab_group_membership.foo", &groupMember), testAccCheckGitlabGroupMembershipAttributes(&groupMember, &testAccGitlabGroupMembershipExpectedAttributes{
-					accessLevel: fmt.Sprintf("developer"), // nolint // TODO: Resolve this golangci-lint issue: S1039: unnecessary use of fmt.Sprintf (gosimple)
+					accessLevel: "developer",
 				})),
 			},
 		},

--- a/internal/provider/resource_gitlab_group_share_group.go
+++ b/internal/provider/resource_gitlab_group_share_group.go
@@ -48,7 +48,7 @@ var _ = registerResource("gitlab_group_share_group", func() *schema.Resource {
 			},
 			"expires_at": {
 				Description:  "Share expiration date. Format: `YYYY-MM-DD`",
-				Type:         schema.TypeString, // Format YYYY-MM-DD
+				Type:         schema.TypeString,
 				ValidateFunc: validateDateFunc,
 				ForceNew:     true,
 				Optional:     true,

--- a/internal/provider/resource_gitlab_project_membership_test.go
+++ b/internal/provider/resource_gitlab_project_membership_test.go
@@ -27,7 +27,7 @@ func TestAccGitlabProjectMembership_basic(t *testing.T) {
 			{
 				Config: testAccGitlabProjectMembershipConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(testAccCheckGitlabProjectMembershipExists("gitlab_project_membership.foo", &membership), testAccCheckGitlabProjectMembershipAttributes(&membership, &testAccGitlabProjectMembershipExpectedAttributes{
-					access_level: fmt.Sprintf("developer"), // nolint // TODO: Resolve this golangci-lint issue: S1039: unnecessary use of fmt.Sprintf (gosimple)
+					access_level: "developer",
 				})),
 			},
 
@@ -44,7 +44,7 @@ func TestAccGitlabProjectMembership_basic(t *testing.T) {
 			{
 				Config: testAccGitlabProjectMembershipConfig(rInt),
 				Check: resource.ComposeTestCheckFunc(testAccCheckGitlabProjectMembershipExists("gitlab_project_membership.foo", &membership), testAccCheckGitlabProjectMembershipAttributes(&membership, &testAccGitlabProjectMembershipExpectedAttributes{
-					access_level: fmt.Sprintf("developer"), // nolint // TODO: Resolve this golangci-lint issue: S1039: unnecessary use of fmt.Sprintf (gosimple)
+					access_level: "developer",
 				})),
 			},
 		},


### PR DESCRIPTION
## Description

<!-- Which issue/s does this PR close? Is there any more context you can give the reviewer? -->
This PR is linked to [#1122](https://github.com/gitlabhq/terraform-provider-gitlab/pull/1122), as we wanted to keep PRs small.

This is a small clean-up for suggestions @timofurrer made in #1122 
### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
