### PR TITLE
Align `gitlab_group` with missing attributes for create

### DIFF
--- a/docs/data-sources/group.md
+++ b/docs/data-sources/group.md
@@ -39,15 +39,18 @@ data "gitlab_group" "foo" {
 
 - `default_branch_protection` (Number) Whether developers and maintainers can push to the applicable default branch.
 - `description` (String) The description of the group.
+- `extra_shared_runners_minutes_limit` (Number) Can be set by administrators only. Additional CI/CD minutes for this group.
 - `full_name` (String) The full name of the group.
 - `id` (String) The ID of this resource.
 - `lfs_enabled` (Boolean) Boolean, is LFS enabled for projects in this group.
+- `membership_lock` (Boolean) Users cannot be added to projects in this group.
 - `name` (String) The name of this group.
 - `parent_id` (Number) Integer, ID of the parent group.
 - `path` (String) The path of the group.
 - `prevent_forking_outside_group` (Boolean) When enabled, users can not fork projects from this group to external namespaces.
 - `request_access_enabled` (Boolean) Boolean, is request for access enabled to the group.
 - `runners_token` (String, Sensitive) The group level registration token to use during runner setup.
+- `shared_runners_minutes_limit` (Number) Can be set by administrators only. Maximum number of monthly CI/CD minutes for this group. Can be nil (default; inherit system default), 0 (unlimited), or > 0.
 - `visibility_level` (String) Visibility level of the group. Possible values are `private`, `internal`, `public`.
 - `web_url` (String) Web URL of the group.
 

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -47,7 +47,9 @@ resource "gitlab_project" "example" {
 - `default_branch_protection` (Number) Defaults to 2. See https://docs.gitlab.com/ee/api/groups.html#options-for-default_branch_protection
 - `description` (String) The description of the group.
 - `emails_disabled` (Boolean) Defaults to false. Disable email notifications.
+- `extra_shared_runners_minutes_limit` (Number) Can be set by administrators only. Additional CI/CD minutes for this group.
 - `lfs_enabled` (Boolean) Defaults to true. Enable/disable Large File Storage (LFS) for the projects in this group.
+- `membership_lock` (Boolean) Users cannot be added to projects in this group.
 - `mentions_disabled` (Boolean) Defaults to false. Disable the capability of a group from getting mentioned.
 - `parent_id` (Number) Id of the parent group (creates a nested group).
 - `prevent_forking_outside_group` (Boolean) Defaults to false. When enabled, users can not fork projects from this group to external namespaces.
@@ -55,6 +57,7 @@ resource "gitlab_project" "example" {
 - `request_access_enabled` (Boolean) Defaults to false. Allow users to request member access.
 - `require_two_factor_authentication` (Boolean) Defaults to false. Require all users in this group to setup Two-factor authentication.
 - `share_with_group_lock` (Boolean) Defaults to false. Prevent sharing a project with another group within this group.
+- `shared_runners_minutes_limit` (Number) Can be set by administrators only. Maximum number of monthly CI/CD minutes for this group. Can be nil (default; inherit system default), 0 (unlimited), or > 0.
 - `subgroup_creation_level` (String) Defaults to owner. Allowed to create subgroups.
 - `two_factor_grace_period` (Number) Defaults to 48. Time before Two-factor authentication is enforced (in hours).
 - `visibility_level` (String) The group's visibility. Can be `private`, `internal`, or `public`.

--- a/internal/provider/access_level_helpers.go
+++ b/internal/provider/access_level_helpers.go
@@ -44,8 +44,9 @@ var validProjectAccessLevelNames = []string{
 }
 
 // NOTE(TF): the documentation here https://docs.gitlab.com/ee/api/protected_branches.html
-//           mentions an `60 => Admin access` level, but it actually seems to not exist.
-//           Ignoring here that I've every read about this ...
+//
+//	mentions an `60 => Admin access` level, but it actually seems to not exist.
+//	Ignoring here that I've every read about this ...
 var validProtectedBranchTagAccessLevelNames = []string{
 	"no one", "developer", "maintainer",
 }

--- a/internal/provider/data_source_gitlab_group.go
+++ b/internal/provider/data_source_gitlab_group.go
@@ -97,6 +97,21 @@ var _ = registerDataSource("gitlab_group", func() *schema.Resource {
 				Type:        schema.TypeBool,
 				Computed:    true,
 			},
+			"membership_lock": {
+				Description: "Users cannot be added to projects in this group.",
+				Type:        schema.TypeBool,
+				Computed:    true,
+			},
+			"extra_shared_runners_minutes_limit": {
+				Description: "Can be set by administrators only. Additional CI/CD minutes for this group.",
+				Type:        schema.TypeInt,
+				Computed:    true,
+			},
+			"shared_runners_minutes_limit": {
+				Description: "Can be set by administrators only. Maximum number of monthly CI/CD minutes for this group. Can be nil (default; inherit system default), 0 (unlimited), or > 0.",
+				Type:        schema.TypeInt,
+				Computed:    true,
+			},
 		},
 	}
 })
@@ -142,6 +157,9 @@ func dataSourceGitlabGroupRead(ctx context.Context, d *schema.ResourceData, meta
 	d.Set("runners_token", group.RunnersToken)
 	d.Set("default_branch_protection", group.DefaultBranchProtection)
 	d.Set("prevent_forking_outside_group", group.PreventForkingOutsideGroup)
+	d.Set("membership_lock", group.MembershipLock)
+	d.Set("extra_shared_runners_minutes_limit", group.ExtraSharedRunnersMinutesLimit)
+	d.Set("shared_runners_minutes_limit", group.SharedRunnersMinutesLimit)
 
 	d.SetId(fmt.Sprintf("%d", group.ID))
 

--- a/internal/provider/resource_gitlab_group_test.go
+++ b/internal/provider/resource_gitlab_group_test.go
@@ -241,6 +241,55 @@ func TestAccGitlabGroup_nested(t *testing.T) {
 	})
 }
 
+func TestAccGitlabGroup_EE(t *testing.T) {
+	testAccCheckEE(t)
+
+	testGroupName := acctest.RandomWithPrefix("acctest-group")
+
+	resource.ParallelTest(t, resource.TestCase{
+		ProviderFactories: providerFactories,
+		CheckDestroy:      testAccCheckGitlabGroupDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(`
+					resource "gitlab_group" "this" {
+						name = "%[1]s"
+						path = "%[1]s"
+
+						membership_lock                    = true
+						extra_shared_runners_minutes_limit = 21
+						shared_runners_minutes_limit       = 42
+					}
+				`, testGroupName),
+			},
+			// Verify import
+			{
+				ResourceName:      "gitlab_group.this",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: fmt.Sprintf(`
+					resource "gitlab_group" "this" {
+						name = "%[1]s"
+						path = "%[1]s"
+
+						membership_lock                    = false
+						extra_shared_runners_minutes_limit = 0
+						shared_runners_minutes_limit       = 0
+					}
+				`, testGroupName),
+			},
+			// Verify import
+			{
+				ResourceName:      "gitlab_group.this",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccGitlabGroup_disappears(t *testing.T) {
 	var group gitlab.Group
 	rInt := acctest.RandInt()

--- a/internal/provider/resource_gitlab_repository_file.go
+++ b/internal/provider/resource_gitlab_repository_file.go
@@ -19,16 +19,17 @@ import (
 const encoding = "base64"
 
 // NOTE: this lock is a bit of a hack to prevent parallel calls to the GitLab Repository Files API.
-//       If it is called concurrently, the API will return a 400 error along the lines of:
-//       ```
-//       (400 Bad Request) DELETE https://gitlab.com/api/v4/projects/30716/repository/files/somefile.yaml: 400
-//       {message: 9:Could not update refs/heads/master. Please refresh and try again..}
-//       ```
 //
-//       This lock only solves half of the problem, where the provider is responsible for
-//       the concurrency. The other half is if the API is called outside of terraform at the same time
-//       this resource makes calls to the API.
-//       To mitigate this, simple retries are used.
+//	If it is called concurrently, the API will return a 400 error along the lines of:
+//	```
+//	(400 Bad Request) DELETE https://gitlab.com/api/v4/projects/30716/repository/files/somefile.yaml: 400
+//	{message: 9:Could not update refs/heads/master. Please refresh and try again..}
+//	```
+//
+//	This lock only solves half of the problem, where the provider is responsible for
+//	the concurrency. The other half is if the API is called outside of terraform at the same time
+//	this resource makes calls to the API.
+//	To mitigate this, simple retries are used.
 var resourceGitlabRepositoryFileApiLock = newLock()
 
 var _ = registerResource("gitlab_repository_file", func() *schema.Resource {


### PR DESCRIPTION
This adds a few missing attributes from the create API to the `gitlab_group` resource. There are still some missing ones which are only supported in the update API - which we can add later.

This is mainly to satisfy the request from #1133 😊 

Closes: #1133