### PR TITLE
Adding message for gitlab_user resource

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -7,6 +7,7 @@ description: |-
   -> the provider needs to be configured with admin-level access for this resource to work.
   -> You must specify either password or reset_password.
   Upstream API: GitLab REST API docs https://docs.gitlab.com/ee/api/users.html
+  -> This resource is only available in self-managed Gitlab instances.
 ---
 
 # gitlab_user (Resource)


### PR DESCRIPTION
https://docs.gitlab.com/ee/api/users.html#user-creation

User creation and management is only available for self-managed Gitlab instances. This Terraform resource is not applicable for SaaS customers.