### PR TITLE
fix: Typo on gitlab_user_sshkey resource

### DIFF
--- a/docs/resources/user_sshkey.md
+++ b/docs/resources/user_sshkey.md
@@ -21,7 +21,7 @@ data "gitlab_user" "example" {
 }
 
 resource "gitlab_user_sshkey" "example" {
-  user_id    = data.gitlab_user.id
+  user_id    = data.gitlab_user.example.id
   title      = "example-key"
   key        = "ssh-rsa AAAA..."
   expires_at = "2016-01-21T00:00:00.000Z"


### PR DESCRIPTION
Fix typo on `gitlab_user_sshkey` resource.

- `data.gitlab_user.id` -> `data.gitlab_user.example.id`