### PR TITLE
gitlab_project: Add ci_separated_caches

### DIFF
--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -47,6 +47,7 @@ data "gitlab_project" "example" {
 - `build_timeout` (Number) The maximum amount of time, in seconds, that a job can run.
 - `builds_access_level` (String) Set the builds access level. Valid values are `disabled`, `private`, `enabled`.
 - `ci_config_path` (String) CI config file path for the project.
+- `ci_separated_caches` (Boolean) Use separate caches for protected branches.
 - `container_expiration_policy` (List of Object) Set the image cleanup policy for this project. **Note**: this field is sometimes named `container_expiration_policy_attributes` in the GitLab Upstream API. (see [below for nested schema](#nestedatt--container_expiration_policy))
 - `container_registry_access_level` (String) Set visibility of container registry, for this project. Valid values are `disabled`, `private`, `enabled`.
 - `default_branch` (String) The default branch for the project.

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -91,6 +91,7 @@ resource "gitlab_project" "peters_repo" {
 - `ci_config_path` (String) Custom Path to CI config file.
 - `ci_default_git_depth` (Number) Default number of revisions for shallow cloning.
 - `ci_forward_deployment_enabled` (Boolean) When a new deployment job starts, skip older deployment jobs that are still pending.
+- `ci_separated_caches` (Boolean) Use separate caches for protected branches.
 - `container_expiration_policy` (Block List, Max: 1) Set the image cleanup policy for this project. **Note**: this field is sometimes named `container_expiration_policy_attributes` in the GitLab Upstream API. (see [below for nested schema](#nestedblock--container_expiration_policy))
 - `container_registry_access_level` (String) Set visibility of container registry, for this project. Valid values are `disabled`, `private`, `enabled`.
 - `container_registry_enabled` (Boolean) Enable container registry for the project.

--- a/internal/provider/data_source_gitlab_project.go
+++ b/internal/provider/data_source_gitlab_project.go
@@ -305,6 +305,11 @@ var _ = registerDataSource("gitlab_project", func() *schema.Resource {
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
+			"ci_separated_caches": {
+				Description: "Use separate caches for protected branches.",
+				Type:        schema.TypeBool,
+				Computed:    true,
+			},
 			"push_rules": {
 				Description: "Push rules for the project.",
 				Type:        schema.TypeList,
@@ -448,6 +453,7 @@ func dataSourceGitlabProjectRead(ctx context.Context, d *schema.ResourceData, me
 	d.Set("merge_commit_template", found.MergeCommitTemplate)
 	d.Set("ci_default_git_depth", found.CIDefaultGitDepth)
 	d.Set("ci_config_path", found.CIConfigPath)
+	d.Set("ci_separated_caches", found.CISeperateCache)
 
 	log.Printf("[DEBUG] Reading Gitlab project %q push rules", d.Id())
 

--- a/internal/provider/resource_gitlab_project.go
+++ b/internal/provider/resource_gitlab_project.go
@@ -402,6 +402,12 @@ var resourceGitLabProjectSchema = map[string]*schema.Schema{
 		Optional:    true,
 		Default:     true,
 	},
+	"ci_separated_caches": {
+		Description: "Use separate caches for protected branches.",
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Default:     true,
+	},
 	"merge_pipelines_enabled": {
 		Description: "Enable or disable merge pipelines.",
 		Type:        schema.TypeBool,
@@ -747,6 +753,7 @@ func resourceGitlabProjectSetToState(ctx context.Context, client *gitlab.Client,
 	d.Set("merge_requests_template", project.MergeRequestsTemplate)
 	d.Set("ci_config_path", project.CIConfigPath)
 	d.Set("ci_forward_deployment_enabled", project.CIForwardDeploymentEnabled)
+	d.Set("ci_separated_caches", project.CISeperateCache)
 	d.Set("merge_pipelines_enabled", project.MergePipelinesEnabled)
 	d.Set("merge_trains_enabled", project.MergeTrainsEnabled)
 	d.Set("resolve_outdated_diff_discussions", project.ResolveOutdatedDiffDiscussions)
@@ -1217,6 +1224,12 @@ func resourceGitlabProjectCreate(ctx context.Context, d *schema.ResourceData, me
 	// lintignore: XR001 // TODO: replace with alternative for GetOkExists
 	if v, ok := d.GetOkExists("ci_forward_deployment_enabled"); ok {
 		editProjectOptions.CIForwardDeploymentEnabled = gitlab.Bool(v.(bool))
+	}
+
+	// nolint:staticcheck // SA1019 ignore deprecated GetOkExists
+	// lintignore: XR001 // TODO: replace with alternative for GetOkExists
+	if v, ok := d.GetOkExists("ci_separated_caches"); ok {
+		editProjectOptions.CISeperateCache = gitlab.Bool(v.(bool))
 	}
 
 	if (editProjectOptions != gitlab.EditProjectOptions{}) {

--- a/internal/provider/resource_gitlab_project_test.go
+++ b/internal/provider/resource_gitlab_project_test.go
@@ -83,6 +83,7 @@ func TestAccGitlabProject_basic(t *testing.T) {
 		MergeRequestsTemplate:           "",
 		CIConfigPath:                    ".gitlab-ci.yml@mynamespace/myproject",
 		CIForwardDeploymentEnabled:      true,
+		CISeperateCache:                 true,
 		ResolveOutdatedDiffDiscussions:  true,
 		AnalyticsAccessLevel:            gitlab.EnabledAccessControl,
 		AutoCancelPendingPipelines:      "enabled",
@@ -159,6 +160,7 @@ func TestAccGitlabProject_basic(t *testing.T) {
 						PackagesEnabled:                false,
 						PagesAccessLevel:               gitlab.DisabledAccessControl,
 						CIForwardDeploymentEnabled:     false,
+						CISeperateCache:                false,
 						ResolveOutdatedDiffDiscussions: false,
 						AnalyticsAccessLevel:           gitlab.DisabledAccessControl,
 						AutoCancelPendingPipelines:     "disabled",
@@ -724,6 +726,7 @@ func TestAccGitlabProject_transfer(t *testing.T) {
 		PrintingMergeRequestLinkEnabled: true,
 		PagesAccessLevel:                gitlab.PrivateAccessControl,
 		CIForwardDeploymentEnabled:      true,
+		CISeperateCache:                 true,
 	}
 
 	pathBeforeTransfer := fmt.Sprintf("foogroup-%d/foo-%d", rInt, rInt)
@@ -1830,6 +1833,7 @@ resource "gitlab_project" "foo" {
   packages_enabled = false
   pages_access_level = "disabled"
   ci_forward_deployment_enabled = false
+  ci_separated_caches = false
   merge_pipelines_enabled = false
   merge_trains_enabled = false
   resolve_outdated_diff_discussions = false


### PR DESCRIPTION
## Description

Adds support for the project setting `ci_separated_caches`

![image](https://user-images.githubusercontent.com/1748909/200505723-549f9ebb-4d9b-4e77-9f1e-a8de621b0c1a.png)

![image](https://user-images.githubusercontent.com/1748909/200507846-d0d79055-b0d7-4119-bdf0-2bc06cca933f.png)

Fixes #1319

### PR Checklist Acknowledgement

<!-- For a smooth review process, please run through this checklist before submitting a PR, and check the box when done. -->

- [x] I acknowledge that all of the following items are true, where applicable:
  - Resource attributes match 1:1 the names and structure of the API resource in [the GitLab API documentation](https://docs.gitlab.com/ee/api/).
  - [Examples](https://github.com/gitlabhq/terraform-provider-gitlab/tree/main/examples) are updated with:
    - A \*.tf file for the resource/s with at least one usage example
    - A \*.sh file for the resource/s with an import example (if applicable)
  - New resources have at minimum a basic test with three steps:
    - Create the resource
    - Update the attributes
    - Import the resource
  - ~~No new `//lintignore` comments were copied from existing code. (Linter rules are meant to be enforced on new code.)~~
    - I wasn't sure which method to use instead of the deprecated `GetOkExists()`. Happy to amend as needed.
