### PR TITLE
resource/gitlab_branch_protection: Support `no one` in `unprotect_access_level`

### DIFF
--- a/docs/resources/branch_protection.md
+++ b/docs/resources/branch_protection.md
@@ -96,7 +96,7 @@ resource "gitlab_branch_protection" "main" {
 - `code_owner_approval_required` (Boolean) Can be set to true to require code owner approval before merging.
 - `merge_access_level` (String) Access levels allowed to merge. Valid values are: `no one`, `developer`, `maintainer`.
 - `push_access_level` (String) Access levels allowed to push. Valid values are: `no one`, `developer`, `maintainer`.
-- `unprotect_access_level` (String) Access levels allowed to unprotect. Valid values are: `developer`, `maintainer`.
+- `unprotect_access_level` (String) Access levels allowed to unprotect. Valid values are: `no one`, `developer`, `maintainer`.
 
 ### Read-Only
 

--- a/internal/provider/access_level_helpers.go
+++ b/internal/provider/access_level_helpers.go
@@ -54,7 +54,7 @@ var validProtectedBranchTagAccessLevelNames = []string{
 // The only access levels allowed to be configured to unprotect a protected branch
 // The API states the others are either forbidden (via 403) or invalid
 var validProtectedBranchUnprotectAccessLevelNames = []string{
-	"developer", "maintainer",
+	"no one", "developer", "maintainer",
 }
 
 var validProtectedEnvironmentDeploymentLevelNames = []string{


### PR DESCRIPTION
This value was simply missing, the truth of allowed ones is here: https://gitlab.com/gitlab-org/gitlab/blob/d2b99cadd0204030bf789ea1523b4e02c9f2535b/app/models/concerns/protected_ref_access.rb#L12

Closes: #1267
