### PR TITLE
Remove name field from update project options since it is not required

### DIFF
--- a/internal/provider/resource_gitlab_project.go
+++ b/internal/provider/resource_gitlab_project.go
@@ -1331,10 +1331,12 @@ func resourceGitlabProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 
 	if d.HasChange("approvals_before_merge") {
 		options.ApprovalsBeforeMerge = gitlab.Int(d.Get("approvals_before_merge").(int))
+		options.Name = gitlab.String(d.Get("name").(string))
 	}
 
 	if d.HasChange("wiki_enabled") {
 		options.WikiEnabled = gitlab.Bool(d.Get("wiki_enabled").(bool))
+		options.Name = gitlab.String(d.Get("name").(string))
 	}
 
 	if d.HasChange("snippets_enabled") {
@@ -1382,11 +1384,13 @@ func resourceGitlabProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 	if d.HasChange("mirror") {
 		options.ImportURL = gitlab.String(d.Get("import_url").(string))
 		options.Mirror = gitlab.Bool(d.Get("mirror").(bool))
+		options.Name = gitlab.String(d.Get("name").(string))
 	}
 
 	if d.HasChange("mirror_trigger_builds") {
 		options.ImportURL = gitlab.String(d.Get("import_url").(string))
 		options.MirrorTriggerBuilds = gitlab.Bool(d.Get("mirror_trigger_builds").(bool))
+		options.Name = gitlab.String(d.Get("name").(string))
 	}
 
 	if d.HasChange("only_mirror_protected_branches") {
@@ -1397,6 +1401,7 @@ func resourceGitlabProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 	if d.HasChange("mirror_overwrites_diverged_branches") {
 		options.ImportURL = gitlab.String(d.Get("import_url").(string))
 		options.MirrorOverwritesDivergedBranches = gitlab.Bool(d.Get("mirror_overwrites_diverged_branches").(bool))
+		options.Name = gitlab.String(d.Get("name").(string))
 	}
 
 	if d.HasChange("build_coverage_regex") {
@@ -1405,6 +1410,7 @@ func resourceGitlabProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 
 	if d.HasChange("issues_template") {
 		options.IssuesTemplate = gitlab.String(d.Get("issues_template").(string))
+		options.Name = gitlab.String(d.Get("name").(string))
 	}
 
 	if d.HasChange("merge_requests_template") {
@@ -1477,6 +1483,7 @@ func resourceGitlabProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 
 	if d.HasChange("external_authorization_classification_label") {
 		options.ExternalAuthorizationClassificationLabel = gitlab.String(d.Get("external_authorization_classification_label").(string))
+		options.Name = gitlab.String(d.Get("name").(string))
 	}
 
 	if d.HasChange("forking_access_level") {
@@ -1509,6 +1516,7 @@ func resourceGitlabProjectUpdate(ctx context.Context, d *schema.ResourceData, me
 
 	if d.HasChange("requirements_access_level") {
 		options.RequirementsAccessLevel = stringToAccessControlValue(d.Get("requirements_access_level").(string))
+		options.Name = gitlab.String(d.Get("name").(string))
 	}
 
 	if d.HasChange("security_and_compliance_access_level") {

--- a/internal/provider/resource_gitlab_project.go
+++ b/internal/provider/resource_gitlab_project.go
@@ -1269,12 +1269,7 @@ func resourceGitlabProjectRead(ctx context.Context, d *schema.ResourceData, meta
 func resourceGitlabProjectUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	client := meta.(*gitlab.Client)
 
-	// Always send the name field, to satisfy the requirement of having one
-	// of the project attributes listed below in the update call
-	// https://gitlab.com/gitlab-org/gitlab-foss/-/blob/master/lib/api/helpers/projects_helpers.rb#L120-188
-	options := &gitlab.EditProjectOptions{
-		Name: gitlab.String(d.Get("name").(string)),
-	}
+	options := &gitlab.EditProjectOptions{}
 
 	transferOptions := &gitlab.TransferProjectOptions{}
 


### PR DESCRIPTION
## Description

<!-- Which issue/s does this PR close? Is there any more context you can give the reviewer? -->
Closes #1262 
There is a [bug in GitLab](https://gitlab.com/gitlab-org/gitlab/-/issues/375033) that prevents project Maintainers to use this provider. Furthermore according to [GitLab documentation](https://docs.gitlab.com/ee/api/projects.html#edit-project), the name field is not required. There should be no use case where the Edit Project API is called without one of the fields required.

With this PR, maintainers would still not be able to update the name of a project, but they would be able to update other fields. Since the bug on GitLab only affects the name field

### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)
