### PR TITLE
Typofix: drop extra "lab"

### DIFF
--- a/docs/resources/application_settings.md
+++ b/docs/resources/application_settings.md
@@ -3,7 +3,7 @@
 page_title: "gitlab_application_settings Resource - terraform-provider-gitlab"
 subcategory: ""
 description: |-
-  The gitlab_application_settings resource allows to manage the GitLabLab application settings.
+  The gitlab_application_settings resource allows to manage the GitLab application settings.
   ~> This is an experimental resource. By nature it doesn't properly fit into how Terraform resources are meant to work.
      Feel free to join the discussion https://github.com/gitlabhq/terraform-provider-gitlab/issues/957 if you have any
      ideas or questions regarding this resource.

--- a/internal/provider/resource_gitlab_application_settings.go
+++ b/internal/provider/resource_gitlab_application_settings.go
@@ -13,7 +13,7 @@ const applicationSettingsID = "gitlab"
 
 var _ = registerResource("gitlab_application_settings", func() *schema.Resource {
 	return &schema.Resource{
-		Description: `The ` + "`" + `gitlab_application_settings` + "`" + ` resource allows to manage the GitLabLab application settings.
+		Description: `The ` + "`" + `gitlab_application_settings` + "`" + ` resource allows to manage the GitLab application settings.
 
 ~> This is an **experimental resource**. By nature it doesn't properly fit into how Terraform resources are meant to work.
    Feel free to join the [discussion](https://github.com/gitlabhq/terraform-provider-gitlab/issues/957) if you have any


### PR DESCRIPTION
## Description

GitLabLab isn't a thing, unless there's a dog who contributes.

### PR Checklist Acknowledgement

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
