### PR TITLE
Add convenience cmd to build and install bin locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,35 @@ You'll first need [Go](http://www.golang.org) installed on your machine (version
    ```
 
 
+You can also install the provider locally so that you can use it with Terraform experimentally.
+Run one of the following `make` commands depending on what is correct for your platform:
+
+```sh
+# Default: suitable for macOS
+make local
+
+# Set the terraform platform directory
+# e.g. for linux amd64:
+make local TERRAFORM_PLATFORM_DIR=linux_amd64
+
+# Set the terraform plugin dir, see https://www.terraform.io/cli/config/config-file#implied-local-mirror-directories
+# e.g. for Windows
+make local TERRAFORM_PLUGIN_DIR=%APPDATA%/terraform.d/plugins
+```
+
+The you can use it in your provider config like this:
+
+```hcl
+terraform {
+  required_providers {
+    gitlab = {
+      version = "99.99.99"
+      source  = "gitlab.local/x/gitlab"
+    }
+  }
+}
+```
+
 ### Use a Remote Environment via GitPod
 
 You can choose to use your own development environment if desired, however a `.gitpod.yml` file is included within the repository to allow the use of [GitPod](https://gitpod.io/) easily.

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -4,10 +4,16 @@ reviewable: build fmt generate test ## Run before committing.
 
 GOBIN = $(shell pwd)/bin
 PROVIDER_SRC_DIR := ./internal/provider
+TERRAFORM_PLUGIN_DIR ?= ~/.terraform.d/plugins/gitlab.local/x/gitlab/99.99.99
+TERRAFORM_PLATFORM_DIR ?= darwin_amd64
 
 build: ## Build the provider binary.
 	go mod tidy
 	GOBIN=$(GOBIN) go install
+
+local: build ## Build and Install the provider locally
+	mkdir -p $(TERRAFORM_PLUGIN_DIR)/$(TERRAFORM_PLATFORM_DIR)
+	cp -f $(GOBIN)/terraform-provider-gitlab $(TERRAFORM_PLUGIN_DIR)/$(TERRAFORM_PLATFORM_DIR)/terraform-provider-gitlab
 
 generate: tool-tfplugindocs ## Generate files to be checked in.
 	@# Setting empty environment variables to work around issue: https://github.com/hashicorp/terraform-plugin-docs/issues/12


### PR DESCRIPTION
This only works for macOS adm64 out of the box,
you may use `TERRAFORM_PLATFORM_DIR` and `TERRAFORM_PLUGIN_DIR`
to control the installation path.

You can use the provider using the following config:

```hcl
gitlab = {
  version = "99.99.99"
  source  = "gitlab.local/x/gitlab"
}
```
