### PR TITLE
Use `crazy-max/ghaction-import-gpg` instead of the one from hashicorp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 # This GitHub action can publish assets for release when a tag is created.
 # Currently its setup to run on any tag that matches the pattern "v*" (ie. v0.1.0).
 #
-# This uses an action (hashicorp/ghaction-import-gpg) that assumes you set your
+# This uses an action (crazy-max/ghaction-import-gpg) that assumes you set your
 # private key in the `GPG_PRIVATE_KEY` secret and passphrase in the `PASSPHRASE`
 # secret. If you would rather own your own GPG handling, please fork this action
 # or use an alternative one for key handling.
@@ -38,11 +38,11 @@ jobs:
           go-version: ${{ needs.go-version.outputs.go-version }}
       - name: Import GPG key
         id: import_gpg
-        uses: hashicorp/ghaction-import-gpg@v2.1.0
-        env:
+        uses: crazy-max/ghaction-import-gpg@v5.1.0
+        with:
           # These secrets will need to be configured for the repository:
-          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
       - name: Generate Release Notes from Changelog
         run: |
           LATEST_TAG=$(git describe --abbrev=0 --match='v*.*.*' --tags | tr -d v)


### PR DESCRIPTION
HashiCorp's `ghaction-import-gpg` is deprecated, see
https://github.com/hashicorp/ghaction-import-gpg/issues/11#issuecomment-1185107410.
