### PR TITLE
Add ci_config_path to data.gitlab_project

### DIFF
--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -46,6 +46,7 @@ data "gitlab_project" "example" {
 - `build_git_strategy` (String) The Git strategy. Defaults to fetch.
 - `build_timeout` (Number) The maximum amount of time, in seconds, that a job can run.
 - `builds_access_level` (String) Set the builds access level. Valid values are `disabled`, `private`, `enabled`.
+- `ci_config_path` (String) CI config file path for the project.
 - `container_expiration_policy` (List of Object) Set the image cleanup policy for this project. **Note**: this field is sometimes named `container_expiration_policy_attributes` in the GitLab Upstream API. (see [below for nested schema](#nestedatt--container_expiration_policy))
 - `container_registry_access_level` (String) Set visibility of container registry, for this project. Valid values are `disabled`, `private`, `enabled`.
 - `default_branch` (String) The default branch for the project.

--- a/internal/provider/data_source_gitlab_project.go
+++ b/internal/provider/data_source_gitlab_project.go
@@ -295,6 +295,11 @@ var _ = registerDataSource("gitlab_project", func() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
+			"ci_config_path": {
+				Description: "CI config file path for the project.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
 			"push_rules": {
 				Description: "Push rules for the project.",
 				Type:        schema.TypeList,
@@ -436,6 +441,7 @@ func dataSourceGitlabProjectRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set("squash_commit_template", found.SquashCommitTemplate)
 	d.Set("merge_commit_template", found.MergeCommitTemplate)
 	d.Set("ci_default_git_depth", found.CIDefaultGitDepth)
+	d.Set("ci_config_path", found.CIConfigPath)
 
 	log.Printf("[DEBUG] Reading Gitlab project %q push rules", d.Id())
 


### PR DESCRIPTION
## Description

I noticed that `data.gitlab_project` does not expose `ci_config_path`, this PR expose that field.

### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
