### PR TITLE
Fix golangci by moving away from deprecated io/ioutil

### DIFF
--- a/internal/provider/config.go
+++ b/internal/provider/config.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
-	"io/ioutil"
 	"net/http"
+	"os"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/logging"
 	"github.com/xanzy/go-gitlab"
@@ -29,7 +29,7 @@ func (c *Config) Client(ctx context.Context) (*gitlab.Client, error) {
 
 	// If a CACertFile has been specified, use that for cert validation
 	if c.CACertFile != "" {
-		caCert, err := ioutil.ReadFile(c.CACertFile)
+		caCert, err := os.ReadFile(c.CACertFile)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Description

golangci-lint 1.42 on go 1.19 reports:
```
internal/provider/config.go:7:2: SA1019: "io/ioutil" has been deprecated since Go 1.16: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. (staticcheck)
        "io/ioutil"
        ^
```
Not sure why it does not appear on GitHub CI.

### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
