### PR TITLE
resource/gitlab_group_membership: Support removal options

### DIFF
--- a/docs/resources/group_membership.md
+++ b/docs/resources/group_membership.md
@@ -39,6 +39,8 @@ resource "gitlab_group_membership" "test" {
 ### Optional
 
 - `expires_at` (String) Expiration date for the group membership. Format: `YYYY-MM-DD`
+- `skip_subresources_on_destroy` (Boolean) Whether the deletion of direct memberships of the removed member in subgroups and projects should be skipped. Only used during a destroy.
+- `unassign_issuables_on_destroy` (Boolean) Whether the removed member should be unassigned from any issues or merge requests inside a given group or project. Only used during a destroy.
 
 ### Read-Only
 

--- a/internal/provider/helper_test.go
+++ b/internal/provider/helper_test.go
@@ -225,6 +225,30 @@ func testAccCreateGroups(t *testing.T, n int) []*gitlab.Group {
 	return groups
 }
 
+// testAccCreateSubGroups is a test helper for creating a specified number of subgroups.
+func testAccCreateSubGroups(t *testing.T, parentGroup *gitlab.Group, n int) []*gitlab.Group {
+	t.Helper()
+
+	groups := make([]*gitlab.Group, n)
+
+	for i := range groups {
+		var err error
+		name := acctest.RandomWithPrefix("acctest-group")
+		groups[i], _, err = testGitlabClient.Groups.CreateGroup(&gitlab.CreateGroupOptions{
+			Name: gitlab.String(name),
+			Path: gitlab.String(name),
+			// So that acceptance tests can be run in a gitlab organization with no billing.
+			Visibility: gitlab.Visibility(gitlab.PublicVisibility),
+			ParentID:   gitlab.Int(parentGroup.ID),
+		})
+		if err != nil {
+			t.Fatalf("could not create test subgroup: %v", err)
+		}
+	}
+
+	return groups
+}
+
 // testAccCreateBranches is a test helper for creating a specified number of branches.
 // It assumes the project will be destroyed at the end of the test and will not cleanup created branches.
 func testAccCreateBranches(t *testing.T, project *gitlab.Project, n int) []*gitlab.Branch {


### PR DESCRIPTION
This change will support the two options when removing a user from a
group using `gitlab_group_membership`. These are
`skip_subresources_on_destroy` and `unassign_issuables_on_destroy`.
Both default to `false` and the change is backwards compatible.

Closes: #1194

/cc @1oglop1
