### PR TITLE
resource/gitlab_user_sshkey: Ignore leading and trailing whitespaces in key

### DIFF
--- a/internal/provider/resource_gitlab_user_sshkey.go
+++ b/internal/provider/resource_gitlab_user_sshkey.go
@@ -48,8 +48,8 @@ var _ = registerResource("gitlab_user_sshkey", func() *schema.Resource {
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
 					// NOTE: the ssh keys consist of three parts: `type`, `data`, `comment`, whereas the `comment` is optional
 					//       and suppressed in the diffing. It's overridden by GitLab with the username and GitLab hostname.
-					newParts := strings.SplitN(new, " ", 3)
-					oldParts := strings.SplitN(old, " ", 3)
+					newParts := strings.Fields(new)
+					oldParts := strings.Fields(old)
 					if len(newParts) < 2 || len(oldParts) < 2 {
 						// NOTE: at least one of the keys doesn't have the required two parts, thus we just compare them
 						return new == old

--- a/internal/provider/resource_gitlab_user_sshkey_test.go
+++ b/internal/provider/resource_gitlab_user_sshkey_test.go
@@ -17,6 +17,7 @@ var testRSAPubKey string = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCi+ErxScCKIVqg
 var testRSAPubKeyUpdatedComment string = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCi+ErxScCKIVqg2ZRJ6Mx2Yd/RTsh2DGyhUR8z8Iey4rpi1YOBlpTgjxxnSLy26J++Un/iWYDP8wMvEjXElkWz3z4I+Z3mfF3dv039FTCu+O17Mw20Ek4DJxdrKvOgul040sUG/ABVHo6DjqjokjoVJwzUrUmoOtbeMMD8hFN9bWdEVyTj18XQO8nvEe/VkbhCRhAlZC1l60fM07/7Tw83SV5UNAnBtOB+nfa3b24baO+Ijc4+PqYcBuUAF6DvhXW2gZPqf5wjDBJqlDlRTYDdHarMXZAKBpWfWj0gntbtEOM+Fnp6hS1HajaeveNSs6yQwgQEDN2boQnDuvXJ8Y7zW3YQKZp8z0uqWYJSIrYRKVEVYL7gDWL9NvdRV52d/RKPnE/BlL2chiAWBRCT8buQdjVtEPPoYbA1667PXZg6PI9yhCGEIjCj71XzPssA6VL/R7yUafsmNLsirWz9Uyh3HJWCcgNuO9mglP5nfFHIXSHQVhEUEYMfzv1iX5FrenU= terraform2@foo.com"
 var updatedRSAPubKey string = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDStVqW58VZ5afXFphIvu2JahndXslJZMkgWsNiYCNdk/NvrEbc4i7yZVoDPFQsbS9I6Ty1RMW7qy3KxJalMsVHcw8arCQFDxs/ka1NHGCUPl68t5ZxUOl900KRQ0lOzGnDQMqG/UUZdPw4CCmigTr6Z9ZBcD1fXAiUwbXR4tWrr5z9KWXC2HgF4WkIJUTIct7ilY1m9W0y79dI/+K8bZrurn3q2QK83pxqqWkLwvUsCxtlhMpwuyflyzyuz8xPZl2GlZgxeIpr68gsPHIzzWizibwFfbRYKCZO4wD0r7JCDOYs9KjcIPpCG6d3HUqijClgdQSBnLwHTdE04ZtdzO8akvy0hMzRCooI5TSc8IAHos53Gp9aaW92sPA8za+WRP6OSH6UsOW4N+iQc4jyl7/fckMSgIZlJouNqqV+P8iqIFJGs70Tj5L8G/m+P2lc3kcE4Vjmj+Fc0xG5+I/PsSOpcc6DfDfZdVDRe8yklYd/qC1jI89OCeqjxu3XcUGHj9s= terraform@gitlab.com"
 var updatedRSAPubKeyWithoutComment string = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDStVqW58VZ5afXFphIvu2JahndXslJZMkgWsNiYCNdk/NvrEbc4i7yZVoDPFQsbS9I6Ty1RMW7qy3KxJalMsVHcw8arCQFDxs/ka1NHGCUPl68t5ZxUOl900KRQ0lOzGnDQMqG/UUZdPw4CCmigTr6Z9ZBcD1fXAiUwbXR4tWrr5z9KWXC2HgF4WkIJUTIct7ilY1m9W0y79dI/+K8bZrurn3q2QK83pxqqWkLwvUsCxtlhMpwuyflyzyuz8xPZl2GlZgxeIpr68gsPHIzzWizibwFfbRYKCZO4wD0r7JCDOYs9KjcIPpCG6d3HUqijClgdQSBnLwHTdE04ZtdzO8akvy0hMzRCooI5TSc8IAHos53Gp9aaW92sPA8za+WRP6OSH6UsOW4N+iQc4jyl7/fckMSgIZlJouNqqV+P8iqIFJGs70Tj5L8G/m+P2lc3kcE4Vjmj+Fc0xG5+I/PsSOpcc6DfDfZdVDRe8yklYd/qC1jI89OCeqjxu3XcUGHj9s="
+var testKeyWithTrailingNewline string = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIMG5+BWfNRCNE9chUUooEwS/QeNMN5Z1RBdY1GQ0VqMa\n"
 
 func TestAccGitlabUserSSHKey_basic(t *testing.T) {
 	var key gitlab.SSHKey
@@ -72,6 +73,48 @@ func TestAccGitlabUserSSHKey_basic(t *testing.T) {
 			},
 			{
 				ResourceName:      "gitlab_user_sshkey.foo_key",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccGitlabUserSSHKey_ignoreTrailingWhitespaces(t *testing.T) {
+	testUser := testAccCreateUsers(t, 1)[0]
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckGitlabUserSSHKeyDestroy,
+		Steps: []resource.TestStep{
+			// Create a user + sshkey
+			{
+				Config: fmt.Sprintf(`
+					resource "gitlab_user_sshkey" "this" {
+						user_id = %d
+						title   = "test"
+						key     = <<EOF
+						%s
+						EOF
+					}
+				`, testUser.ID, testKeyWithTrailingNewline),
+			},
+			// Check for no-op plan
+			{
+				Config: fmt.Sprintf(`
+					resource "gitlab_user_sshkey" "this" {
+						user_id = %d
+						title   = "test"
+						key     = <<EOF
+						%s
+						EOF
+					}
+				`, testUser.ID, testKeyWithTrailingNewline),
+				PlanOnly: true,
+			},
+			// Verify Import
+			{
+				ResourceName:      "gitlab_user_sshkey.this",
 				ImportState:       true,
 				ImportStateVerify: true,
 			},


### PR DESCRIPTION
This change set handles ssh keys with leading or trailing whitespaces gracefully - they are simply ignored when diffing and there won't trigger an update.

This is a probably a common source of issue when using it together with `tls_private_key.public_key_openssh` which appends a newline.

Closes: #1174
