### PR TITLE
fix(docs/pipeline_schedule_variable): Add missing resorce name in example

### DIFF
--- a/docs/resources/pipeline_schedule_variable.md
+++ b/docs/resources/pipeline_schedule_variable.md
@@ -24,8 +24,8 @@ resource "gitlab_pipeline_schedule" "example" {
 }
 
 resource "gitlab_pipeline_schedule_variable" "example" {
-  project              = gitlab_pipeline_schedule.project
-  pipeline_schedule_id = gitlab_pipeline_schedule.id
+  project              = gitlab_pipeline_schedule.example.project
+  pipeline_schedule_id = gitlab_pipeline_schedule.example.id
   key                  = "EXAMPLE_KEY"
   value                = "example"
 }


### PR DESCRIPTION
## Description

Just a small fix in docs example
