### PR TITLE
resource/gitlab_project: Fix passing `ci_forward_deployment_enabled=false` at project creation

### DIFF
--- a/internal/provider/resource_gitlab_project.go
+++ b/internal/provider/resource_gitlab_project.go
@@ -539,9 +539,9 @@ var resourceGitLabProjectSchema = map[string]*schema.Schema{
 	},
 	"repository_storage": {
 		Description: "	Which storage shard the repository is on. (administrator only)",
-		Type:        schema.TypeString,
-		Optional:    true,
-		Computed:    true,
+		Type:     schema.TypeString,
+		Optional: true,
+		Computed: true,
 	},
 	"requirements_access_level": {
 		Description:      fmt.Sprintf("Set the requirements access level. Valid values are %s.", renderValueListForDocs(validProjectAccessLevels)),

--- a/internal/provider/resource_gitlab_project.go
+++ b/internal/provider/resource_gitlab_project.go
@@ -810,7 +810,6 @@ func resourceGitlabProjectCreate(ctx context.Context, d *schema.ResourceData, me
 		Mirror:                                    gitlab.Bool(d.Get("mirror").(bool)),
 		MirrorTriggerBuilds:                       gitlab.Bool(d.Get("mirror_trigger_builds").(bool)),
 		CIConfigPath:                              gitlab.String(d.Get("ci_config_path").(string)),
-		CIForwardDeploymentEnabled:                gitlab.Bool(d.Get("ci_forward_deployment_enabled").(bool)),
 	}
 
 	if v, ok := d.GetOk("build_coverage_regex"); ok {

--- a/internal/provider/resource_gitlab_project.go
+++ b/internal/provider/resource_gitlab_project.go
@@ -539,9 +539,9 @@ var resourceGitLabProjectSchema = map[string]*schema.Schema{
 	},
 	"repository_storage": {
 		Description: "	Which storage shard the repository is on. (administrator only)",
-		Type:     schema.TypeString,
-		Optional: true,
-		Computed: true,
+		Type:        schema.TypeString,
+		Optional:    true,
+		Computed:    true,
 	},
 	"requirements_access_level": {
 		Description:      fmt.Sprintf("Set the requirements access level. Valid values are %s.", renderValueListForDocs(validProjectAccessLevels)),
@@ -1202,6 +1202,12 @@ func resourceGitlabProjectCreate(ctx context.Context, d *schema.ResourceData, me
 
 	if v, ok := d.GetOk("ci_default_git_depth"); ok {
 		editProjectOptions.CIDefaultGitDepth = gitlab.Int(v.(int))
+	}
+
+	// nolint:staticcheck // SA1019 ignore deprecated GetOkExists
+	// lintignore: XR001 // TODO: replace with alternative for GetOkExists
+	if v, ok := d.GetOkExists("ci_forward_deployment_enabled"); ok {
+		editProjectOptions.CIForwardDeploymentEnabled = gitlab.Bool(v.(bool))
 	}
 
 	if (editProjectOptions != gitlab.EditProjectOptions{}) {

--- a/internal/provider/resource_gitlab_project_test.go
+++ b/internal/provider/resource_gitlab_project_test.go
@@ -1377,6 +1377,7 @@ func TestAccGitlabProject_SetDefaultFalseBooleansOnCreate(t *testing.T) {
 						public_builds                       = false
 						merge_pipelines_enabled             = false
 						merge_trains_enabled                = false
+						ci_forward_deployment_enabled       = false
 					}`, rInt),
 			},
 			{


### PR DESCRIPTION
## Description

Gitlab API only allows updating `ci_forward_deployment_enabled` when editing a project. Setting `ci_forward_deployment_enabled=false` at project creation has no effect. We need to `terraform apply` twice the apply the change.

Related Gitlab issues:
- https://gitlab.com/gitlab-org/gitlab/-/issues/341672
- https://gitlab.com/gitlab-org/gitlab/-/merge_requests/44510

This MR add `ci_forward_deployment_enabled` to `editProjectOptions` to update the parameter after the creation.

### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
