### PR TITLE
Fixed example docs for gitlab_group_variable (Resource)

### DIFF
--- a/docs/resources/group_variable.md
+++ b/docs/resources/group_variable.md
@@ -27,7 +27,7 @@ resource "gitlab_group_variable" "example" {
 
 # Example  with masked and hidden
 resource "gitlab_group_variable" "example" {
-  project   = "12345"
+  group     = "12345"
   key       = "group_variable_key"
   value     = "group_variable_value"
   masked    = true


### PR DESCRIPTION
The second example in the resource docs of "gitlab_group_variable" shows `project` as a required input parameter. However, `project` is not a parameter of the resource and should be replaced by `group`.