### PR TITLE
resource/gitlab_repository_file: Fix check if file exists during read. Closes #1260

### DIFF
--- a/internal/provider/resource_gitlab_repository_file.go
+++ b/internal/provider/resource_gitlab_repository_file.go
@@ -163,8 +163,8 @@ func resourceGitlabRepositoryFileRead(ctx context.Context, d *schema.ResourceDat
 
 	repositoryFile, _, err := client.RepositoryFiles.GetFile(project, filePath, options, gitlab.WithContext(ctx))
 	if err != nil {
-		if strings.Contains(err.Error(), "404 File Not Found") {
-			log.Printf("[WARN] file %s not found, removing from state", filePath)
+		if is404(err) {
+			log.Printf("[DEBUG] file %s not found, removing from state", filePath)
 			d.SetId("")
 			return nil
 		}


### PR DESCRIPTION
For some reason the check if the file exists was matching some text in the error message - however it should check the status code, like everywhere else.