### PR TITLE
resource_gitlab_group_ldap_link: Update docs

### DIFF
--- a/docs/resources/group_ldap_link.md
+++ b/docs/resources/group_ldap_link.md
@@ -31,7 +31,7 @@ resource "gitlab_group_ldap_link" "test" {
 
 - `cn` (String) The CN of the LDAP group to link with.
 - `group_id` (String) The id of the GitLab group.
-- `ldap_provider` (String) The name of the LDAP provider as stored in the GitLab database.
+- `ldap_provider` (String) The name of the LDAP provider as stored in the GitLab database. Note that this is NOT the value of the `label` attribute as shown in the web UI. In most cases this will be `ldapmain` but you may use the [LDAP check rake task](https://docs.gitlab.com/ee/administration/raketasks/ldap.html#check) for receiving the LDAP server name: `LDAP: ... Server: ldapmain`
 
 ### Optional
 

--- a/internal/provider/resource_gitlab_group_ldap_link.go
+++ b/internal/provider/resource_gitlab_group_ldap_link.go
@@ -57,7 +57,7 @@ var _ = registerResource("gitlab_group_ldap_link", func() *schema.Resource {
 			},
 			// Changing GitLab API parameter "provider" to "ldap_provider" to avoid clashing with the Terraform "provider" key word
 			"ldap_provider": {
-				Description: "The name of the LDAP provider as stored in the GitLab database.",
+				Description: "The name of the LDAP provider as stored in the GitLab database. Note that this is NOT the value of the `label` attribute as shown in the web UI. In most cases this will be `ldapmain` but you may use the [LDAP check rake task](https://docs.gitlab.com/ee/administration/raketasks/ldap.html#check) for receiving the LDAP server name: `LDAP: ... Server: ldapmain`",
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,


### PR DESCRIPTION
## Description

Add a note about the `ldap_provider` not being the LDAP `label` value
and add information on how to receive the LDAP server name using a rake
task.

Fixes https://github.com/gitlabhq/terraform-provider-gitlab/issues/605

### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
