### PR TITLE
resource: fix typo in error message

### DIFF
--- a/internal/provider/resource_gitlab_group_label.go
+++ b/internal/provider/resource_gitlab_group_label.go
@@ -134,7 +134,7 @@ func resourceGitlabGroupLabelImporter(ctx context.Context, d *schema.ResourceDat
 	client := meta.(*gitlab.Client)
 	parts := strings.SplitN(d.Id(), ":", 2)
 	if len(parts) != 2 {
-		return nil, fmt.Errorf("invalid label id (should be <group ID>.<label name>): %s", d.Id())
+		return nil, fmt.Errorf("invalid label id (should be <group ID>:<label name>): %s", d.Id())
 	}
 
 	d.SetId(parts[1])


### PR DESCRIPTION
## Description

Fix typo in the error message of the import command for `gitlab_group_label`. The doc states [here](https://registry.terraform.io/providers/gitlabhq/gitlab/latest/docs/resources/group_label#import) that it should be `terraform import gitlab_group_label.example <group ID>:<label name>` but the error message says `terraform import gitlab_group_label.example <group ID>.<label name>`

### PR Checklist Acknowledgement

- [X] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
