### PR TITLE
Fix GitLab external URL configuration

### DIFF
--- a/scripts/gitlab.rb
+++ b/scripts/gitlab.rb
@@ -1,3 +1,6 @@
+external_url "http://127.0.0.1:8080"
+nginx['listen_port'] = 80
+
 pages_external_url 'http://127.0.0.1:5051'
 pages_nginx['redirect_http_to_https'] = false
 pages_nginx['ssl_certificate'] = "/etc/gitlab/ssl/gitlab-registry.pem"


### PR DESCRIPTION
This will fix the acceptance testing instance to have a proper external
URL configured. With that redirects within GitLab will work (e.g. from
the WebIDE back to the repository) and stuff like clone URLs etc.
