### PR TITLE
Enable dummy SAML provider to allow saml group link features

### DIFF
--- a/scripts/gitlab.rb
+++ b/scripts/gitlab.rb
@@ -18,3 +18,21 @@ gitlab_rails['application_settings_cache_seconds'] = 0
 gitlab_rails['env'] = {
     'IN_MEMORY_APPLICATION_SETTINGS' => 'false'
 }
+
+# Enable SAML authentication for GitLab (required for SAML group links).
+# see https://docs.gitlab.com/ee/integration/saml.html
+gitlab_rails['omniauth_allow_single_sign_on'] = ['saml']
+gitlab_rails['omniauth_block_auto_created_users'] = false
+gitlab_rails['omniauth_providers'] = [
+  {
+    name: "saml",
+    label: "Dummy Test Provider",
+    args: {
+      assertion_consumer_service_url: "https://gitlab.example.com/users/auth/saml/callback",
+      idp_cert_fingerprint: "aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa:aa",
+      idp_sso_target_url: "https://saml.provider.example.com/sso/saml",
+      issuer: "https://gitlab.example.com",
+      name_identifier_format: "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"
+    }
+  }
+]


### PR DESCRIPTION
This change configures a dummy SAML provider so that we can properly test the saml group link resource contributed with #1215 .

![image](https://user-images.githubusercontent.com/1008252/186457049-a20b3e52-79a8-44bc-9550-af43597e5f97.png)


![image](https://user-images.githubusercontent.com/1008252/186456954-a3147613-765b-4458-8b57-de8b001cb41a.png)

